### PR TITLE
Add repo specific config for monorepos

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -3,6 +3,12 @@
 You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward updates your repository.
 
 ```properties
+# sbtDirectory allows to specify a repository subfolder where the sbt project is located
+#
+# Defaults to empty String
+#
+sbtDirectory = backend/scala
+
 # pullRequests.frequency allows to control how often or when Scala Steward
 # is allowed to create pull requests.
 #
@@ -77,7 +83,7 @@ updatePullRequests = "always" | "on-conflicts" | "never"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
-# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}" 
+# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
 commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 ```
 
@@ -103,7 +109,7 @@ libraryDependencies ++= Seq(
   // scala-steward:off
   "com.github.pathikrit" %% "better-files" % "3.8.0",
   "com.olegpy" %% "better-monadic-for" % "0.3.1",
-  // scala-steward:on 
+  // scala-steward:on
   "org.typelevel" %% "cats-effect" % "1.3.1",  // This and subsequent will get updated
   "org.typelevel" %% "cats-kernel-laws" % "1.6.1"
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -50,7 +50,7 @@ object SbtAlg {
       logger: Logger[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
-	  repoConfigAlg: RepoConfigAlg[F],
+      repoConfigAlg: RepoConfigAlg[F],
       F: BracketThrowable[F]
   ): SbtAlg[F] =
     new SbtAlg[F] {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -30,6 +30,7 @@ import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.{BracketThrowable, Nel}
 import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.repoconfig.RepoConfigAlg
 
 trait SbtAlg[F[_]] extends BuildToolAlg[F] {
   def addGlobalPluginTemporarily[A](plugin: FileData)(fa: F[A]): F[A]
@@ -49,6 +50,7 @@ object SbtAlg {
       logger: Logger[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
+	  repoConfigAlg: RepoConfigAlg[F],
       F: BracketThrowable[F]
   ): SbtAlg[F] =
     new SbtAlg[F] {
@@ -72,15 +74,19 @@ object SbtAlg {
       override def getSbtVersion(repo: Repo): F[Option[SbtVersion]] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)
-          maybeProperties <- fileAlg.readFile(repoDir / "project" / "build.properties")
+          repoConfig <- repoConfigAlg.readRepoConfigOrDefault(repo)
+          maybeProperties <- fileAlg.readFile(
+            repoDir / repoConfig.sbtDirectory / "project" / "build.properties"
+          )
           version = maybeProperties.flatMap(parser.parseBuildProperties)
         } yield version
 
       override def getDependencies(repo: Repo): F[List[Scope.Dependencies]] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)
+          repoConfig <- repoConfigAlg.readRepoConfigOrDefault(repo)
           commands = List(setOffline, crossStewardDependencies, reloadPlugins, stewardDependencies)
-          lines <- exec(sbtCmd(commands), repoDir)
+          lines <- exec(sbtCmd(commands), repoDir / repoConfig.sbtDirectory)
           dependencies = parser.parseDependencies(lines)
           additionalDependencies <- getAdditionalDependencies(repo)
         } yield additionalDependencies ::: dependencies
@@ -104,8 +110,8 @@ object SbtAlg {
       val sbtDir: F[File] =
         fileAlg.home.map(_ / ".sbt")
 
-      def exec(command: Nel[String], repoDir: File): F[List[String]] =
-        maybeIgnoreOptsFiles(repoDir)(processAlg.execSandboxed(command, repoDir))
+      def exec(command: Nel[String], sbtDir: File): F[List[String]] =
+        maybeIgnoreOptsFiles(sbtDir)(processAlg.execSandboxed(command, sbtDir))
 
       def sbtCmd(commands: List[String]): Nel[String] =
         Nel.of("sbt", "-batch", "-no-colors", commands.mkString(";", ";", ""))

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -24,7 +24,8 @@ final case class RepoConfig(
     commits: CommitsConfig = CommitsConfig(),
     pullRequests: PullRequestsConfig = PullRequestsConfig(),
     updates: UpdatesConfig = UpdatesConfig(),
-    updatePullRequests: Option[PullRequestUpdateStrategy] = None
+    updatePullRequests: Option[PullRequestUpdateStrategy] = None,
+    sbtDirectory: String = ""
 ) {
   def updatePullRequestsOrDefault: PullRequestUpdateStrategy =
     updatePullRequests.getOrElse(PullRequestUpdateStrategy.default)

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -38,7 +38,7 @@ object ScalafmtAlg {
       repoConfigAlg: RepoConfigAlg[F],
       F: Monad[F]
   ): ScalafmtAlg[F] =
-	new ScalafmtAlg[F] {
+    new ScalafmtAlg[F] {
       override def getScalafmtVersion(repo: Repo): F[Option[Version]] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.buildtool
 
+import better.files.File
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Resolver, Scope, Version}
@@ -26,6 +27,8 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
         List("test", "-f", s"$repoDir/pom.xml"),
         List("test", "-f", s"$repoDir/build.sc"),
         List("test", "-f", s"$repoDir/build.sbt"),
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
         List(
           "TEST_VAR=GREAT",
           "ANOTHER_TEST_VAR=ALSO_GREAT",
@@ -37,7 +40,11 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
           "-no-colors",
           s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
         List("read", s"$repoDir/project/build.properties"),
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
         List("read", s"$repoDir/.scalafmt.conf")
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.buildtool.sbt
 
+import better.files.File
 import cats.data.StateT
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
@@ -38,6 +39,8 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
     val state = sbtAlg.getDependencies(repo).runS(initial).unsafeRunSync()
     state shouldBe initial.copy(
       commands = Vector(
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
         List(
           "TEST_VAR=GREAT",
           "ANOTHER_TEST_VAR=ALSO_GREAT",
@@ -49,6 +52,8 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "-no-colors",
           s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
         List("read", s"$repoDir/project/build.properties")
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -70,6 +70,7 @@ object MockContext {
   implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
   implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
   implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config, gitAlg)
+  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
   implicit val migrationAlg: MigrationAlg =
     MigrationAlg.create[MockEff](config.scalafixMigrations).runA(MockState.empty).unsafeRunSync()
@@ -86,7 +87,6 @@ object MockContext {
   implicit val millAlg: MillAlg[MockEff] = MillAlg.create
   implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
-  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
   implicit val pullRequestRepository: PullRequestRepository[MockEff] =
     new PullRequestRepository[MockEff](new JsonKeyValueStore("pull_requests", "1"))
   implicit val pruningAlg: PruningAlg[MockEff] = new PruningAlg[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.scalafmt
 
+import better.files.File
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
@@ -24,7 +25,11 @@ class ScalafmtAlgTest extends AnyFunSuite with Matchers {
 
     maybeUpdate shouldBe Some(Version("2.0.0-RC8"))
     state shouldBe MockState.empty.copy(
-      commands = Vector(List("read", s"$repoDir/.scalafmt.conf")),
+      commands = Vector(
+        List("read", s"$repoDir/.scala-steward.conf"),
+        List("read", s"${File.temp}/default.scala-steward.conf"),
+        List("read", s"$repoDir/.scalafmt.conf")
+      ),
       files = Map(
         scalafmtConf ->
           """maxColumn = 100


### PR DESCRIPTION
Fixes #678 for monorepos with a single sbt project in a monorepo subfolder.

It doesn't support multi build repos (#1158).

At [buildo](https://github.com/buildo) we are going to use ScalaSteward for private monorepos. We usually have one sbt project per repo, possibly multimodule, in a subfolder other than the repo root. This is going to work for buildo, let me know if repository specific config is the right approach or there is a better way to support this use case.

