### PR TITLE
Allow setting compiler options for Scalafix migrations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -87,14 +87,20 @@ object SbtAlg {
 
       override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] =
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {
-          for {
-            repoDir <- workspaceAlg.repoDir(repo)
-            scalafixCmds = for {
-              migration <- migrations
-              rule <- migration.rewriteRules
-            } yield s"$scalafixAll $rule"
-            _ <- exec(sbtCmd(scalafixEnable :: scalafixCmds.toList), repoDir)
-          } yield ()
+          workspaceAlg.repoDir(repo).flatMap { repoDir =>
+            migrations.traverse_ { migration =>
+              val withScalacOptions: F[Unit] => F[Unit] =
+                migration.scalacOptions
+                  .map { opts =>
+                    val file = scalaStewardScalafixOptions(opts.toList)
+                    fileAlg.createTemporarily[Unit, Throwable](repoDir / file.name, file.content)(_)
+                  }
+                  .getOrElse(identity)
+
+              val scalafixCmds = migration.rewriteRules.map(rule => s"$scalafixAll $rule").toList
+              withScalacOptions(exec(sbtCmd(scalafixEnable :: scalafixCmds), repoDir).void)
+            }
+          }
         }
 
       val sbtDir: F[File] =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -28,16 +28,9 @@ package object sbt {
     org.scalasteward.core.BuildInfo.scalaBinaryVersion
 
   def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
-    if (sbtVersion.toVersion >= Version("1.0.0"))
-      Some(
-        Dependency(
-          GroupId("org.scala-sbt"),
-          ArtifactId("sbt"),
-          sbtVersion.value
-        )
-      )
-    else
-      None
+    Option.when(sbtVersion.toVersion >= Version("1.0.0")) {
+      Dependency(GroupId("org.scala-sbt"), ArtifactId("sbt"), sbtVersion.value)
+    }
 
   val scalaStewardScalafixSbt: FileData =
     FileData(

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -45,6 +45,11 @@ package object sbt {
       """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")"""
     )
 
+  def scalaStewardScalafixOptions(scalacOptions: List[String]): FileData = {
+    val args = scalacOptions.map(s => s""""$s"""").mkString(", ")
+    FileData("scala-steward-scalafix-options.sbt", s"ThisBuild / scalacOptions ++= List($args)")
+  }
+
   def stewardPlugin[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
     val name = "StewardPlugin.scala"
     fileAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -26,8 +26,8 @@ final case class Migration(
     artifactIds: Nel[String],
     newVersion: Version,
     rewriteRules: Nel[String],
-    scalacOptions: Option[Nel[String]],
-    doc: Option[String]
+    doc: Option[String],
+    scalacOptions: Option[Nel[String]]
 )
 
 object Migration {

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -26,6 +26,7 @@ final case class Migration(
     artifactIds: Nel[String],
     newVersion: Version,
     rewriteRules: Nel[String],
+    scalacOptions: Option[Nel[String]],
     doc: Option[String]
 )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -63,6 +63,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
         Nel.of("fs2-core"),
         Version("1.0.0"),
         Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"),
+        None,
         None
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/sbtTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/sbtTest.scala
@@ -1,0 +1,11 @@
+package org.scalasteward.core.buildtool.sbt
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class sbtTest extends AnyFunSuite with Matchers {
+  test("scalaStewardScalafixOptions") {
+    scalaStewardScalafixOptions(List("-P:semanticdb:synthetics:on")).content shouldBe
+      """ThisBuild / scalacOptions ++= List("-P:semanticdb:synthetics:on")"""
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
@@ -34,8 +34,8 @@ class MigrationAlgTest extends AnyFunSuite with Matchers {
           Nel.of("yumyum-.*"),
           Version("1.0.0"),
           Nel.of("awesome rewrite rule"),
-          None,
-          Some("https://scalacenter.github.io/scalafix/")
+          Some("https://scalacenter.github.io/scalafix/"),
+          None
         )
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
@@ -34,6 +34,7 @@ class MigrationAlgTest extends AnyFunSuite with Matchers {
           Nel.of("yumyum-.*"),
           Version("1.0.0"),
           Nel.of("awesome rewrite rule"),
+          None,
           Some("https://scalacenter.github.io/scalafix/")
         )
       )
@@ -61,6 +62,7 @@ class MigrationAlgTest extends AnyFunSuite with Matchers {
         Nel.of("yumyum-.*"),
         Version("1.0.0"),
         Nel.of("awesome rewrite rule"),
+        None,
         None
       )
     )
@@ -87,6 +89,6 @@ class MigrationAlgTest extends AnyFunSuite with Matchers {
   test("loadMigrations without extra file") {
     val migrations =
       MigrationAlg.loadMigrations[MockEff](None).runA(MockState.empty).unsafeRunSync()
-    migrations.size shouldBe 14
+    migrations.size should be > 1
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -99,6 +99,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       Nel.of(update.artifactId.name),
       Version("0.7.0"),
       Nel.of("I am a rewrite rule"),
+      None,
       None
     )
     val (label, appliedMigrations) = NewPullRequestData.migrationNote(List(migration))
@@ -120,6 +121,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       Nel.of(update.artifactId.name),
       Version("0.7.0"),
       Nel.of("I am a rewrite rule"),
+      None,
       Some("https://scalacenter.github.io/scalafix/")
     )
     val (label, appliedMigrations) = NewPullRequestData.migrationNote(List(migration))

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -121,8 +121,8 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       Nel.of(update.artifactId.name),
       Version("0.7.0"),
       Nel.of("I am a rewrite rule"),
-      None,
-      Some("https://scalacenter.github.io/scalafix/")
+      Some("https://scalacenter.github.io/scalafix/"),
+      None
     )
     val (label, appliedMigrations) = NewPullRequestData.migrationNote(List(migration))
 


### PR DESCRIPTION
In anticipation to https://github.com/typelevel/cats/pull/3566