### PR TITLE
Add preliminary Scalafix migration for Cats 2.2.0

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -59,7 +59,7 @@ migrations = [
   {
     groupId: "org.typelevel",
     artifactIds: ["cats-core"],
-    newVersion: "2.2.0-RC5",
+    newVersion: "2.2.0-RC4",
     rewriteRules: ["github:cb372/cats/Cats_v2_2_0?sha=aa19f94a85a3043cce263ade4b712136df9e48fb"],
     doc: "https://github.com/typelevel/cats/blob/aa19f94a85a3043cce263ade4b712136df9e48fb/scalafix/README.md#migration-to-cats-v220",
     scalacOptions: ["-P:semanticdb:synthetics:on"]

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -59,6 +59,14 @@ migrations = [
   {
     groupId: "org.typelevel",
     artifactIds: ["cats-core"],
+    newVersion: "2.2.0-RC5",
+    rewriteRules: ["github:cb372/cats/Cats_v2_2_0?sha=aa19f94a85a3043cce263ade4b712136df9e48fb"],
+    doc: "https://github.com/typelevel/cats/blob/aa19f94a85a3043cce263ade4b712136df9e48fb/scalafix/README.md#migration-to-cats-v220",
+    scalacOptions: ["-P:semanticdb:synthetics:on"]
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["cats-core"],
     newVersion: "1.0.0",
     rewriteRules: ["https://raw.githubusercontent.com/typelevel/cats/master/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala"],
     doc: "https://github.com/typelevel/cats/blob/v1.0.0/scalafix/README.md"


### PR DESCRIPTION
This adds @cb372's Scalafix for Cats 2.2.0 from https://github.com/typelevel/cats/pull/3566. Once that PR is merged, we should update the `rewriteRules` so that it points to the official Cats repo. Using 2.2.0-RC4 as `newVersion` allows us to test this migration before the final release. To do so just bump Cats to 2.2.0-RC3 and let Scala Steward do the update to 2.2.0-RC4 with this migration applied.