### PR TITLE
Update cats-core to 2.2.0-RC3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % "0.3.1"
   val caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.4"
   val catsEffect = "org.typelevel" %% "cats-effect" % "2.1.4"
-  val catsCore = "org.typelevel" %% "cats-core" % "2.1.1"
+  val catsCore = "org.typelevel" %% "cats-core" % "2.2.0-RC3"
   val catsLaws = "org.typelevel" %% "cats-laws" % catsCore.revision
   val circeConfig = "io.circe" %% "circe-config" % "0.8.0"
   val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"


### PR DESCRIPTION
For testing the Cats 2.2.0 Scalafix migration: https://github.com/scala-steward-org/scala-steward/pull/1588