### PR TITLE
Use a proper Mill release instead of a hash version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val `sbt-plugin` = myCrossProject("sbt-plugin")
 lazy val `mill-plugin` = myCrossProject("mill-plugin")
   .settings(
     crossScalaVersions := Seq(Scala213, Scala212),
-    libraryDependencies += Dependencies.mill.value % Provided
+    libraryDependencies += Dependencies.millScalalib.value % Provided
   )
 
 /// settings
@@ -205,7 +205,7 @@ lazy val dockerSettings = Def.settings(
     val getSbtVersion = sbtVersion.value
     val sbtTgz = s"sbt-$getSbtVersion.tgz"
     val sbtUrl = s"https://github.com/sbt/sbt/releases/download/v$getSbtVersion/$sbtTgz"
-    val millVersion = Dependencies.mill.value.revision
+    val millVersion = Dependencies.millVersion.value
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,10 +3,6 @@ import sbt.Keys._
 import sbt.librarymanagement.syntax.ExclusionRule
 
 object Dependencies {
-  val mill = Def.setting {
-    val version = if (scalaBinaryVersion.value == "2.12") "0.6.3" else "0.8.0-11-8cd135"
-    "com.lihaoyi" %% "mill-scalalib" % version
-  }
   val attoCore = "org.tpolecat" %% "atto-core" % "0.8.0"
   val betterFiles = "com.github.pathikrit" %% "better-files" % "3.9.1"
   val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % "0.3.1"
@@ -33,6 +29,8 @@ object Dependencies {
   val kindProjector = "org.typelevel" % "kind-projector" % "0.11.0"
   val log4catsSlf4j = "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1"
   val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.2.3"
+  val millVersion = Def.setting(if (scalaBinaryVersion.value == "2.12") "0.6.3" else "0.8.0")
+  val millScalalib = Def.setting("com.lihaoyi" %% "mill-scalalib" % millVersion.value)
   val monocleCore = "com.github.julien-truffaut" %% "monocle-core" % "2.1.0"
   val refined = "eu.timepit" %% "refined" % "0.9.15"
   val refinedCats = "eu.timepit" %% "refined-cats" % refined.revision


### PR DESCRIPTION
We switched to a hash version in https://github.com/scala-steward-org/scala-steward/pull/1551 but that switch wasn't intentional. Such PRs are now prevented by https://github.com/scala-steward-org/scala-steward/pull/1552. 