### PR TITLE
Fix transitivity of Order[Version]

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -121,7 +121,6 @@ object Version {
   object Component {
     final case class Numeric(value: String, startIndex: Int) extends Component {
       def toBigInt: BigInt = BigInt(value)
-      def isZero: Boolean = toBigInt === BigInt(0)
     }
     final case class Alpha(value: String, startIndex: Int) extends Component {
       def isPreReleaseIdent: Boolean = order < 0
@@ -200,8 +199,6 @@ object Version {
     implicit val componentOrder: Order[Component] =
       Order.from[Component] {
         case (n1: Numeric, n2: Numeric) => n1.toBigInt.compare(n2.toBigInt)
-        case (n: Numeric, a: Alpha)     => if (a.isPreReleaseIdent || !n.isZero) 1 else -1
-        case (a: Alpha, n: Numeric)     => if (a.isPreReleaseIdent || !n.isZero) -1 else 1
         case (_: Numeric, _)            => 1
         case (_, _: Numeric)            => -1
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -26,6 +26,7 @@ class VersionTest
     val versions = List(
       "0.1",
       "0-20170604",
+      "1.0e",
       "1.0.0-SNAP8",
       "1.0.0-M2",
       "1.0.0",
@@ -96,6 +97,7 @@ class VersionTest
 
   test("similar ordering as Coursier") {
     List(
+      ("1.0e", "1.0.0-SNAP8"),
       ("1.0.1e", "1.0.1"),
       ("42.2.9.jre7", "42.2.9"),
       ("42.2.9.jre7", "42.2.9.jre8"),

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -17,6 +17,11 @@ class VersionTest
     with ScalaCheckPropertyChecks {
   checkAll("Order[Version]", OrderTests[Version].order)
 
+  test("issue 1615: broken transitivity") {
+    val res = OrderTests[Version].laws.transitivity(Version(""), Version("0"), Version("X"))
+    res.lhs shouldBe res.rhs
+  }
+
   test("pairwise 1") {
     val versions = List(
       "0.1",


### PR DESCRIPTION
This fixes the broken transitivity of `Order[Version]` noticed in #1615 by removing cases in `Order[Component]`. It is concerning that that there are no test cases that were sensitive to the removed code. We should double-check if it is OK to remove that code or if we can write tests that are sensitive to that code.