### PR TITLE
Delete file in createTemporarily if writeFile fails

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -52,8 +52,10 @@ trait FileAlg[F[_]] {
 
   final def createTemporarily[A, E](file: File, content: String)(
       fa: F[A]
-  )(implicit F: Bracket[F, E]): F[A] =
-    F.bracket(writeFile(file, content))(_ => fa)(_ => deleteForce(file))
+  )(implicit F: Bracket[F, E]): F[A] = {
+    val create = writeFile(file, content).onError(_ => deleteForce(file))
+    F.bracket(create)(_ => fa)(_ => deleteForce(file))
+  }
 
   final def editFile(file: File, edit: String => Option[String])(implicit
       F: MonadThrowable[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -53,8 +53,9 @@ trait FileAlg[F[_]] {
   final def createTemporarily[A, E](file: File, content: String)(
       fa: F[A]
   )(implicit F: Bracket[F, E]): F[A] = {
-    val create = writeFile(file, content).onError(_ => deleteForce(file))
-    F.bracket(create)(_ => fa)(_ => deleteForce(file))
+    val delete = deleteForce(file)
+    val create = writeFile(file, content).onError(_ => delete)
+    F.bracket(create)(_ => fa)(_ => delete)
   }
 
   final def editFile(file: File, edit: String => Option[String])(implicit


### PR DESCRIPTION
`FileAlg.createTemporarily` could leave partially written files behind
if `writeFile` fails with an error - for example if it fails with
an `IOException` if there is no space left on the device. With this
change `deleteForce` will be called in case of an error and the error
will be rethrown so that `createTemporarily` fails too (as before).