### PR TITLE
Tweak and test splitDuration

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -16,6 +16,7 @@
 
 package org.scalasteward.core.util
 
+import cats.syntax.all._
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.concurrent.duration._
@@ -39,10 +40,13 @@ object dateTime {
     @tailrec
     def loop(d1: FiniteDuration, acc: List[FiniteDuration]): List[FiniteDuration] =
       nextUnitAndCap(d1.unit) match {
-        case Some((nextUnit, cap)) if d1.length > cap =>
+        case Some((nextUnit, cap)) if d1.length >= cap =>
           val next = FiniteDuration(d1.length / cap, nextUnit)
           val capped = FiniteDuration(d1.length % cap, d1.unit)
-          loop(next, capped :: acc)
+          if (capped.length === 0L)
+            loop(next, acc)
+          else
+            loop(next, capped :: acc)
         case _ => d1 :: acc
       }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
@@ -1,12 +1,27 @@
 package org.scalasteward.core.util
 
+import cats.syntax.all._
 import org.scalasteward.core.util.dateTime._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.duration._
 
-class dateTimeTest extends AnyFunSuite with Matchers {
-  test("showDuration") {
-    showDuration(247023586491264L.nanoseconds) shouldBe "2d 20h 37m 3s 586ms 491µs 264ns"
+class dateTimeTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks {
+  test("showDuration: example 1") {
+    val d = 2.days + 20.hours + 37.minutes + 3.seconds + 586.millis + 491.micros + 264.nanos
+    showDuration(d) shouldBe "2d 20h 37m 3s 586ms 491µs 264ns"
+  }
+
+  test("showDuration: example 2") {
+    showDuration(60.minutes + 30.seconds + 1000.millis) shouldBe "1h 31s"
+  }
+
+  test("showDuration: example 3") {
+    showDuration(23.hours + 59.minutes + 59.seconds + 1000.millis) shouldBe "1d"
+  }
+
+  test("splitDuration and combineAll is identity") {
+    forAll((d: FiniteDuration) => splitDuration(d).combineAll.eqv(d))
   }
 }


### PR DESCRIPTION
Before this change `showDuration` returned `"60m 31s 0ms"` instead of `"1h 31s"` for example.