### PR TITLE
Do not print stack trace if Cli.parseArgs fails

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -17,9 +17,13 @@
 package org.scalasteward.core
 
 import cats.effect.{ExitCode, IO, IOApp}
-import org.scalasteward.core.application.Context
+import org.scalasteward.core.application.{Cli, Context}
 
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
-    Context.create[IO](args).use(_.runF)
+    Cli.parseArgs(args) match {
+      case Cli.ParseResult.Success(args) => Context.create[IO](args).use(_.runF)
+      case Cli.ParseResult.Help(help)    => IO(Console.out.println(help)).as(ExitCode.Success)
+      case Cli.ParseResult.Error(error)  => IO(Console.err.println(error)).as(ExitCode.Error)
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -44,12 +44,11 @@ import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg, VCSSelecti
 
 object Context {
   def create[F[_]: ConcurrentEffect: ContextShift: Parallel: Timer](
-      args: List[String]
+      args: Cli.Args
   ): Resource[F, StewardAlg[F]] =
     for {
       blocker <- Blocker[F]
-      cliArgs_ <- Resource.liftF(new Cli[F].parseArgs(args))
-      implicit0(config: Config) <- Resource.liftF(Config.create[F](cliArgs_))
+      implicit0(config: Config) <- Resource.liftF(Config.create[F](args))
       implicit0(client: Client[F]) <- AsyncHttpClient.resource[F]()
       implicit0(logger: Logger[F]) <- Resource.liftF(Slf4jLogger.create[F])
       implicit0(httpExistenceClient: HttpExistenceClient[F]) <- HttpExistenceClient.create[F]

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -63,7 +63,11 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
   }
 
   test("parseArgs fail if required option not provided") {
-    Cli.parseArgs(Nil) shouldBe a[Error]
+    Cli.parseArgs(Nil).asInstanceOf[Error].error should startWith("Required option")
+  }
+
+  test("parseArgs unrecognized argument") {
+    Cli.parseArgs(List("--foo")).asInstanceOf[Error].error should startWith("Unrecognized")
   }
 
   test("parseArgs --help") {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -2,17 +2,15 @@ package org.scalasteward.core.application
 
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli.EnvVar
+import org.scalasteward.core.application.Cli.ParseResult._
 import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class CliTest extends AnyFunSuite with Matchers with EitherValues {
-  type Result[A] = Either[Throwable, A]
-  val cli: Cli[Result] = new Cli[Result]
-
   test("parseArgs") {
-    cli.parseArgs(
+    Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -27,7 +25,7 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
         List("--env-var", "i=j"),
         List("--process-timeout", "30min")
       ).flatten
-    ) shouldBe Right(
+    ) shouldBe Success(
       Cli.Args(
         workspace = "a",
         reposFile = "b",
@@ -45,7 +43,7 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
   }
 
   test("parseArgs minimal version") {
-    cli.parseArgs(
+    Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -53,7 +51,7 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
         List("--vcs-login", "e"),
         List("--git-ask-pass", "f")
       ).flatten
-    ) shouldBe Right(
+    ) shouldBe Success(
       Cli.Args(
         workspace = "a",
         reposFile = "b",
@@ -65,15 +63,15 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
   }
 
   test("parseArgs fail if required option not provided") {
-    cli.parseArgs(Nil).isLeft shouldBe true
+    Cli.parseArgs(Nil) shouldBe a[Error]
   }
 
   test("parseArgs --help") {
-    cli.parseArgs(List("--help")).left.value.getMessage should include("--git-author-email")
+    Cli.parseArgs(List("--help")).asInstanceOf[Help].help should include("--git-author-email")
   }
 
   test("parseArgs --usage") {
-    cli.parseArgs(List("--usage")).left.value.getMessage should startWith("Usage: args")
+    Cli.parseArgs(List("--usage")).asInstanceOf[Help].help should startWith("Usage: args")
   }
 
   test("env-var without equals sign") {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class CliTest extends AnyFunSuite with Matchers with EitherValues {
-  test("parseArgs") {
+  test("parseArgs: example") {
     Cli.parseArgs(
       List(
         List("--workspace", "a"),
@@ -42,7 +42,7 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
     )
   }
 
-  test("parseArgs minimal version") {
+  test("parseArgs: minimal example") {
     Cli.parseArgs(
       List(
         List("--workspace", "a"),
@@ -62,40 +62,44 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
     )
   }
 
-  test("parseArgs fail if required option not provided") {
+  test("parseArgs: fail if required option not provided") {
     Cli.parseArgs(Nil).asInstanceOf[Error].error should startWith("Required option")
   }
 
-  test("parseArgs unrecognized argument") {
+  test("parseArgs: unrecognized argument") {
     Cli.parseArgs(List("--foo")).asInstanceOf[Error].error should startWith("Unrecognized")
   }
 
-  test("parseArgs --help") {
+  test("parseArgs: --help") {
     Cli.parseArgs(List("--help")).asInstanceOf[Help].help should include("--git-author-email")
   }
 
-  test("parseArgs --usage") {
+  test("parseArgs: --usage") {
     Cli.parseArgs(List("--usage")).asInstanceOf[Help].help should startWith("Usage: args")
   }
 
-  test("env-var without equals sign") {
+  test("envVarArgParser: env-var without equals sign") {
     Cli.envVarArgParser(None, "SBT_OPTS").isLeft shouldBe true
   }
 
-  test("env-var with multiple equals signs") {
+  test("envVarArgParser: env-var with multiple equals signs") {
     val value = "-Xss8m -XX:MaxMetaspaceSize=256m"
     Cli.envVarArgParser(None, s"SBT_OPTS=$value") shouldBe Right(EnvVar("SBT_OPTS", value))
   }
 
-  test("valid timeout") {
+  test("finiteDurationArgParser: well-formed duration") {
     Cli.finiteDurationArgParser(None, "30min") shouldBe Right(30.minutes)
   }
 
-  test("malformed timeout") {
+  test("finiteDurationArgParser: malformed duration") {
     Cli.finiteDurationArgParser(None, "xyz").isLeft shouldBe true
   }
 
-  test("malformed timeout (Inf)") {
+  test("finiteDurationArgParser: malformed duration (Inf)") {
     Cli.finiteDurationArgParser(None, "Inf").isLeft shouldBe true
+  }
+
+  test("finiteDurationArgParser: previous value") {
+    Cli.finiteDurationArgParser(Some(10.seconds), "20seconds").isLeft shouldBe true
   }
 }


### PR DESCRIPTION
We're currently printing a rather unhelpful stack trace if `Cli.parseArgs`
fails. This currently happens if
 - a required argument is missing
 - the value of an argument cannot be parsed
 - `--help` or `--usage` is provided

With this PR no stack traces are printed under these conditions. Error
or help messages are just printed to stderr or stdout and the program
exits with an appropriate status.