### PR TITLE
Ground work to close obsolete pull requests

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/json.scala
@@ -39,9 +39,10 @@ private[http4s] object json {
 
   implicit val pullRequestOutDecoder: Decoder[PullRequestOut] = Decoder.instance { c =>
     for {
+      id <- c.downField("id").as[Int]
       title <- c.downField("title").as[String]
       state <- c.downField("state").as[PullRequestState]
       html_url <- c.downField("links").downField("self").downField("href").as[Uri]
-    } yield (PullRequestOut(html_url, state, title))
+    } yield (PullRequestOut(id, html_url, state, title))
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
@@ -59,7 +59,7 @@ class Http4sBitbucketServerApiAlg[F[_]](
         reviewers = reviewers
       )
       pr <- client.postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify(repo))
-    } yield PullRequestOut(pr.links("self").head.href, pr.state, pr.title)
+    } yield PullRequestOut(pr.id, pr.links("self").head.href, pr.state, pr.title)
   }
 
   private def useDefaultReviewers(repo: Repo): F[List[Reviewer]] =
@@ -92,7 +92,9 @@ class Http4sBitbucketServerApiAlg[F[_]](
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
     client
       .get[Json.Page[Json.PR]](url.listPullRequests(repo, s"refs/heads/$head"), modify(repo))
-      .map(_.values.map(pr => PullRequestOut(pr.links("self").head.href, pr.state, pr.title)))
+      .map(
+        _.values.map(pr => PullRequestOut(pr.id, pr.links("self").head.href, pr.state, pr.title))
+      )
 
   def ni(name: String): Nothing = throw new NotImplementedError(name)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
@@ -34,7 +34,7 @@ object Json {
 
   case class Link(href: Uri, name: Option[String])
 
-  case class PR(title: String, state: PullRequestState, links: Links)
+  case class PR(id: Int, title: String, state: PullRequestState, links: Links)
 
   case class NewPR(
       title: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/git/Branch.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Branch.scala
@@ -16,6 +16,8 @@
 
 package org.scalasteward.core.git
 
+import cats.Eq
+import cats.syntax.eq._
 import io.circe.{Decoder, Encoder}
 
 final case class Branch(name: String)
@@ -28,4 +30,8 @@ object Branch {
 
   implicit val branchEncoder: Encoder[Branch] =
     Encoder[String].contramap(_.name)
+
+  implicit val branchEq: Eq[Branch] = Eq.instance { (branch1, branch2) =>
+    branch1.name === branch2.name
+  }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -21,8 +21,9 @@ import org.scalasteward.core.repoconfig.CommitsConfig
 import org.scalasteward.core.update.show
 
 package object git {
+  def branchPrefix(update: Update): String = s"update/${update.name}"
   def branchFor(update: Update): Branch =
-    Branch(s"update/${update.name}-${update.nextVersion}")
+    Branch(s"${branchPrefix(update)}-${update.nextVersion}")
 
   def commitMsgFor(update: Update, commitsConfig: CommitsConfig): String = {
     val artifact = show.oneLiner(update)

--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -43,6 +43,11 @@ private[http4s] object MergeRequestPayload {
     MergeRequestPayload(id, data.title, data.body, projectId, data.head, data.base)
 }
 
+private[http4s] case class MergeRequestUpdatePayload(state_event: String)
+private[http4s] object MergeRequestUpdatePayload {
+  val Close: MergeRequestUpdatePayload = MergeRequestUpdatePayload("closed")
+}
+
 final private[http4s] case class MergeRequestOut(
     webUrl: Uri,
     state: PullRequestState,
@@ -50,7 +55,7 @@ final private[http4s] case class MergeRequestOut(
     iid: Int,
     mergeStatus: String
 ) {
-  val pullRequestOut: PullRequestOut = PullRequestOut(webUrl, state, title)
+  val pullRequestOut: PullRequestOut = PullRequestOut(iid, webUrl, state, title)
 }
 
 final private[http4s] case class CommitId(id: Sha1) {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
@@ -24,6 +24,7 @@ import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 
 final case class PullRequestOut(
+    id: Int,
     html_url: Uri,
     state: PullRequestState,
     title: String

--- a/modules/core/src/test/scala/org/scalasteward/core/bitbucket/http4s/Http4sBitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/bitbucket/http4s/Http4sBitbucketApiAlgTest.scala
@@ -98,6 +98,7 @@ class Http4sBitbucketApiAlgTest extends AnyFunSuite with Matchers {
     case POST -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" =>
       Ok(
         json"""{
+            "id": 1,
             "title": "scala-steward-pr",
             "state": "OPEN",
             "links": {
@@ -112,6 +113,7 @@ class Http4sBitbucketApiAlgTest extends AnyFunSuite with Matchers {
         json"""{
           "values": [
               {
+                  "id": 1,
                   "title": "scala-steward-pr",
                   "state": "OPEN",
                   "links": {
@@ -158,7 +160,7 @@ class Http4sBitbucketApiAlgTest extends AnyFunSuite with Matchers {
     CommitOut(Sha1(HexString("07eb2a203e297c8340273950e98b2cab68b560c1")))
   )
 
-  val pullRequest = PullRequestOut(prUrl, PullRequestState.Open, "scala-steward-pr")
+  val pullRequest = PullRequestOut(1, prUrl, PullRequestState.Open, "scala-steward-pr")
 
   test("createForkOrGetRepo") {
     val repoOut =

--- a/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
@@ -94,6 +94,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
         .unsafeRunSync()
 
     prOut shouldBe PullRequestOut(
+      7115,
       uri"https://gitlab.com/foo/bar/merge_requests/7115",
       PullRequestState.Open,
       "title"
@@ -115,6 +116,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
         .unsafeRunSync()
 
     prOut shouldBe PullRequestOut(
+      150,
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
       "title"
@@ -141,6 +143,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
         .unsafeRunSync()
 
     prOut shouldBe PullRequestOut(
+      150,
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
       "title"
@@ -174,6 +177,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
         .unsafeRunSync()
 
     prOut shouldBe PullRequestOut(
+      150,
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
       "title"

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
@@ -12,6 +12,7 @@ class PullRequestOutTest extends AnyFunSuite with Matchers {
     val expected =
       List(
         PullRequestOut(
+          1,
           uri"https://github.com/octocat/Hello-World/pull/1347",
           Open,
           "new-feature"


### PR DESCRIPTION
This is some ground work to bring in #119.

Let me know what you think. In an upcoming MR:
* implement close pr for gitlab/github/bitbucket
* write the domain logic to extract branches, find related pr and close em

Here is the initial feature document I have locally:

# Introduction
Currently, the Scala Steward creates a pull-request with a specific branch pattern. I hope to reuse this branch pattern to find opened PR on branches that matches this pattern. 

Suppose the bot is working with `org.typelevel:cats`. If there is an opened PR on the project to update from `2.0.0` to `2.0.1` (branch: `update/cats-2.0.1`) and when the bot runs again, it opens a new PR to update from `2.0.0` to `2.0.2` (branch: `update/cats-2.0.2`), we'd like the bot to close the older PR.

This is to prevent PRs to pile up.

# Details

The pattern looks like this: `update/${artifact}-${version}`. If the various providers give us a way to get only opened branches that match the first part of the pattern: `update/${artifact}` (i.e.: ignoring the version)

So the bot needs to:

1. list branches in the repository (locally using `git`)
2. filter out the current branch, and keep only branches related to the current main artifact id we're updating
3. foreach branch, check whether a pull request is open for it, if yes, close it


# References:

Github Pulls API: https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls

Gitlab MRs API: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests

Bitbucket pullrequests API https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests