### PR TITLE
submodules added with ssh-style apparently use the ssh binary directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val dockerSettings = Def.settings(
     val millVersion = Dependencies.millVersion.value
     Seq(
       Cmd("USER", "root"),
-      Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven"),
+      Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd(
         "RUN",


### PR DESCRIPTION
Looking at the logs:
```
Cloning into '/opt/scala-steward/workspace/repos/myorg/myrepo'...
Submodule 'external/mysubmodule' (git@internal.repo:myorg/mysubmodule.git) registered for path 'external/mysubmodule'
Cloning into '/opt/scala-steward/workspace/repos/myorg/myrepo/external/mysubmodule'...
error: cannot run ssh: No such file or directory
fatal: unable to fork
fatal: clone of 'git@internal.repo:myorg/mysubmodule.git' into submodule path '/opt/scala-steward/workspace/repos/myorg/myrepo/external/mysubmodule' failed
```

I added the `openssh` dep and the error went away