### PR TITLE
Avoid duplicated VCSApiAlg.createForkOrGetRepo call

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -25,9 +25,9 @@ import org.scalasteward.core.data.{Dependency, DependencyInfo}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.util.MonadThrowable
-import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
+import scala.util.control.NoStackTrace
 
 final class RepoCacheAlg[F[_]](implicit
     buildToolDispatcher: BuildToolDispatcher[F],
@@ -42,10 +42,10 @@ final class RepoCacheAlg[F[_]](implicit
     vcsRepoAlg: VCSRepoAlg[F],
     F: MonadThrowable[F]
 ) {
-  def checkCache(repo: Repo): F[Unit] =
-    logger.attemptLog_(s"Check cache of ${repo.show}") {
+  def checkCache(repo: Repo): F[RepoOut] =
+    logger.info(s"Check cache of ${repo.show}") >> {
       F.ifM(refreshErrorAlg.failedRecently(repo))(
-        logger.info(s"Skipping due to previous error"),
+        F.raiseError(new Throwable("Skipping due to previous error") with NoStackTrace),
         for {
           ((repoOut, branchOut), cachedSha1) <- (
             vcsApiAlg.createForkOrGetRepoWithDefaultBranch(repo, config.doNotFork),
@@ -54,7 +54,7 @@ final class RepoCacheAlg[F[_]](implicit
           latestSha1 = branchOut.commit.sha
           refreshRequired = cachedSha1.forall(_ =!= latestSha1)
           _ <- if (refreshRequired) cloneAndRefreshCache(repo, repoOut) else F.unit
-        } yield ()
+        } yield repoOut
       )
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -24,24 +24,19 @@ import scala.concurrent.duration.FiniteDuration
 
 object logger {
   implicit final class LoggerOps[F[_]](private val logger: Logger[F]) extends AnyVal {
-    def attemptLog[A](message: String)(fa: F[A])(implicit
+    def attemptLog[A](label: String, errorLabel: Option[String] = None)(fa: F[A])(implicit
         F: MonadThrowable[F]
     ): F[Either[Throwable, A]] =
-      logger.info(message) >> fa.attempt.flatTap {
-        case Left(t)  => logger.error(t)(s"$message failed")
+      logger.info(label) >> fa.attempt.flatTap {
+        case Left(t)  => logger.error(t)(s"${errorLabel.getOrElse(label)} failed")
         case Right(_) => F.unit
       }
-
-    def attemptLog_[A](message: String)(fa: F[A])(implicit F: MonadThrowable[F]): F[Unit] =
-      attemptLog(message)(fa).void
 
     def infoTimed[A](msg: FiniteDuration => String)(fa: F[A])(implicit
         dateTimeAlg: DateTimeAlg[F],
         F: Monad[F]
     ): F[A] =
-      dateTimeAlg.timed(fa).flatMap { case (a, duration) =>
-        logger.info(msg(duration)) >> F.pure(a)
-      }
+      dateTimeAlg.timed(fa).flatMap { case (a, duration) => logger.info(msg(duration)).as(a) }
 
     def infoTotalTime[A](label: String)(fa: F[A])(implicit
         dateTimeAlg: DateTimeAlg[F],

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -8,11 +8,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class loggerTest extends AnyFunSuite with Matchers {
-  test("attemptLog_") {
+  test("attemptLog") {
     final case class Err(msg: String) extends Throwable(msg)
     val err = Err("hmm?")
     val state = mockLogger
-      .attemptLog_("run")(Sync[MockEff].raiseError(err))
+      .attemptLog("run")(Sync[MockEff].raiseError(err))
       .runS(MockState.empty)
       .unsafeRunSync()
 


### PR DESCRIPTION
This removes the `VCSApiAlg.createForkOrGetRepo` call in `NurtureAlg` by
reusing the result of `createForkOrGetRepoWithDefaultBranch` in
`RepoCacheAlg`.