### PR TITLE
Use File in Cli.Args

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -87,7 +87,7 @@ object Cli {
       }
     }
 
-  implicit val fileParser: ArgParser[File] =
+  implicit val fileArgParser: ArgParser[File] =
     ArgParser[String].xmapError(
       _.toString,
       s => Either.catchNonFatal(File(s)).leftMap(t => MalformedValue("File", t.getMessage))

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -92,31 +92,29 @@ object Config {
       disableDefaults: Boolean
   )
 
-  def create[F[_]](args: Cli.Args)(implicit F: Sync[F]): F[Config] =
-    F.delay {
-      Config(
-        workspace = args.workspace.toFile,
-        reposFile = args.reposFile.toFile,
-        defaultRepoConfigFile = args.defaultRepoConf.map(_.toFile),
-        gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
-        vcsType = args.vcsType,
-        vcsApiHost = args.vcsApiHost,
-        vcsLogin = args.vcsLogin,
-        gitAskPass = args.gitAskPass.toFile,
-        signCommits = args.signCommits,
-        whitelistedDirectories = args.whitelist,
-        readOnlyDirectories = args.readOnly,
-        disableSandbox = args.disableSandbox,
-        doNotFork = args.doNotFork,
-        ignoreOptsFiles = args.ignoreOptsFiles,
-        envVars = args.envVar,
-        processTimeout = args.processTimeout,
-        scalafix = Scalafix(args.scalafixMigrations, args.disableDefaultScalafixMigrations),
-        groupMigrations = args.groupMigrations.map(_.toFile),
-        cacheTtl = args.cacheTtl,
-        cacheMissDelay = args.cacheMissDelay,
-        bitbucketServerUseDefaultReviewers = args.bitbucketServerUseDefaultReviewers,
-        gitlabMergeWhenPipelineSucceeds = args.gitlabMergeWhenPipelineSucceeds
-      )
-    }
+  def from(args: Cli.Args): Config =
+    Config(
+      workspace = args.workspace,
+      reposFile = args.reposFile,
+      defaultRepoConfigFile = args.defaultRepoConf,
+      gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
+      vcsType = args.vcsType,
+      vcsApiHost = args.vcsApiHost,
+      vcsLogin = args.vcsLogin,
+      gitAskPass = args.gitAskPass,
+      signCommits = args.signCommits,
+      whitelistedDirectories = args.whitelist,
+      readOnlyDirectories = args.readOnly,
+      disableSandbox = args.disableSandbox,
+      doNotFork = args.doNotFork,
+      ignoreOptsFiles = args.ignoreOptsFiles,
+      envVars = args.envVar,
+      processTimeout = args.processTimeout,
+      scalafix = Scalafix(args.scalafixMigrations, args.disableDefaultScalafixMigrations),
+      groupMigrations = args.groupMigrations,
+      cacheTtl = args.cacheTtl,
+      cacheMissDelay = args.cacheMissDelay,
+      bitbucketServerUseDefaultReviewers = args.bitbucketServerUseDefaultReviewers,
+      gitlabMergeWhenPipelineSucceeds = args.gitlabMergeWhenPipelineSucceeds
+    )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -51,7 +51,7 @@ object Context {
       blocker <- Blocker[F]
       implicit0(logger: Logger[F]) <- Resource.liftF(Slf4jLogger.create[F])
       _ <- Resource.liftF(printBanner[F])
-      implicit0(config: Config) <- Resource.liftF(Config.create[F](args))
+      implicit0(config: Config) <- Resource.pure(Config.from(args))
       implicit0(client: Client[F]) <- AsyncHttpClient.resource[F]()
       implicit0(httpExistenceClient: HttpExistenceClient[F]) <- HttpExistenceClient.create[F]
       implicit0(user: AuthenticatedUser) <- Resource.liftF(config.vcsUser[F])

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.application
 
+import better.files.File
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.Cli.ParseResult._
@@ -27,14 +28,14 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
       ).flatten
     ) shouldBe Success(
       Cli.Args(
-        workspace = "a",
-        reposFile = "b",
-        defaultRepoConf = Some("c"),
+        workspace = File("a"),
+        reposFile = File("b"),
+        defaultRepoConf = Some(File("c")),
         gitAuthorEmail = "d",
         vcsType = SupportedVCS.Gitlab,
         vcsApiHost = uri"http://example.com",
         vcsLogin = "e",
-        gitAskPass = "f",
+        gitAskPass = File("f"),
         ignoreOptsFiles = true,
         envVar = List(EnvVar("g", "h"), EnvVar("i", "j")),
         processTimeout = 30.minutes
@@ -53,11 +54,11 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
       ).flatten
     ) shouldBe Success(
       Cli.Args(
-        workspace = "a",
-        reposFile = "b",
+        workspace = File("a"),
+        reposFile = File("b"),
         gitAuthorEmail = "d",
         vcsLogin = "e",
-        gitAskPass = "f"
+        gitAskPass = File("f")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -103,4 +103,8 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
   test("finiteDurationArgParser: previous value") {
     Cli.finiteDurationArgParser(Some(10.seconds), "20seconds").isLeft shouldBe true
   }
+
+  test("fileArgParser: previous value") {
+    Cli.fileArgParser(Some(File("/tmp")), "/opt").isLeft shouldBe true
+  }
 }


### PR DESCRIPTION
This uses `File` in `Cli.Args` so that we don't need `Sync` when converting
from `Args` to `Config`.