### PR TITLE
Rename *Throwable aliases to *Throw

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -19,12 +19,12 @@ package org.scalasteward.core.application
 import cats.syntax.all._
 import io.chrisdavenport.log4cats.Logger
 import org.http4s.Uri
-import org.scalasteward.core.util.{HttpExistenceClient, MonadThrowable}
+import org.scalasteward.core.util.{HttpExistenceClient, MonadThrow}
 
 final class SelfCheckAlg[F[_]](implicit
     httpExistenceClient: HttpExistenceClient[F],
     logger: Logger[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def checkAll: F[Unit] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -29,7 +29,7 @@ import org.scalasteward.core.repocache.RepoCacheAlg
 import org.scalasteward.core.update.PruningAlg
 import org.scalasteward.core.util
 import org.scalasteward.core.util.logger.LoggerOps
-import org.scalasteward.core.util.{BracketThrowable, DateTimeAlg}
+import org.scalasteward.core.util.{BracketThrow, DateTimeAlg}
 import org.scalasteward.core.vcs.data.Repo
 
 final class StewardAlg[F[_]](implicit
@@ -45,7 +45,7 @@ final class StewardAlg[F[_]](implicit
     selfCheckAlg: SelfCheckAlg[F],
     streamCompiler: Stream.Compiler[F, F],
     workspaceAlg: WorkspaceAlg[F],
-    F: BracketThrowable[F]
+    F: BracketThrow[F]
 ) {
   private def readRepos(reposFile: File): Stream[F, Repo] =
     Stream.evals {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -28,7 +28,7 @@ import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Dependency, Resolver, Scope}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
-import org.scalasteward.core.util.{BracketThrowable, Nel}
+import org.scalasteward.core.util.{BracketThrow, Nel}
 import org.scalasteward.core.vcs.data.Repo
 
 trait SbtAlg[F[_]] extends BuildToolAlg[F] {
@@ -49,7 +49,7 @@ object SbtAlg {
       logger: Logger[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
-      F: BracketThrowable[F]
+      F: BracketThrow[F]
   ): SbtAlg[F] =
     new SbtAlg[F] {
       override def addGlobalPluginTemporarily[A](plugin: FileData)(fa: F[A]): F[A] =

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
@@ -23,7 +23,7 @@ import io.circe.{Codec, KeyEncoder}
 import org.scalasteward.core.coursier.VersionsCache.{Key, Value}
 import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
 import org.scalasteward.core.persistence.KeyValueStore
-import org.scalasteward.core.util.{DateTimeAlg, MonadThrowable, Timestamp}
+import org.scalasteward.core.util.{DateTimeAlg, MonadThrow, Timestamp}
 import scala.concurrent.duration.FiniteDuration
 
 final class VersionsCache[F[_]](
@@ -33,7 +33,7 @@ final class VersionsCache[F[_]](
     coursierAlg: CoursierAlg[F],
     dateTimeAlg: DateTimeAlg[F],
     parallel: Parallel[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def getVersions(dependency: Scope.Dependency, maxAge: Option[FiniteDuration]): F[List[Version]] =
     dependency.resolvers

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -35,7 +35,7 @@ final class EditAlg[F[_]](implicit
     migrationAlg: MigrationAlg,
     streamCompiler: Stream.Compiler[F, F],
     workspaceAlg: WorkspaceAlg[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def applyUpdate(repo: Repo, update: Update, fileExtensions: Set[String]): F[Unit] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -23,7 +23,7 @@ import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.util.{BracketThrowable, Nel}
+import org.scalasteward.core.util.{BracketThrow, Nel}
 import org.scalasteward.core.vcs.data.Repo
 
 trait GitAlg[F[_]] {
@@ -76,7 +76,7 @@ object GitAlg {
       fileAlg: FileAlg[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
-      F: BracketThrowable[F]
+      F: BracketThrow[F]
   ): GitAlg[F] =
     new GitAlg[F] {
       override def branchAuthors(repo: Repo, branch: Branch, base: Branch): F[List[String]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -24,7 +24,7 @@ import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.gitlab._
 import org.scalasteward.core.util.uri.uriDecoder
-import org.scalasteward.core.util.{HttpJsonClient, MonadThrowable, UnexpectedResponse}
+import org.scalasteward.core.util.{HttpJsonClient, MonadThrow, UnexpectedResponse}
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data._
 
@@ -117,7 +117,7 @@ class Http4sGitLabApiAlg[F[_]](
 )(implicit
     client: HttpJsonClient[F],
     logger: Logger[F],
-    monad: MonadThrowable[F]
+    monad: MonadThrow[F]
 ) extends VCSApiAlg[F] {
   import GitlabJsonCodec._
 

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -25,7 +25,7 @@ import io.chrisdavenport.log4cats.Logger
 import org.apache.commons.io.FileUtils
 import org.http4s.Uri
 import org.http4s.implicits.http4sLiteralsSyntax
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.util.MonadThrow
 import scala.io.Source
 
 trait FileAlg[F[_]] {
@@ -63,14 +63,14 @@ trait FileAlg[F[_]] {
   }
 
   final def editFile(file: File, edit: String => Option[String])(implicit
-      F: MonadThrowable[F]
+      F: MonadThrow[F]
   ): F[Boolean] =
     readFile(file)
       .flatMap(_.flatMap(edit).fold(F.pure(false))(writeFile(file, _).as(true)))
       .adaptError { case t => new Throwable(s"failed to edit $file", t) }
 
   final def editFiles[G[_]](files: G[File], edit: String => Option[String])(implicit
-      F: MonadThrowable[F],
+      F: MonadThrow[F],
       G: Traverse[G]
   ): F[Boolean] =
     files.traverse(editFile(_, edit)).map(_.foldLeft(false)(_ || _))

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -30,7 +30,7 @@ import org.scalasteward.core.git.{Branch, Commit, GitAlg}
 import org.scalasteward.core.repocache.RepoCacheRepository
 import org.scalasteward.core.repoconfig.{PullRequestUpdateStrategy, RepoConfigAlg}
 import org.scalasteward.core.scalafix.MigrationAlg
-import org.scalasteward.core.util.{BracketThrowable, HttpExistenceClient}
+import org.scalasteward.core.util.{BracketThrow, HttpExistenceClient}
 import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg}
 import org.scalasteward.core.{git, util, vcs}
@@ -50,7 +50,7 @@ final class NurtureAlg[F[_]](implicit
     pullRequestRepository: PullRequestRepository[F],
     repoCacheRepository: RepoCacheRepository[F],
     streamCompiler: Stream.Compiler[F, F],
-    F: BracketThrowable[F]
+    F: BracketThrow[F]
 ) {
   def nurture(repo: Repo, fork: RepoOut, updates: List[Update.Single]): F[Unit] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -24,7 +24,7 @@ import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.data.{Dependency, DependencyInfo}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.util.MonadThrow
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 import scala.util.control.NoStackTrace
@@ -40,7 +40,7 @@ final class RepoCacheAlg[F[_]](implicit
     repoConfigAlg: RepoConfigAlg[F],
     vcsApiAlg: VCSApiAlg[F],
     vcsRepoAlg: VCSRepoAlg[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def checkCache(repo: Repo): F[RepoOut] =
     logger.info(s"Check cache of ${repo.show}") >> {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -25,7 +25,7 @@ import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfigAlg._
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.util.MonadThrow
 import org.scalasteward.core.vcs.data.Repo
 
 final class RepoConfigAlg[F[_]](implicit
@@ -33,7 +33,7 @@ final class RepoConfigAlg[F[_]](implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
     workspaceAlg: WorkspaceAlg[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
 
   def readRepoConfigWithDefault(repo: Repo): F[RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/MigrationsLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/MigrationsLoader.scala
@@ -24,12 +24,12 @@ import org.http4s.implicits.http4sLiteralsSyntax
 import org.scalasteward.core.application.Config.ScalafixCfg
 import org.scalasteward.core.io.FileAlg
 import org.scalasteward.core.scalafix.MigrationsLoader._
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.util.MonadThrow
 
 final class MigrationsLoader[F[_]](implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def loadAll(config: ScalafixCfg): F[List[Migration]] = {
     val maybeDefaultMigrationsUrl =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/GroupMigrations.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/GroupMigrations.scala
@@ -23,14 +23,14 @@ import io.circe.generic.extras.{semiauto, Configuration}
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.data._
 import org.scalasteward.core.io.FileAlg
-import org.scalasteward.core.util.{MonadThrowable, Nel}
+import org.scalasteward.core.util.{MonadThrow, Nel}
 
 trait GroupMigrations {
   def findUpdateWithNewerGroupId(dependency: Dependency): Option[Update.Single]
 }
 
 object GroupMigrations {
-  def create[F[_]: MonadThrowable](implicit
+  def create[F[_]: MonadThrow](implicit
       fileAlg: FileAlg[F],
       config: Config
   ): F[GroupMigrations] = {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
@@ -31,7 +31,7 @@ final class HttpExistenceClient[F[_]](statusCache: Cache[Status])(implicit
     client: Client[F],
     logger: Logger[F],
     mode: Mode[F],
-    F: MonadThrowable[F]
+    F: MonadThrow[F]
 ) {
   def exists(uri: Uri): F[Boolean] =
     status(uri).map(_ === Status.Ok).handleErrorWith { throwable =>

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration.FiniteDuration
 object logger {
   implicit final class LoggerOps[F[_]](private val logger: Logger[F]) extends AnyVal {
     def attemptLog[A](label: String, errorLabel: Option[String] = None)(fa: F[A])(implicit
-        F: MonadThrowable[F]
+        F: MonadThrow[F]
     ): F[Either[Throwable, A]] =
       logger.info(label) >> fa.attempt.flatTap {
         case Left(t)  => logger.error(t)(s"${errorLabel.getOrElse(label)} failed")

--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -26,11 +26,11 @@ package object util {
   final type Nel[+A] = cats.data.NonEmptyList[A]
   final val Nel = cats.data.NonEmptyList
 
-  type ApplicativeThrowable[F[_]] = ApplicativeError[F, Throwable]
+  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
 
-  type MonadThrowable[F[_]] = MonadError[F, Throwable]
+  type MonadThrow[F[_]] = MonadError[F, Throwable]
 
-  type BracketThrowable[F[_]] = Bracket[F, Throwable]
+  type BracketThrow[F[_]] = Bracket[F, Throwable]
 
   /** Appends `elem` to `buffer` such that its size does not exceed `maxSize`. */
   def appendBounded[A](buffer: ListBuffer[A], elem: A, maxSize: Int): Unit = {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.vcs
 
 import cats.syntax.all._
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.util.{ApplicativeThrowable, MonadThrowable}
+import org.scalasteward.core.util.{ApplicativeThrow, MonadThrow}
 import org.scalasteward.core.vcs.data._
 
 trait VCSApiAlg[F[_]] {
@@ -36,7 +36,7 @@ trait VCSApiAlg[F[_]] {
     if (doNotFork) getRepo(repo) else createFork(repo)
 
   final def createForkOrGetRepoWithDefaultBranch(repo: Repo, doNotFork: Boolean)(implicit
-      F: MonadThrowable[F]
+      F: MonadThrow[F]
   ): F[(RepoOut, BranchOut)] =
     for {
       forkOrRepo <- createForkOrGetRepo(repo, doNotFork)
@@ -44,12 +44,12 @@ trait VCSApiAlg[F[_]] {
     } yield (forkOrRepo, defaultBranch)
 
   final def getDefaultBranchOfParentOrRepo(repoOut: RepoOut, doNotFork: Boolean)(implicit
-      F: MonadThrowable[F]
+      F: MonadThrow[F]
   ): F[BranchOut] =
     parentOrRepo(repoOut, doNotFork).flatMap(getDefaultBranch)
 
   final def parentOrRepo(repoOut: RepoOut, doNotFork: Boolean)(implicit
-      F: ApplicativeThrowable[F]
+      F: ApplicativeThrow[F]
   ): F[RepoOut] =
     if (doNotFork) F.pure(repoOut) else repoOut.parentOrRaise[F]
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -22,7 +22,7 @@ import org.http4s.Uri.UserInfo
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.util
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.util.MonadThrow
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 
 trait VCSRepoAlg[F[_]] {
@@ -32,7 +32,7 @@ trait VCSRepoAlg[F[_]] {
 }
 
 object VCSRepoAlg {
-  def create[F[_]: MonadThrowable](config: Config, gitAlg: GitAlg[F]): VCSRepoAlg[F] =
+  def create[F[_]: MonadThrow](config: Config, gitAlg: GitAlg[F]): VCSRepoAlg[F] =
     new VCSRepoAlg[F] {
       override def clone(repo: Repo, repoOut: RepoOut): F[Unit] =
         for {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
@@ -20,7 +20,7 @@ import io.circe.Decoder
 import io.circe.generic.semiauto._
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.util.ApplicativeThrowable
+import org.scalasteward.core.util.ApplicativeThrow
 import org.scalasteward.core.util.uri.uriDecoder
 
 final case class RepoOut(
@@ -30,7 +30,7 @@ final case class RepoOut(
     clone_url: Uri,
     default_branch: Branch
 ) {
-  def parentOrRaise[F[_]](implicit F: ApplicativeThrowable[F]): F[RepoOut] =
+  def parentOrRaise[F[_]](implicit F: ApplicativeThrow[F]): F[RepoOut] =
     parent.fold(F.raiseError[RepoOut](new Throwable(s"repo $name has no parent")))(F.pure)
 
   def repo: Repo =

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.scalafix.{MigrationAlg, MigrationsLoader, Migration
 import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.update.{FilterAlg, GroupMigrations, PruningAlg, UpdateAlg}
 import org.scalasteward.core.util.uri._
-import org.scalasteward.core.util.{BracketThrowable, DateTimeAlg}
+import org.scalasteward.core.util.{BracketThrow, DateTimeAlg}
 import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
@@ -55,7 +55,7 @@ object MockContext {
       )
     )
 
-  implicit val mockEffBracketThrowable: BracketThrowable[MockEff] = Sync[MockEff]
+  implicit val mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
   implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
 
   implicit val fileAlg: MockFileAlg = new MockFileAlg


### PR DESCRIPTION
These aliases are defined in Cats Effect 3 and we'll use them once we
update to that version. This change will make the diff to that version
smaller.