### PR TITLE
Run mill with execSandboxed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,7 +268,9 @@ runSteward := Def.taskDyn {
     Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),
     Seq("--whitelist", s"$home/.cache/coursier"),
     Seq("--whitelist", s"$home/.cache/JNA"),
+    Seq("--whitelist", s"$home/.cache/mill"),
     Seq("--whitelist", s"$home/.ivy2"),
+    Seq("--whitelist", s"$home/.mill"),
     Seq("--whitelist", s"$home/.sbt"),
     Seq("--whitelist", myJavaHome),
     Seq("--read-only", myJavaHome)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -17,14 +17,13 @@
 package org.scalasteward.core.buildtool.mill
 
 import cats.syntax.all._
-import cats.effect.Sync
 import org.scalasteward.core.BuildInfo
 import org.scalasteward.core.buildtool.BuildToolAlg
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.util.{MonadThrow, Nel}
 import org.scalasteward.core.vcs.data.Repo
 
 trait MillAlg[F[_]] extends BuildToolAlg[F]
@@ -43,7 +42,7 @@ object MillAlg {
       fileAlg: FileAlg[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
-      F: Sync[F]
+      F: MonadThrow[F]
   ): MillAlg[F] =
     new MillAlg[F] {
       override def containsBuild(repo: Repo): F[Boolean] =
@@ -54,24 +53,15 @@ object MillAlg {
           repoDir <- workspaceAlg.repoDir(repo)
           predef = repoDir / "scala-steward.sc"
           _ <- fileAlg.writeFile(predef, content)
-          extracted <- processAlg.exec(
-            Nel(
-              "mill",
-              List(
-                "-i",
-                "-p",
-                predef.toString(),
-                "show",
-                s"${BuildInfo.millPluginModuleRootPkg}.StewardPlugin/extractDeps"
-              )
-            ),
+          extractDeps = s"${BuildInfo.millPluginModuleRootPkg}.StewardPlugin/extractDeps"
+          extracted <- processAlg.execSandboxed(
+            Nel("mill", List("-i", "-p", predef.toString(), "show", extractDeps)),
             repoDir
           )
           parsed <- F.fromEither(
             parser.parseModules(extracted.dropWhile(!_.startsWith("{")).mkString("\n"))
           )
           _ <- fileAlg.deleteForce(predef)
-
         } yield parsed.map(module => Scope(module.dependencies, module.repositories))
 
       override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] = F.unit

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -12,7 +12,8 @@ class MillAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("lihaoyi", "fastparse")
     val repoDir = config.workspace / repo.show
     val predef = s"$repoDir/scala-steward.sc"
-    val millCmd = List("mill", "-i", "-p", predef, "show", extractDeps)
+    val millCmd =
+      List("firejail", s"--whitelist=$repoDir", "mill", "-i", "-p", predef, "show", extractDeps)
     val initial = MockState.empty.copy(commandOutputs = Map(millCmd -> List("""{"modules":[]}""")))
     val state = millAlg.getDependencies(repo).runS(initial).unsafeRunSync()
     state shouldBe initial.copy(

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -35,7 +35,9 @@ COMMON_ARGS=(
   --process-timeout 20min
   --whitelist $HOME/.cache/coursier
   --whitelist $HOME/.cache/JNA
+  --whitelist $HOME/.cache/mill
   --whitelist $HOME/.ivy2
+  --whitelist $HOME/.mill
   --whitelist $HOME/.sbt
   --whitelist $HOME/.scio-ideaPluginIC
   --whitelist $HOME/.tagless-redux-ijextPluginIC


### PR DESCRIPTION
We're doing the same with sbt and Maven. All builds should be run with
`execSandboxed` since we're executing user-provided code.