### PR TITLE
Replace @daily, @weekly, @monthly with arbitrary timespans

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -10,9 +10,10 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 #   @asap
 #     PRs are created without delay.
 #
-#   @daily | @weekly | @monthly
-#     PRs are created at least 1 day | 7 days | 30 days after the last PR.
-#
+#   <timespan>
+#     PRs are created only again after the given timespan since the last PR
+#     has passed. Example values are "36 hours", "1 day", or "14 days".
+
 #   <CRON expression>
 #     PRs are created roughly according to the given CRON expression.
 #
@@ -29,7 +30,7 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 # Default: @asap
 #
 #pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-pullRequests.frequency = "@weekly"
+pullRequests.frequency = "7 days"
 
 # Only these dependencies which match the given patterns are updated.
 #

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -23,6 +23,7 @@ import caseapp.core.argparser.{ArgParser, SimpleArgParser}
 import cats.syntax.all._
 import org.http4s.Uri
 import org.http4s.syntax.literals._
+import org.scalasteward.core.util.dateTime.parseFiniteDuration
 import scala.concurrent.duration._
 
 object Cli {
@@ -101,12 +102,6 @@ object Cli {
           MalformedValue("FiniteDuration", error)
         }
     )
-
-  private def parseFiniteDuration(s: String): Either[Throwable, FiniteDuration] =
-    Either.catchNonFatal(Duration(s)).flatMap {
-      case fd: FiniteDuration => Right(fd)
-      case d                  => Left(new Throwable(s"$d is not a FiniteDuration"))
-    }
 
   implicit val uriArgParser: ArgParser[Uri] =
     ArgParser[String].xmapError(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -22,6 +22,7 @@ import cron4s.lib.javatime._
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.repoconfig.PullRequestFrequency._
 import org.scalasteward.core.util.Timestamp
+import org.scalasteward.core.util.dateTime.parseFiniteDuration
 import scala.concurrent.duration._
 
 sealed trait PullRequestFrequency {
@@ -36,9 +37,7 @@ sealed trait PullRequestFrequency {
   def waitingTime(lastCreated: Timestamp, now: Timestamp): Option[FiniteDuration] = {
     val nextPossible = this match {
       case Asap           => None
-      case Daily          => Some(lastCreated + 1.day)
-      case Weekly         => Some(lastCreated + 7.days)
-      case Monthly        => Some(lastCreated + 30.days)
+      case Timespan(fd)   => Some(lastCreated + fd)
       case CronExpr(expr) => expr.next(lastCreated.toLocalDateTime).map(Timestamp.fromLocalDateTime)
     }
     nextPossible.map(now.until).filter(_.length > 0)
@@ -47,9 +46,9 @@ sealed trait PullRequestFrequency {
 
 object PullRequestFrequency {
   case object Asap extends PullRequestFrequency { val render = "@asap" }
-  case object Daily extends PullRequestFrequency { val render = "@daily" }
-  case object Weekly extends PullRequestFrequency { val render = "@weekly" }
-  case object Monthly extends PullRequestFrequency { val render = "@monthly" }
+  final case class Timespan(fd: FiniteDuration) extends PullRequestFrequency {
+    val render: String = fd.toString
+  }
   final case class CronExpr(expr: cron4s.CronExpr) extends PullRequestFrequency {
     val render: String = expr.toString
   }
@@ -58,19 +57,21 @@ object PullRequestFrequency {
 
   def fromString(s: String): Either[String, PullRequestFrequency] =
     s.trim.toLowerCase match {
-      case Asap.render    => Right(Asap)
-      case Daily.render   => Right(Daily)
-      case Weekly.render  => Right(Weekly)
-      case Monthly.render => Right(Monthly)
-      case other          =>
-        // cron4s requires exactly 6 fields, but we also want to support the more
-        // common format with 5 fields. Therefore we're prepending the "seconds"
-        // field ourselves if parsing the original string fails.
-        parseCron4s(other).orElse(parseCron4s("0 " + other)).leftMap(_.toString).map(CronExpr.apply)
+      case Asap.render => Right(Asap)
+      case "@daily"    => Right(Timespan(1.day))
+      case "@weekly"   => Right(Timespan(7.day))
+      case "@monthly"  => Right(Timespan(30.day))
+      case other       => parseTimespan(other).orElse(parseCronExpr(other))
     }
 
-  private def parseCron4s(s: String): Either[Throwable, cron4s.CronExpr] =
-    Either.catchNonFatal(cron4s.Cron.unsafeParse(s))
+  private def parseTimespan(s: String): Either[String, Timespan] =
+    parseFiniteDuration(s).bimap(_.toString, Timespan.apply)
+
+  private def parseCronExpr(s: String): Either[String, CronExpr] =
+    // cron4s requires exactly 6 fields, but we also want to support the more
+    // common format with 5 fields. Therefore we're prepending the "seconds"
+    // field ourselves if parsing the original string fails.
+    cron4s.Cron.parse(s).orElse(cron4s.Cron.parse("0 " + s)).bimap(_.toString, CronExpr.apply)
 
   implicit val pullRequestFrequencyEq: Eq[PullRequestFrequency] =
     Eq.fromUniversalEquals

--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -22,6 +22,12 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 
 object dateTime {
+  def parseFiniteDuration(s: String): Either[Throwable, FiniteDuration] =
+    Either.catchNonFatal(Duration(s)).flatMap {
+      case fd: FiniteDuration => Right(fd)
+      case d                  => Left(new Throwable(s"$d is not a FiniteDuration"))
+    }
+
   def showDuration(d: FiniteDuration): String = {
     def symbol(unit: TimeUnit): String =
       unit match {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -22,6 +22,11 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
     freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)
   }
 
+  test("waitingTime: timespan") {
+    val Right(freq) = PullRequestFrequency.fromString("14 days")
+    freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe Some(6.hours + 13.days)
+  }
+
   test("waitingTime: cron expr") {
     val Right(freq) = PullRequestFrequency.fromString("0 1 ? * *")
     freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -17,6 +17,11 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
     notThursday.onSchedule(epoch) shouldBe false
   }
 
+  test("waitingTime: @asap") {
+    val Right(freq) = PullRequestFrequency.fromString("@asap")
+    freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe None
+  }
+
   test("waitingTime: @daily") {
     val Right(freq) = PullRequestFrequency.fromString("@daily")
     freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
@@ -2,11 +2,12 @@ package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.SemigroupTests
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Daily, Monthly, Weekly}
+import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+import scala.concurrent.duration._
 
 class PullRequestsConfigTest
     extends AnyFunSuite
@@ -15,7 +16,7 @@ class PullRequestsConfigTest
     with Configuration {
 
   implicit val pullRequestFrequencyArbitrary: Arbitrary[PullRequestFrequency] = Arbitrary(
-    Gen.oneOf(Asap, Daily, Weekly, Monthly)
+    Gen.oneOf(Asap, Timespan(1.day), Timespan(7.days), Timespan(30.days))
   )
   implicit val pullRequestsConfigArbitrary: Arbitrary[PullRequestsConfig] = Arbitrary(for {
     e <- Arbitrary.arbitrary[Option[PullRequestFrequency]]

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
@@ -15,9 +15,9 @@ class PullRequestsConfigTest
     with FunSuiteDiscipline
     with Configuration {
 
-  implicit val pullRequestFrequencyArbitrary: Arbitrary[PullRequestFrequency] = Arbitrary(
-    Gen.oneOf(Asap, Timespan(1.day), Timespan(7.days), Timespan(30.days))
-  )
+  implicit val pullRequestFrequencyArbitrary: Arbitrary[PullRequestFrequency] =
+    Arbitrary(Arbitrary.arbitrary[FiniteDuration].flatMap(fd => Gen.oneOf(Asap, Timespan(fd))))
+
   implicit val pullRequestsConfigArbitrary: Arbitrary[PullRequestsConfig] = Arbitrary(for {
     e <- Arbitrary.arbitrary[Option[PullRequestFrequency]]
   } yield PullRequestsConfig(e))

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -10,6 +10,7 @@ import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
 
 class RepoConfigAlgTest extends AnyFunSuite with Matchers {
   test("config with all fields set") {
@@ -34,7 +35,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val config = repoConfigAlg.readRepoConfigWithDefault(repo).runA(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig(
-      pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Weekly)),
+      pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(7.days))),
       updates = UpdatesConfig(
         allow = List(UpdatePattern(GroupId("eu.timepit"), None, None)),
         pin = List(
@@ -118,7 +119,9 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val content = """pullRequests.frequency = "@daily" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Daily)))
+      RepoConfig(pullRequests =
+        PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(1.day)))
+      )
     )
   }
 
@@ -126,7 +129,9 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val content = """pullRequests.frequency = "@monthly" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Monthly)))
+      RepoConfig(pullRequests =
+        PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(30.days)))
+      )
     )
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
@@ -4,6 +4,7 @@ import cats.syntax.semigroup._
 import org.scalasteward.core.data.GroupId
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
 
 class RepoConfigTest extends AnyFunSuite with Matchers {
   test("RepoConfig: semigroup") {
@@ -25,7 +26,7 @@ class RepoConfigTest extends AnyFunSuite with Matchers {
 
     val cfg2 = RepoConfig(
       commits = CommitsConfig(Some("b")),
-      pullRequests = PullRequestsConfig(Some(PullRequestFrequency.Daily)),
+      pullRequests = PullRequestsConfig(Some(PullRequestFrequency.Timespan(1.day))),
       updates = UpdatesConfig(
         allow =
           List(UpdatePattern(GroupId("B"), None, None), UpdatePattern(GroupId("C"), None, None))

--- a/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
@@ -8,6 +8,10 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.duration._
 
 class dateTimeTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks {
+  test("parseFiniteDuration") {
+    forAll((d: FiniteDuration) => parseFiniteDuration(d.toString) shouldBe Right(d))
+  }
+
   test("showDuration: example 1") {
     val d = 2.days + 20.hours + 37.minutes + 3.seconds + 586.millis + 491.micros + 264.nanos
     showDuration(d) shouldBe "2d 20h 37m 3s 586ms 491µs 264ns"


### PR DESCRIPTION
This replaces `PullRequestFrequency.{Daily, Weekly, Monthly}` with a new
`Timespan` case for arbitrary timespans. It allows for example to set
the PR frequency like this:
```
pullRequests.frequency = "14 days"
```

`@daily`, `@weekly`, `@monthly` can still be parsed and are translated
to `Timespan(1.day)`, `Timespan(7.days)`, and `Timespan(30.days)`. The
main motivation for this change is to make it easier for users to set
the frequencey to every x days without resorting to cron expressions
which are harder to read and write.