### PR TITLE
Add fs2-io as dependency explicitly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val core = myCrossProject("core")
       Dependencies.coursierCatsInterop,
       Dependencies.cron4sCore,
       Dependencies.fs2Core,
+      Dependencies.fs2Io,
       Dependencies.http4sAsyncHttpClient,
       Dependencies.http4sCirce,
       Dependencies.log4catsSlf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val disciplineScalatest = ("org.typelevel" %% "discipline-scalatest" % "2.0.1")
     .excludeAll(ExclusionRule().withOrganization("org.scalatest"))
   val fs2Core = "co.fs2" %% "fs2-core" % "2.4.4"
+  val fs2Io = "co.fs2" %% "fs2-io" % fs2Core.revision
   val http4sAsyncHttpClient = "org.http4s" %% "http4s-async-http-client" % "0.21.7"
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sAsyncHttpClient.revision
   val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sAsyncHttpClient.revision


### PR DESCRIPTION
We're using fs2-io already in `process` so this has been an undeclared
compile-time dependency for a while. Not declaring it also leads to a
binary incompatibility when updating to Cats Effect 3.