### PR TITLE
Close obsolete PRs only if a PR was created or updated

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -87,7 +87,10 @@ final class NurtureAlg[F[_]](implicit
         update => {
           val updateData =
             UpdateData(repo, fork, repoConfig, update, baseBranch, baseSha1, git.branchFor(update))
-          processUpdate(updateData) <* closeObsoletePullRequests(updateData)
+          processUpdate(updateData).flatMap {
+            case result @ Updated => closeObsoletePullRequests(updateData).as(result)
+            case result @ Ignored => F.pure(result)
+          }
         },
         repoConfig.updates.limit
       )


### PR DESCRIPTION
This closes obsolete PRs only if a new PR was created or if an existing
PR was updated. Sometimes `processUpdate` does not create a new PR
because it can't figure out where to bump the version number. I think
that in these cases Scala Steward should not close the PRs of older
updates.

Follow-up to #1667. /cc @daddykotex 