### PR TITLE
Run scalafmt when upgrading scalafmt (opt-out)

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -80,6 +80,12 @@ updatePullRequests = "always" | "on-conflicts" | "never"
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
 # Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}" 
 commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+
+# If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt 
+# and add a separate commit when format changed. So you don't need reformat manually and can merge PR.
+# If false, Scala Steward will not perform scalafmt, so your CI may abort when reformat needed.
+# Default: true
+scalafmt.runAfterUpgrading = false
 ```
 
 The version information given in the patterns above can be in two formats:

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -26,7 +26,8 @@ final case class RepoConfig(
     commits: CommitsConfig = CommitsConfig(),
     pullRequests: PullRequestsConfig = PullRequestsConfig(),
     updates: UpdatesConfig = UpdatesConfig(),
-    updatePullRequests: Option[PullRequestUpdateStrategy] = None
+    updatePullRequests: Option[PullRequestUpdateStrategy] = None,
+    scalafmt: Option[ScalafmtConfig] = None
 ) {
   def updatePullRequestsOrDefault: PullRequestUpdateStrategy =
     updatePullRequests.getOrElse(PullRequestUpdateStrategy.default)
@@ -51,7 +52,8 @@ object RepoConfig {
             commits = x.commits |+| y.commits,
             pullRequests = x.pullRequests |+| y.pullRequests,
             updates = x.updates |+| y.updates,
-            updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests)
+            updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests),
+            scalafmt = x.scalafmt.orElse(y.scalafmt)
           )
       }
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018-2020 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.kernel.Eq
+import io.circe.Codec
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+
+case class ScalafmtConfig(
+    runAfterUpgrading: Boolean
+)
+
+object ScalafmtConfig {
+  implicit val scalafmtConfig: Configuration =
+    Configuration.default.withDefaults
+
+  implicit val eqScalafmtConfig: Eq[ScalafmtConfig] = Eq.fromUniversalEquals
+
+  implicit val scalafmtConfigCodec: Codec[ScalafmtConfig] = deriveConfiguredCodec
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -62,7 +62,7 @@ object ScalafmtAlg {
               F.pure(false)
             }
           _ <- F.whenA(shouldRunScalafmt) {
-            processAlg.execSandboxed(Nel.of("sbt", ";scalafmtAll;scalafmtSbt"), repoDir)
+            processAlg.exec(Nel.of("scalafmt"), repoDir)
           }
         } yield ()
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -20,10 +20,14 @@ import cats.data.Nested
 import cats.syntax.all._
 import cats.{Functor, Monad}
 import org.scalasteward.core.data.{Dependency, Version}
-import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
+import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.repoconfig.RepoConfigAlg
+import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
 trait ScalafmtAlg[F[_]] {
+  def runScalafmt(repo: Repo, mainArtifactId: String): F[Unit]
+
   def getScalafmtVersion(repo: Repo): F[Option[Version]]
 
   final def getScalafmtDependency(repo: Repo)(implicit F: Functor[F]): F[Option[Dependency]] =
@@ -34,6 +38,8 @@ object ScalafmtAlg {
   def create[F[_]](implicit
       fileAlg: FileAlg[F],
       workspaceAlg: WorkspaceAlg[F],
+      repoConfigAlg: RepoConfigAlg[F],
+      processAlg: ProcessAlg[F],
       F: Monad[F]
   ): ScalafmtAlg[F] =
     new ScalafmtAlg[F] {
@@ -43,5 +49,21 @@ object ScalafmtAlg {
           scalafmtConfFile = repoDir / ".scalafmt.conf"
           fileContent <- fileAlg.readFile(scalafmtConfFile)
         } yield fileContent.flatMap(parseScalafmtConf)
+
+      override def runScalafmt(repo: Repo, mainArtifactId: String): F[Unit] =
+        for {
+          repoDir <- workspaceAlg.repoDir(repo)
+          shouldRunScalafmt <-
+            if (mainArtifactId === scalafmtArtifactId) {
+              repoConfigAlg
+                .readRepoConfigWithDefault(repo)
+                .map(_.scalafmt.exists(_.runAfterUpgrading))
+            } else {
+              F.pure(false)
+            }
+          _ <- F.whenA(shouldRunScalafmt) {
+            processAlg.execSandboxed(Nel.of("sbt", ";scalafmtAll;scalafmtSbt"), repoDir)
+          }
+        } yield ()
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -57,7 +57,7 @@ object ScalafmtAlg {
             if (mainArtifactId === scalafmtArtifactId) {
               repoConfigAlg
                 .readRepoConfigWithDefault(repo)
-                .map(_.scalafmt.exists(_.runAfterUpgrading))
+                .map(_.scalafmt.forall(_.runAfterUpgrading))
             } else {
               F.pure(false)
             }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -21,10 +21,12 @@ import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 
 package object scalafmt {
+  val scalafmtArtifactId: String = "scalafmt-core"
+
   def scalafmtDependency(scalafmtVersion: Version): Dependency =
     Dependency(
       GroupId(if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson"),
-      ArtifactId("scalafmt-core", s"scalafmt-core_$defaultScalaBinaryVersion"),
+      ArtifactId(scalafmtArtifactId, s"${scalafmtArtifactId}_$defaultScalaBinaryVersion"),
       scalafmtVersion.value
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -62,6 +62,7 @@ object MockContext {
   implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
   implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
   implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config, gitAlg)
+  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
   val migrationsLoader: MigrationsLoader[MockEff] = new MigrationsLoader[MockEff]
   implicit val migrationAlg: MigrationAlg = migrationsLoader
@@ -82,7 +83,6 @@ object MockContext {
   implicit val millAlg: MillAlg[MockEff] = MillAlg.create
   implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
-  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
   implicit val pullRequestRepository: PullRequestRepository[MockEff] =
     new PullRequestRepository[MockEff](new JsonKeyValueStore("pull_requests", "2"))
   implicit val pruningAlg: PruningAlg[MockEff] = new PruningAlg[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -135,6 +135,14 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     )
   }
 
+  test("config with 'scalafmt.runAfterUpgrading = true'") {
+    val content = "scalafmt.runAfterUpgrading = true"
+    val config = RepoConfigAlg.parseRepoConfig(content)
+    config shouldBe Right(
+      RepoConfig(scalafmt = Some(ScalafmtConfig(runAfterUpgrading = true)))
+    )
+  }
+
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -91,15 +91,7 @@ class ScalafmtAlgTest extends AnyFunSuite with Matchers {
       commands = Vector(
         List("read", s"$repoDir/.scala-steward.conf"),
         List("read", s"$rootDir/default.scala-steward.conf"),
-        List(
-          "VAR1=val1",
-          "VAR2=val2",
-          repoDir.toString,
-          "firejail",
-          s"--whitelist=$repoDir",
-          "sbt",
-          s";scalafmtAll;scalafmtSbt"
-        )
+        List("VAR1=val1", "VAR2=val2", repoDir.toString, "scalafmt")
       ),
       files = Map(
         repoConf -> "scalafmt.runAfterUpgrading = true"
@@ -120,15 +112,7 @@ class ScalafmtAlgTest extends AnyFunSuite with Matchers {
       commands = Vector(
         List("read", s"$repoDir/.scala-steward.conf"),
         List("read", s"$rootDir/default.scala-steward.conf"),
-        List(
-          "VAR1=val1",
-          "VAR2=val2",
-          repoDir.toString,
-          "firejail",
-          s"--whitelist=$repoDir",
-          "sbt",
-          s";scalafmtAll;scalafmtSbt"
-        )
+        List("VAR1=val1", "VAR2=val2", repoDir.toString, "scalafmt")
       ),
       files = Map()
     )


### PR DESCRIPTION
Closes #1056

This PR adds `scalafmt.runAfterUpgrading` config, as opt-oput (default `true`).
If `true` and when `scalafmt-core` is being updated, Scala Steward will run `scalafmt` CLI and add a separate commit if dirty.

Example PR: https://github.com/exoego/scala-steward-test-project/pull/173
