### PR TITLE
Check that git and scalafmt can be executed in SelfCheckAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -70,7 +70,6 @@ object Context {
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
         new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "1", kvsPrefix))
-      implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
@@ -78,6 +77,7 @@ object Context {
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "2", kvsPrefix))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
+      implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create[F]
       implicit val versionsCache: VersionsCache[F] =
         new VersionsCache[F](config.cacheTtl, new JsonKeyValueStore("versions", "2"))

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -30,6 +30,8 @@ trait ScalafmtAlg[F[_]] {
 
   def getScalafmtVersion(repo: Repo): F[Option[Version]]
 
+  def version: F[String]
+
   final def getScalafmtDependency(repo: Repo)(implicit F: Functor[F]): F[Option[Dependency]] =
     Nested(getScalafmtVersion(repo)).map(scalafmtDependency).value
 }
@@ -65,5 +67,10 @@ object ScalafmtAlg {
             processAlg.exec(Nel.of("scalafmt"), repoDir)
           }
         } yield ()
+
+      override def version: F[String] =
+        workspaceAlg.rootDir
+          .flatMap(processAlg.exec(Nel.of("scalafmt", "--version"), _))
+          .map(_.mkString.trim)
     }
 }


### PR DESCRIPTION
The first few lines of Scala Steward's output now look like this:
```
2020-10-19 17:27:05,585 INFO
  ____            _         ____  _                             _
 / ___|  ___ __ _| | __ _  / ___|| |_ _____      ____ _ _ __ __| |
 \___ \ / __/ _` | |/ _` | \___ \| __/ _ \ \ /\ / / _` | '__/ _` |
  ___) | (_| (_| | | (_| |  ___) | ||  __/\ V  V / (_| | | | (_| |
 |____/ \___\__,_|_|\__,_| |____/ \__\___| \_/\_/ \__,_|_|  \__,_|
 v0.7.0-59-1fcfcc01-20201019-1455-SNAPSHOT

2020-10-19 17:27:06,745 INFO  Loaded 15 Scalafix migrations
2020-10-19 17:27:06,934 INFO  Run self checks
2020-10-19 17:27:07,135 INFO  Using git version 2.17.1
2020-10-19 17:27:07,769 INFO  Using scalafmt 2.7.5
```

If one of the binaries cannot be executed, it will print a warning:
```
2020-10-19 17:28:49,122 WARN  Failed to execute scalafmt
java.io.IOException: Cannot run program "scalafmt"
```