### PR TITLE
Do not check in StewardPlugin if dependencies are defined in build files

### DIFF
--- a/modules/sbt-plugin/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin.scala
@@ -17,9 +17,8 @@
 package org.scalasteward.sbt.plugin
 
 import sbt.Keys._
-import sbt.{Def, _}
+import sbt._
 import scala.util.Try
-import scala.util.matching.Regex
 
 object StewardPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
@@ -35,14 +34,11 @@ object StewardPlugin extends AutoPlugin {
     Seq(
       stewardDependencies := {
         val log = streams.value.log
-        val sourcePositions = dependencyPositions.value
-        val buildRoot = baseDirectory.in(ThisBuild).value
         val scalaBinaryVersionValue = scalaBinaryVersion.value
         val scalaVersionValue = scalaVersion.value
         val sbtCredentials = findCredentials.value
 
         val libraryDeps = libraryDependencies.value
-          .filter(isDefinedInBuildFiles(_, sourcePositions, buildRoot))
           .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
         val scalafixDeps = findScalafixDependencies.value
@@ -79,44 +75,6 @@ object StewardPlugin extends AutoPlugin {
         log.info(sb.result())
       }
     )
-
-  // Inspired by https://github.com/rtimush/sbt-updates/issues/42 and
-  // https://github.com/rtimush/sbt-updates/pull/112
-  private def isDefinedInBuildFiles(
-      moduleId: ModuleID,
-      sourcePositions: Map[ModuleID, SourcePosition],
-      buildRoot: File
-  ): Boolean =
-    sourcePositions.get(moduleId) match {
-      case Some(fp: FilePosition) =>
-        val path = fp.path
-        () match {
-          case _ if path.startsWith("(sbt.Classpaths") => true
-          case _ if path.startsWith("(") =>
-            extractFileName(path).exists(fileExists(buildRoot, _))
-
-          // Compiler plugins added via addCompilerPlugin(...) have a SourcePosition
-          // like this: LinePosition(Defaults.scala,3738).
-          case _ if path.startsWith("Defaults.scala") && isCompilerPlugin(moduleId) => true
-          case _ if path.startsWith("Defaults.scala")                               => false
-          case _                                                                    => true
-        }
-      case _ => true
-    }
-
-  private def extractFileName(path: String): Option[String] = {
-    val FileNamePattern: Regex = "^\\([^\\)]+\\) (.*)$".r
-    path match {
-      case FileNamePattern(fileName) => Some(fileName)
-      case _                         => None
-    }
-  }
-
-  private def fileExists(buildRoot: File, file: String): Boolean =
-    (buildRoot / "project" / file).exists()
-
-  private def isCompilerPlugin(moduleId: ModuleID): Boolean =
-    moduleId.configurations.exists(_ == "plugin->default(compile)")
 
   // base on mdoc
   // https://github.com/scalameta/mdoc/blob/62cacfbc4c7b618228e349d4f460061916398424/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala#L164-L182


### PR DESCRIPTION
This reverts #584 which shouldn't be needed any more since #1188.

The goal of #584 was to ignore dependencies that are added by plugins
because those dependencies cannot be updated. Unfortunately this
solution is brittle because it also ignores plugins that are added via
`addSbtPlugin` in `settings`, see https://github.com/http4s/sbt-http4s-org/pull/26#issuecomment-712351259.
(They also have a source position like ` LinePosition(Defaults.scala,...)`.)

A similar optimization was later added in #1188 which ignores all
dependencies whose versions number cannot be found in files of the repo.
This optimization also covers dependencies that are added by plugins.
Let's see if this is good enough to also cover #584.