### PR TITLE
Install scalafmt on Dockerfile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -214,6 +214,10 @@ lazy val dockerSettings = Def.settings(
       Cmd(
         "RUN",
         s"curl -L https://github.com/lihaoyi/mill/releases/download/${millVersion.split("-").head}/$millVersion > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
+      ),
+      Cmd(
+        "RUN",
+        "curl -L https://git.io/coursier-cli > /usr/local/bin/coursier && chmod +x /usr/local/bin/coursier && coursier install scalafmt --install-dir /usr/local/bin/ && rm -rf /usr/local/bin/coursier"
       )
     )
   },

--- a/build.sbt
+++ b/build.sbt
@@ -207,17 +207,18 @@ lazy val dockerSettings = Def.settings(
     val sbtTgz = s"sbt-$getSbtVersion.tgz"
     val sbtUrl = s"https://github.com/sbt/sbt/releases/download/v$getSbtVersion/$sbtTgz"
     val millVersion = Dependencies.millVersion.value
+    val binDir = "/usr/local/bin/"
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd(
         "RUN",
-        s"curl -L https://github.com/lihaoyi/mill/releases/download/${millVersion.split("-").head}/$millVersion > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
+        s"curl -L https://github.com/lihaoyi/mill/releases/download/${millVersion.split("-").head}/$millVersion >${binDir}mill && chmod +x ${binDir}mill"
       ),
       Cmd(
         "RUN",
-        "curl -L https://git.io/coursier-cli > /usr/local/bin/coursier && chmod +x /usr/local/bin/coursier && coursier install scalafmt --install-dir /usr/local/bin/ && rm -rf /usr/local/bin/coursier"
+        s"curl -L https://git.io/coursier-cli > ${binDir}coursier && chmod +x ${binDir}coursier && coursier install scalafmt --install-dir ${binDir} && rm -rf ${binDir}coursier"
       )
     )
   },


### PR DESCRIPTION
Closes #1677 

JAR-version of scalafmt is chosen, instead of GraalVM-native version of scalafmt.
Because native scalafmt is very slow on many Scala files, due to lack of JIT.

On my machine, on scala-steward repo (200 scala files) 
- JAR scalafmt took 20 seconds
- native scalafmt took 71 seconds

Also I guess native scalafmt may not work on alpine Docker image, due to lack of enough libs for native.



