### PR TITLE
Change scalafmt commit message and add version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -166,7 +166,10 @@ final class NurtureAlg[F[_]](implicit
           _ <- gitAlg.createBranch(data.repo, data.updateBranch)
           maybeCommit <- commitChanges(data)
           _ <- scalafmtAlg.runScalafmt(data.repo, data.update.mainArtifactId)
-          maybeScalafmtCommit <- gitAlg.commitAllIfDirty(data.repo, "Apply scalafmt")
+          maybeScalafmtCommit <- gitAlg.commitAllIfDirty(
+            data.repo,
+            s"Reformat with scalafmt ${data.update.nextVersion}"
+          )
           _ <- pushCommits(data, List(maybeCommit, maybeScalafmtCommit).flatten)
           _ <- createPullRequest(data)
         } yield Updated


### PR DESCRIPTION
This changes the commit message for scalafmt commits to "Reformat with
scalafmt $version". I think "Reformat" is a more common commit message
for scalafmt changes and the version allows to search on GitHub for all
scalafmt commits of a particular version by Scala Steward.