### PR TITLE
Differentiate between non-set and empty file extensions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -56,6 +56,17 @@ package object util {
   def bindUntilTrue[G[_]: Foldable, F[_]: Monad](gfb: G[F[Boolean]]): F[Boolean] =
     gfb.existsM(identity)
 
+  /** Like `Semigroup[Option[A]].combine` but allows to specify how `A`s are combined. */
+  def combineOptions[A](x: Option[A], y: Option[A])(f: (A, A) => A): Option[A] =
+    x match {
+      case None => y
+      case Some(xv) =>
+        y match {
+          case None     => x
+          case Some(yv) => Some(f(xv, yv))
+        }
+    }
+
   /** Returns true if there is an element that is both in `fa` and `ga`. */
   def intersects[F[_]: UnorderedFoldable, G[_]: UnorderedFoldable, A: Eq](
       fa: F[A],

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -65,7 +65,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
         ),
         limit = Some(PosInt.unsafeFrom(4)),
         includeScala = Some(true),
-        fileExtensions = List(".txt")
+        fileExtensions = Some(List(".txt"))
       ),
       commits = CommitsConfig(
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -122,7 +122,7 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
     UpdatesConfig.mergeFileExtensions(Some(List("a")), Some(List("b"))) shouldBe Some(List())
   }
 
-  test("fileExtensions: non-set != empty") {
+  test("fileExtensionsOrDefault: non-set != empty") {
     UpdatesConfig(fileExtensions = None).fileExtensionsOrDefault shouldNot
       be(UpdatesConfig(fileExtensions = Some(Nil)).fileExtensionsOrDefault)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -121,4 +121,9 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
       Some(List("b"))
     UpdatesConfig.mergeFileExtensions(Some(List("a")), Some(List("b"))) shouldBe Some(List())
   }
+
+  test("fileExtensions: non-set != empty") {
+    UpdatesConfig(fileExtensions = None).fileExtensionsOrDefault shouldNot
+      be(UpdatesConfig(fileExtensions = Some(Nil)).fileExtensionsOrDefault)
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -33,7 +33,7 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
       ignore = List(aa0),
       limit = Some(PosInt(10)),
       includeScala = Some(false),
-      fileExtensions = List(".txt", ".scala", ".sbt")
+      fileExtensions = Some(List(".txt", ".scala", ".sbt"))
     )
     cfg |+| cfg shouldBe cfg
 
@@ -46,7 +46,7 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
       ignore = List(ab0),
       limit = Some(PosInt(20)),
       includeScala = Some(true),
-      fileExtensions = List(".sbt", ".scala")
+      fileExtensions = Some(List(".sbt", ".scala"))
     )
 
     cfg |+| cfg2 shouldBe UpdatesConfig(
@@ -55,7 +55,7 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
       ignore = List(aa0, ab0),
       limit = Some(PosInt(10)),
       includeScala = Some(false),
-      fileExtensions = List(".scala", ".sbt")
+      fileExtensions = Some(List(".scala", ".sbt"))
     )
 
     cfg2 |+| cfg shouldBe UpdatesConfig(
@@ -64,7 +64,7 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
       ignore = List(ab0, aa0),
       limit = Some(PosInt(20)),
       includeScala = Some(true),
-      fileExtensions = List(".sbt", ".scala")
+      fileExtensions = Some(List(".sbt", ".scala"))
     )
   }
 
@@ -112,14 +112,13 @@ class UpdatesConfigTest extends AnyFunSuite with Matchers {
   }
 
   test("mergeFileExtensions: basic checks") {
-    UpdatesConfig.mergeFileExtensions(Nil, Nil) shouldBe Nil
-    UpdatesConfig.mergeFileExtensions(Nil, List("txt")) shouldBe List("txt")
-    UpdatesConfig.mergeFileExtensions(List("txt"), Nil) shouldBe List("txt")
-    UpdatesConfig.mergeFileExtensions(List("txt"), List("txt")) shouldBe List("txt")
-    UpdatesConfig.mergeFileExtensions(List("a", "b", "c"), List("b", "d")) shouldBe List("b")
-    UpdatesConfig.mergeFileExtensions(
-      List("a"),
-      List("b")
-    ) shouldBe UpdatesConfig.nonExistingFileExtension
+    UpdatesConfig.mergeFileExtensions(None, None) shouldBe None
+    UpdatesConfig.mergeFileExtensions(None, Some(List("txt"))) shouldBe Some(List("txt"))
+    UpdatesConfig.mergeFileExtensions(Some(List("txt")), None) shouldBe Some(List("txt"))
+    UpdatesConfig.mergeFileExtensions(Some(List("txt")), Some(List("txt"))) shouldBe
+      Some(List("txt"))
+    UpdatesConfig.mergeFileExtensions(Some(List("a", "b", "c")), Some(List("b", "d"))) shouldBe
+      Some(List("b"))
+    UpdatesConfig.mergeFileExtensions(Some(List("a")), Some(List("b"))) shouldBe Some(List())
   }
 }


### PR DESCRIPTION
See https://github.com/scala-steward-org/scala-steward/pull/1488#pullrequestreview-434222425

The main purpose here is to get rid of `nonExistingFileExtension`.