### PR TITLE
Change findMigrations to allow finding pinned artifacts by a different artifact name

### DIFF
--- a/modules/core/src/test/resources/extra-artifact-migrations.conf
+++ b/modules/core/src/test/resources/extra-artifact-migrations.conf
@@ -1,0 +1,21 @@
+changes = [
+  {
+    groupIdAfter = org.typelevel
+    artifactIdBefore = fake-artifact-id
+    artifactIdAfter = kind-projector
+    initialVersion = 0.10.0
+  }
+  {
+    groupIdBefore = org.fake
+    groupIdAfter = org.typelevel
+    artifactIdBefore = fake-artifact-id
+    artifactIdAfter = kind-projector
+    initialVersion = 0.10.0
+  }
+  {
+    groupIdAfter = io.circe
+    artifactIdBefore = circe-refined
+    artifactIdAfter = different-circe-refined
+    initialVersion = 0.12.0
+  }
+]

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -29,8 +29,8 @@ import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
-object MockContext {
-  val config: Config =
+trait MockContext {
+  implicit def config: Config =
     Config.from(
       Cli.Args(
         workspace = File.temp / "ws",
@@ -51,41 +51,43 @@ object MockContext {
       )
     )
 
-  implicit val mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
-  implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
+  implicit def mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
+  implicit def mockEffParallel: Parallel[MockEff] = Parallel.identity
 
-  implicit val fileAlg: FileAlg[MockEff] = new MockFileAlg
-  implicit val mockLogger: Logger[MockEff] = new MockLogger
-  implicit val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
-  implicit val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
+  implicit def fileAlg: FileAlg[MockEff] = new MockFileAlg
+  implicit def mockLogger: Logger[MockEff] = new MockLogger
+  implicit def processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
+  implicit def workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
 
-  implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
-  implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
-  implicit val gitAlg: GitAlg[MockEff] = GitAlg.create(config)
-  implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
-  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config)
-  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
-  implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
+  implicit def coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
+  implicit def dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
+  implicit def gitAlg: GitAlg[MockEff] = GitAlg.create(config)
+  implicit def user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
+  implicit def vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config)
+  implicit def repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
+  implicit def scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
   val migrationsLoader: MigrationsLoader[MockEff] = new MigrationsLoader[MockEff]
-  implicit val migrationAlg: MigrationAlg = migrationsLoader
+  implicit def migrationAlg: MigrationAlg = migrationsLoader
     .loadAll(config.scalafixCfg)
     .map(new MigrationAlg(_))
     .runA(MigrationsLoaderTest.mockState)
     .unsafeRunSync()
-  implicit val cacheRepository: RepoCacheRepository[MockEff] =
+  implicit def cacheRepository: RepoCacheRepository[MockEff] =
     new RepoCacheRepository[MockEff](new JsonKeyValueStore("repo_cache", "1"))
-  implicit val filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
-  implicit val versionsCache: VersionsCache[MockEff] =
+  implicit def filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
+  implicit def versionsCache: VersionsCache[MockEff] =
     new VersionsCache[MockEff](config.cacheTtl, new JsonKeyValueStore("versions", "1"))
-  implicit val artifactMigrations: ArtifactMigrations =
+  implicit def artifactMigrations: ArtifactMigrations =
     ArtifactMigrations.create[MockEff](config).runA(MockState.empty).unsafeRunSync()
-  implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
-  implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create(config)
-  implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create(config)
-  implicit val millAlg: MillAlg[MockEff] = MillAlg.create
-  implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
-  implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
-  implicit val pullRequestRepository: PullRequestRepository[MockEff] =
+  implicit def updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
+  implicit def mavenAlg: MavenAlg[MockEff] = MavenAlg.create(config)
+  implicit def sbtAlg: SbtAlg[MockEff] = SbtAlg.create(config)
+  implicit def millAlg: MillAlg[MockEff] = MillAlg.create
+  implicit def buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
+  implicit def editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
+  implicit def pullRequestRepository: PullRequestRepository[MockEff] =
     new PullRequestRepository[MockEff](new JsonKeyValueStore("pull_requests", "2"))
-  implicit val pruningAlg: PruningAlg[MockEff] = new PruningAlg[MockEff]
+  implicit def pruningAlg: PruningAlg[MockEff] = new PruningAlg[MockEff]
 }
+
+object MockContext extends MockContext

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
@@ -1,7 +1,10 @@
 package org.scalasteward.core.update
 
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{ArtifactId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Resolver, Scope, Update}
+import org.scalasteward.core.mock.MockContext.updateAlg
+import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -21,5 +24,53 @@ class UpdateAlgTest extends AnyFunSuite with Matchers {
       Nel.of("0.12.3")
     )
     UpdateAlg.isUpdateFor(update, dependency) shouldBe true
+  }
+
+  test("findUpdates") {
+    val dependency = "io.circe" % ArtifactId("circe-refined", "circe-refined_2.12") % "0.11.2"
+    val updates: List[Update.Single] = updateAlg
+      .findUpdates(
+        dependencies = List(Scope(value = dependency, resolvers = List(Resolver.mavenCentral))),
+        repoConfig = RepoConfig.empty,
+        maxAge = None
+      )
+      .runA(
+        MockState.empty
+      )
+      .unsafeRunSync()
+    val newerVersions = updates.headOption
+      .map(_.newerVersions)
+      .getOrElse(Nel.one(""))
+    val update: Update.Single =
+      Update.Single(crossDependency = dependency, newerVersions = newerVersions)
+
+    updates.contains(update) shouldBe true
+  }
+
+  test("findUpdates returns additional artifact migration artifacts") {
+    val dependency = "io.circe" % ArtifactId("circe-refined", "circe-refined_2.12") % "0.11.2"
+    val artMigrationVersion = "0.12.0"
+    val updates: List[Update.Single] = ArtifactMigrationsTest.TestMockContext.updateAlg
+      .findUpdates(
+        dependencies = List(Scope(value = dependency, resolvers = List(Resolver.mavenCentral))),
+        repoConfig = RepoConfig.empty,
+        maxAge = None
+      )
+      .runA(MockState.empty)
+      .unsafeRunSync()
+    val newerVersions = updates.headOption
+      .map(_.newerVersions)
+      .getOrElse(Nel.one(""))
+    val update: Update.Single =
+      Update.Single(crossDependency = dependency, newerVersions = newerVersions)
+    val artMigrationUpdated: Update.Single = Update.Single(
+      crossDependency = dependency,
+      newerVersions = Nel.one(artMigrationVersion),
+      newerGroupId = Some(GroupId("io.circe")),
+      newerArtifactId = Some("different-circe-refined")
+    )
+
+    updates.contains(update) shouldBe true
+    updates.contains(artMigrationUpdated) shouldBe true
   }
 }


### PR DESCRIPTION
This PR changes `UpdateAlg.findUpdates` to consider artifact migration updates when there are additional versions available greater than the current version for the same artifact. So, for artifact
```
"com.test" %% "test-artifact" % "1.0.0"
```
with newer versions `"com.test" %% "test-artifact" % "1.1.0"` and `"com.test" %% "name-changed-test-artifact" % "2.0.0"` available, but a `.scala-steward.conf` with
```
updates.pin = [
   { groupId = "com.test", version = "2.0.0" }
]
```
and an `artifact-migrations.conf` with
```
changes = [
  {
    groupIdAfter = com.test
    artifactIdBefore = test-artifact
    artifactIdAfter = name-changed-test-artifact
    initialVersion = 2.0.0
  }
]
```
 the desired behavior is for scala-steward to update from `"com.test" %% "test-artifact" % "1.0.0"` -> `"com.test" %% "name-changed-test-artifact" % "2.0.0"`. However, the current behavior (before this PR) is that scala-steward doesn't get to the `.orElse(artifactMigrations.findUpdateWithRenamedArtifact(dependency.value))`, since it finds `"com.test" %% "test-artifact" % "1.1.0"`, which is later ignored due to the pinned version.