### PR TITLE
Pass environment variables as List to process.slurp

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -10,10 +10,10 @@ import scala.concurrent.duration._
 
 class processTest extends AnyFunSuite with Matchers {
   def slurp1(cmd: Nel[String]): IO[List[String]] =
-    process.slurp[IO](cmd, None, Map.empty, 1.minute, _ => IO.unit, blocker)
+    process.slurp[IO](cmd, None, List.empty, 1.minute, _ => IO.unit, blocker)
 
   def slurp2(cmd: Nel[String], timeout: FiniteDuration): IO[List[String]] =
-    process.slurp[IO](cmd, None, Map.empty, timeout, _ => IO.unit, blocker)
+    process.slurp[IO](cmd, None, List.empty, timeout, _ => IO.unit, blocker)
 
   test("echo hello") {
     slurp1(Nel.of("echo", "-n", "hello")).unsafeRunSync() shouldBe List("hello")


### PR DESCRIPTION
Using a `Map` there is unnecessary because we never look up the values
by key. This PR also unifies how commands are logged.