### PR TITLE
Allow passing environment variables to execSandboxed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -265,7 +265,6 @@ moduleRootPkg := rootPkg
 lazy val runSteward = taskKey[Unit]("")
 runSteward := Def.taskDyn {
   val home = System.getenv("HOME")
-  val myJavaHome = System.getenv("JAVA_HOME")
   val projectDir = (LocalRootProject / baseDirectory).value
   val args = Seq(
     Seq("--workspace", s"$projectDir/workspace"),
@@ -279,9 +278,7 @@ runSteward := Def.taskDyn {
     Seq("--whitelist", s"$home/.cache/mill"),
     Seq("--whitelist", s"$home/.ivy2"),
     Seq("--whitelist", s"$home/.mill"),
-    Seq("--whitelist", s"$home/.sbt"),
-    Seq("--whitelist", myJavaHome),
-    Seq("--read-only", myJavaHome)
+    Seq("--whitelist", s"$home/.sbt")
   ).flatten.mkString(" ", " ", "")
   (core.jvm / Compile / run).toTask(args)
 }.value

--- a/build.sbt
+++ b/build.sbt
@@ -277,6 +277,7 @@ runSteward := Def.taskDyn {
     Seq("--whitelist", s"$home/.cache/JNA"),
     Seq("--whitelist", s"$home/.cache/mill"),
     Seq("--whitelist", s"$home/.ivy2"),
+    Seq("--whitelist", s"$home/.m2"),
     Seq("--whitelist", s"$home/.mill"),
     Seq("--whitelist", s"$home/.sbt")
   ).flatten.mkString(" ", " ", "")

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -27,11 +27,11 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
         List("test", "-f", s"$repoDir/build.sc"),
         List("test", "-f", s"$repoDir/build.sbt"),
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "sbt",
           "-batch",
           "-no-colors",

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -21,21 +21,21 @@ class MavenAlgTest extends AnyFunSuite with Matchers {
       logs = Vector.empty,
       commands = Vector(
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "mvn",
           "--batch-mode",
           command.listDependencies
         ),
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "mvn",
           "--batch-mode",
           command.listRepositories

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -12,14 +12,24 @@ class MillAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("lihaoyi", "fastparse")
     val repoDir = config.workspace / repo.show
     val predef = s"$repoDir/scala-steward.sc"
-    val millCmd =
-      List("firejail", s"--whitelist=$repoDir", "mill", "-i", "-p", predef, "show", extractDeps)
+    val millCmd = List(
+      "firejail",
+      s"--whitelist=$repoDir",
+      "--env=VAR1=val1",
+      "--env=VAR2=val2",
+      "mill",
+      "-i",
+      "-p",
+      predef,
+      "show",
+      extractDeps
+    )
     val initial = MockState.empty.copy(commandOutputs = Map(millCmd -> List("""{"modules":[]}""")))
     val state = millAlg.getDependencies(repo).runS(initial).unsafeRunSync()
     state shouldBe initial.copy(
       commands = Vector(
         List("write", predef),
-        List("VAR1=val1", "VAR2=val2", repoDir.toString) ++ millCmd,
+        repoDir.toString :: millCmd,
         List("rm", "-rf", predef)
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -39,11 +39,11 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "sbt",
           "-batch",
           "-no-colors",
@@ -74,11 +74,11 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
         List("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
         List("write", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "sbt",
           "-batch",
           "-no-colors",
@@ -111,11 +111,11 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
         List("write", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         List("write", s"$repoDir/scala-steward-scalafix-options.sbt"),
         List(
-          "VAR1=val1",
-          "VAR2=val2",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
+          "--env=VAR1=val1",
+          "--env=VAR2=val2",
           "sbt",
           "-batch",
           "-no-colors",

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
@@ -1,23 +1,16 @@
 package org.scalasteward.core.io
 
-import better.files.File
 import org.scalasteward.core.application.Config.ProcessCfg
-import org.scalasteward.core.io.ProcessAlg.UsingFirejail
 import org.scalasteward.core.mock.{applyPure, MockEff}
-import org.scalasteward.core.util.Nel
 
-class MockProcessAlg(config: ProcessCfg) extends UsingFirejail[MockEff](config.sandboxCfg) {
-  private val envVars = config.envVars.map(v => (v.name, v.value))
-
-  override def exec(
-      command: Nel[String],
-      cwd: File,
-      extraEnv: (String, String)*
-  ): MockEff[List[String]] =
-    applyPure { s =>
-      (
-        s.exec(cwd.toString :: command.toList, extraEnv ++ envVars: _*),
-        s.commandOutputs.getOrElse(command.toList, List.empty)
-      )
+object MockProcessAlg {
+  def create(config: ProcessCfg): ProcessAlg[MockEff] =
+    ProcessAlg.fromExecImpl(config) { (command, cwd, extraEnv) =>
+      applyPure { s =>
+        (
+          s.exec(cwd.toString :: command.toList, extraEnv: _*),
+          s.commandOutputs.getOrElse(command.toList, List.empty)
+        )
+      }
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
@@ -5,12 +5,12 @@ import org.scalasteward.core.mock.{applyPure, MockEff}
 
 object MockProcessAlg {
   def create(config: ProcessCfg): ProcessAlg[MockEff] =
-    ProcessAlg.fromExecImpl(config) { (command, cwd, extraEnv) =>
+    ProcessAlg.fromExecImpl(config) { args =>
       applyPure { s =>
-        (
-          s.exec(cwd.toString :: command.toList, extraEnv: _*),
-          s.commandOutputs.getOrElse(command.toList, List.empty)
-        )
+        val cmd = args.workingDirectory.map(_.toString).toList ++ args.command.toList
+        val s1 = s.exec(cmd, args.extraEnv: _*)
+        val a = s.commandOutputs.getOrElse(args.command.toList, List.empty)
+        (s1, a)
       }
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -30,7 +30,8 @@ class ProcessAlgTest extends AnyFunSuite with Matchers {
 
   test("execSandboxed: echo with disableSandbox = true") {
     val cfg = ProcessCfg(Nil, Duration.Zero, SandboxCfg(Nil, Nil, disableSandbox = true))
-    val state = new MockProcessAlg(cfg)
+    val state = MockProcessAlg
+      .create(cfg)
       .execSandboxed(Nel.of("echo", "hello"), File.temp)
       .runS(MockState.empty)
       .unsafeRunSync()
@@ -44,7 +45,8 @@ class ProcessAlgTest extends AnyFunSuite with Matchers {
 
   test("execSandboxed: echo with disableSandbox = false") {
     val cfg = ProcessCfg(Nil, Duration.Zero, SandboxCfg(Nil, Nil, disableSandbox = false))
-    val state = new MockProcessAlg(cfg)
+    val state = MockProcessAlg
+      .create(cfg)
       .execSandboxed(Nel.of("echo", "hello"), File.temp)
       .runS(MockState.empty)
       .unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -3,17 +3,19 @@ package org.scalasteward.core.io
 import cats.effect.IO
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.io.ProcessAlgTest.blocker
+import org.scalasteward.core.io.process.Args
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
 import scala.concurrent.duration._
 
 class processTest extends AnyFunSuite with Matchers {
   def slurp1(cmd: Nel[String]): IO[List[String]] =
-    process.slurp[IO](cmd, None, List.empty, 1.minute, _ => IO.unit, blocker)
+    process.slurp[IO](Args(cmd), 1.minute, _ => IO.unit, blocker)
 
   def slurp2(cmd: Nel[String], timeout: FiniteDuration): IO[List[String]] =
-    process.slurp[IO](cmd, None, List.empty, timeout, _ => IO.unit, blocker)
+    process.slurp[IO](Args(cmd), timeout, _ => IO.unit, blocker)
 
   test("echo hello") {
     slurp1(Nel.of("echo", "-n", "hello")).unsafeRunSync() shouldBe List("hello")

--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -7,7 +7,6 @@ import org.scalasteward.core.io.process.Args
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-
 import scala.concurrent.duration._
 
 class processTest extends AnyFunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.mock
 import better.files.File
 import cats.Parallel
 import cats.effect.Sync
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.Uri
 import org.scalasteward.core.TestInstances.ioContextShift
 import org.scalasteward.core.application.Cli.EnvVar
@@ -14,7 +15,7 @@ import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.GitAlg
-import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
+import org.scalasteward.core.io._
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.persistence.JsonKeyValueStore
 import org.scalasteward.core.repocache.RepoCacheRepository
@@ -26,6 +27,7 @@ import org.scalasteward.core.util.uri._
 import org.scalasteward.core.util.{BracketThrow, DateTimeAlg}
 import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
+
 import scala.concurrent.duration._
 
 object MockContext {
@@ -52,10 +54,10 @@ object MockContext {
   implicit val mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
   implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
 
-  implicit val fileAlg: MockFileAlg = new MockFileAlg
-  implicit val mockLogger: MockLogger = new MockLogger
-  implicit val processAlg: MockProcessAlg = new MockProcessAlg(config.processCfg)
-  implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg
+  implicit val fileAlg: FileAlg[MockEff] = new MockFileAlg
+  implicit val mockLogger: Logger[MockEff] = new MockLogger
+  implicit val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
+  implicit val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
 
   implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
   implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -27,7 +27,6 @@ import org.scalasteward.core.util.uri._
 import org.scalasteward.core.util.{BracketThrow, DateTimeAlg}
 import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
-
 import scala.concurrent.duration._
 
 object MockContext {


### PR DESCRIPTION
This allows to pass extra environment variables to `execSandboxed` in
preparation for a fix for #1698. It also changes how environment
variables are used if firejail is enabled. All environment variables
(those from the config and those passed to `execSandboxed`) are
now passed via the `--env` parameter of the firejail command instead of
injecting them into the environment. This has been suggested earlier in
https://github.com/scala-steward-org/scala-steward/pull/337#discussion_r264052558 by @mwz.