### PR TITLE
Run sbt without -batch and -no-colors options

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -33,8 +33,6 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          "-batch",
-          "-no-colors",
           s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         List("read", s"$repoDir/project/build.properties"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -45,8 +45,6 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          "-batch",
-          "-no-colors",
           s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         List("read", s"$repoDir/project/build.properties")
@@ -80,8 +78,6 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          "-batch",
-          "-no-colors",
           s";$scalafixEnable;$scalafixAll github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
         List("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
@@ -117,8 +113,6 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          "-batch",
-          "-no-colors",
           s";$scalafixEnable;$scalafixAll github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"
         ),
         List("rm", "-rf", s"$repoDir/scala-steward-scalafix-options.sbt"),


### PR DESCRIPTION
This runs sbt without the `-batch` and `-no-colors` command line
options since not all launchers support them, see #1698.

I did some tests and everything works as before and I also didn't see
any colors or color escape sequences in the log output when the log
level is set to `TRACE`. Maybe these options were redundant the whole
time. Let's test this.

Closes #1698.