### PR TITLE
Do not put sbt in offline mode

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -79,8 +79,7 @@ object SbtAlg {
       override def getDependencies(repo: Repo): F[List[Scope.Dependencies]] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)
-          commands =
-            Nel.of(setOffline, crossStewardDependencies, reloadPlugins, stewardDependencies)
+          commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
           lines <- sbt(commands, repoDir)
           dependencies = parser.parseDependencies(lines)
           additionalDependencies <- getAdditionalDependencies(repo)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
@@ -17,7 +17,6 @@
 package org.scalasteward.core.buildtool.sbt
 
 object command {
-  val setOffline = "set offline := true"
   val stewardDependencies = "stewardDependencies"
   val crossStewardDependencies = s"+ $stewardDependencies"
   val reloadPlugins = "reload plugins"

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -33,7 +33,7 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         List("read", s"$repoDir/project/build.properties"),
         List("read", s"$repoDir/.scalafmt.conf")

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -45,7 +45,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "--env=VAR1=val1",
           "--env=VAR2=val2",
           "sbt",
-          s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         List("read", s"$repoDir/project/build.properties")
       )


### PR DESCRIPTION
Some builds cannot be loaded in offline mode because of missing
dependencies. They then fail with errors like this:
```
sbt.librarymanagement.ResolveException: unresolved dependency: com.github.gseitz#sbt-release;1.0.13: not found
```

Using `offline` was added in #1253 in an attempt to reduce traffic with
Maven Central. But it turned out that the policy of our version cache was
responsible for most of the traffic (#1259) so I'm fine with removing
this again now.