### PR TITLE
Close standard input of processes created by slurp

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
@@ -75,7 +75,10 @@ object process {
       if (args.clearEnv) env.clear()
       args.extraEnv.foreach { case (key, value) => env.put(key, value) }
       pb.redirectErrorStream(true)
-      pb.start()
+      val p = pb.start()
+      // Close standard input so that the process never waits for input.
+      p.getOutputStream.close()
+      p
     }
 
   private def readInputStream[F[_]](is: InputStream, blocker: Blocker)(implicit


### PR DESCRIPTION
This closes the standard input of processes created by `process.slurp`
so that these processes do not wait for user input. This emulates the
effect of sbt's `-batch` option which does the following:
```sh
  -batch|--batch) exec </dev/null && shift ;; #>
```
So `-batch` redirects `/dev/input` to sbt's stdin which effectively
closes it so that sbt never waits for user input. The `-batch` option
was removed in #1705.

This change is required for projects that fail to load and wait for
user input with:
```
[info] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```