### PR TITLE
Do not pass Config implicitly

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -32,8 +32,7 @@ import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.util.{BracketThrow, DateTimeAlg}
 import org.scalasteward.core.vcs.data.Repo
 
-final class StewardAlg[F[_]](implicit
-    config: Config,
+final class StewardAlg[F[_]](config: Config)(implicit
     dateTimeAlg: DateTimeAlg[F],
     fileAlg: FileAlg[F],
     gitAlg: GitAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -30,8 +30,7 @@ import org.scalasteward.core.vcs.data.Repo
 trait MavenAlg[F[_]] extends BuildToolAlg[F]
 
 object MavenAlg {
-  def create[F[_]](implicit
-      config: Config,
+  def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -43,8 +43,7 @@ trait SbtAlg[F[_]] extends BuildToolAlg[F] {
 }
 
 object SbtAlg {
-  def create[F[_]](implicit
-      config: Config,
+  def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
       logger: Logger[F],
       processAlg: ProcessAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -73,8 +73,7 @@ trait GitAlg[F[_]] {
 }
 
 object GitAlg {
-  def create[F[_]](implicit
-      config: Config,
+  def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -32,10 +32,9 @@ trait WorkspaceAlg[F[_]] {
 }
 
 object WorkspaceAlg {
-  def create[F[_]](implicit
+  def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
       logger: Logger[F],
-      config: Config,
       F: FlatMap[F]
   ): WorkspaceAlg[F] =
     new WorkspaceAlg[F] {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -39,8 +39,7 @@ import org.scalasteward.core.{git, util, vcs}
 
 import scala.util.control.NonFatal
 
-final class NurtureAlg[F[_]](implicit
-    config: Config,
+final class NurtureAlg[F[_]](config: Config)(implicit
     editAlg: EditAlg[F],
     repoConfigAlg: RepoConfigAlg[F],
     gitAlg: GitAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -29,9 +29,8 @@ import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 import scala.util.control.NoStackTrace
 
-final class RepoCacheAlg[F[_]](implicit
+final class RepoCacheAlg[F[_]](config: Config)(implicit
     buildToolDispatcher: BuildToolDispatcher[F],
-    config: Config,
     gitAlg: GitAlg[F],
     logger: Logger[F],
     parallel: Parallel[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -28,8 +28,7 @@ import org.scalasteward.core.repoconfig.RepoConfigAlg._
 import org.scalasteward.core.util.MonadThrow
 import org.scalasteward.core.vcs.data.Repo
 
-final class RepoConfigAlg[F[_]](implicit
-    config: Config,
+final class RepoConfigAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
     workspaceAlg: WorkspaceAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/update/ArtifactMigrations.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/ArtifactMigrations.scala
@@ -30,9 +30,9 @@ trait ArtifactMigrations {
 }
 
 object ArtifactMigrations {
-  def create[F[_]: MonadThrow](implicit
+  def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
-      config: Config
+      F: MonadThrow[F]
   ): F[ArtifactMigrations] = {
     val migrationSources = {
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
@@ -45,8 +45,7 @@ final class HttpExistenceClient[F[_]](statusCache: Cache[Status])(implicit
 }
 
 object HttpExistenceClient {
-  def create[F[_]](implicit
-      config: Config,
+  def create[F[_]](config: Config)(implicit
       client: Client[F],
       logger: Logger[F],
       F: Async[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -30,9 +30,8 @@ trait VCSExtraAlg[F[_]] {
 }
 
 object VCSExtraAlg {
-  def create[F[_]](implicit
+  def create[F[_]](config: Config)(implicit
       existenceClient: HttpExistenceClient[F],
-      config: Config,
       F: Monad[F]
   ): VCSExtraAlg[F] =
     new VCSExtraAlg[F] {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -32,7 +32,7 @@ trait VCSRepoAlg[F[_]] {
 }
 
 object VCSRepoAlg {
-  def create[F[_]: MonadThrow](config: Config, gitAlg: GitAlg[F]): VCSRepoAlg[F] =
+  def create[F[_]](config: Config)(implicit gitAlg: GitAlg[F], F: MonadThrow[F]): VCSRepoAlg[F] =
     new VCSRepoAlg[F] {
       override def clone(repo: Repo, repoOut: RepoOut): F[Unit] =
         for {
@@ -41,7 +41,7 @@ object VCSRepoAlg {
         } yield ()
 
       override def syncFork(repo: Repo, repoOut: RepoOut): F[Unit] =
-        if (config.doNotFork) ().pure[F]
+        if (config.doNotFork) F.unit
         else
           for {
             parent <- repoOut.parentOrRaise[F]

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -17,8 +17,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class GitAlgTest extends AnyFunSuite with Matchers {
-  implicit val workspaceAlg: WorkspaceAlg[IO] = WorkspaceAlg.create[IO]
-  implicit val ioGitAlg: GitAlg[IO] = GitAlg.create[IO]
+  implicit val workspaceAlg: WorkspaceAlg[IO] = WorkspaceAlg.create[IO](config)
+  implicit val ioGitAlg: GitAlg[IO] = GitAlg.create[IO](config)
 
   val repo: Repo = Repo("fthomas", "datapackage")
   val repoDir: String = (config.workspace / "fthomas/datapackage").toString

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -30,7 +30,7 @@ import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
 object MockContext {
-  implicit val config: Config =
+  val config: Config =
     Config.from(
       Cli.Args(
         workspace = File.temp / "ws",
@@ -61,10 +61,10 @@ object MockContext {
 
   implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
   implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
-  implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
+  implicit val gitAlg: GitAlg[MockEff] = GitAlg.create(config)
   implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
-  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config, gitAlg)
-  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
+  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config)
+  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
   val migrationsLoader: MigrationsLoader[MockEff] = new MigrationsLoader[MockEff]
   implicit val migrationAlg: MigrationAlg = migrationsLoader
@@ -78,10 +78,10 @@ object MockContext {
   implicit val versionsCache: VersionsCache[MockEff] =
     new VersionsCache[MockEff](config.cacheTtl, new JsonKeyValueStore("versions", "1"))
   implicit val artifactMigrations: ArtifactMigrations =
-    ArtifactMigrations.create[MockEff].runA(MockState.empty).unsafeRunSync()
+    ArtifactMigrations.create[MockEff](config).runA(MockState.empty).unsafeRunSync()
   implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
-  implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create
-  implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
+  implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create(config)
+  implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create(config)
   implicit val millAlg: MillAlg[MockEff] = MillAlg.create
   implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -7,7 +7,7 @@ import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.application.{Config, SupportedVCS}
+import org.scalasteward.core.application.SupportedVCS
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
 import org.scalasteward.core.mock.MockContext
 import org.scalasteward.core.util.{HttpExistenceClient, Nel}
@@ -22,17 +22,16 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
       case _                                                            => NotFound()
     }
 
-  implicit val cfg = MockContext.config
   implicit val client = Client.fromHttpApp[IO](routes.orNotFound)
   implicit val httpExistenceClient =
-    HttpExistenceClient.create[IO].allocated.map(_._1).unsafeRunSync()
+    HttpExistenceClient.create[IO](MockContext.config).allocated.map(_._1).unsafeRunSync()
 
   val updateFoo = Update.Single("com.example" % "foo" % "0.1.0", Nel.of("0.2.0"))
   val updateBar = Update.Single("com.example" % "bar" % "0.1.0", Nel.of("0.2.0"))
   val updateBuz = Update.Single("com.example" % "buz" % "0.1.0", Nel.of("0.2.0"))
 
   test("getBranchCompareUrl: std vsc") {
-    val vcsExtraAlg = VCSExtraAlg.create[IO]
+    val vcsExtraAlg = VCSExtraAlg.create[IO](MockContext.config)
 
     vcsExtraAlg
       .getReleaseRelatedUrls(uri"https://github.com/foo/foo", updateFoo)
@@ -50,11 +49,11 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("getBranchCompareUrl: github on prem") {
-    implicit val cfg: Config = MockContext.config.copy(
+    val config = MockContext.config.copy(
       vcsType = SupportedVCS.GitHub,
       vcsApiHost = uri"https://github.on-prem.com/"
     )
-    val githubOnPremVcsExtraAlg = VCSExtraAlg.create[IO]
+    val githubOnPremVcsExtraAlg = VCSExtraAlg.create[IO](config)
 
     githubOnPremVcsExtraAlg
       .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/foo", updateFoo)
@@ -79,7 +78,7 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
   )
   validExtractPRTestCases.foreach { case (vcs, uri) =>
     test(s"valid - extractPRIdFromUrls for ${vcs.asString}") {
-      val vcsExtraAlg = VCSExtraAlg.create[IO]
+      val vcsExtraAlg = VCSExtraAlg.create[IO](MockContext.config)
       vcsExtraAlg.extractPRIdFromUrls(vcs, uri) shouldBe Some(13)
     }
   }
@@ -92,7 +91,7 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
   )
   invalidExtractPRTestCases.foreach { case (vcs, uri) =>
     test(s"invalid - extractPRIdFromUrls for ${vcs.asString}") {
-      val vcsExtraAlg = VCSExtraAlg.create[IO]
+      val vcsExtraAlg = VCSExtraAlg.create[IO](MockContext.config)
       vcsExtraAlg.extractPRIdFromUrls(vcs, uri) shouldBe None
     }
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -80,7 +80,7 @@ class VCSRepoAlgTest extends AnyFunSuite with Matchers {
   test("syncFork should do nothing when doNotFork = true") {
     val config = MockContext.config.copy(doNotFork = true)
     val state = VCSRepoAlg
-      .create(config, gitAlg)
+      .create(config)
       .syncFork(repo, parentRepoOut)
       .runS(MockState.empty)
       .unsafeRunSync()


### PR DESCRIPTION
This unifies how `Config` is passed to all other classes. Before this
change there was a mix of passing it explicitly and implicitly. It is
now always passed explicitly. I think we should converge to only pass
type classes and DSLs implicitly.