### PR TITLE
Remove http4s packag/prefix from VCSApiAlg implementations

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -83,7 +83,7 @@ example1.realm=Example Realm
 
 ### Running locally from sbt
 
-#### Sample run for Gitlab
+#### Sample run for GitLab
 
 ```
 sbt
@@ -130,14 +130,14 @@ docker run -v $PWD:/opt/scala-steward \
 There is an article on how they run Scala Steward on-premise at Avast:
 * [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)
 
-#### Gitlab
+#### GitLab
 
-The following describes a setup using Gitlab Docker runner, which you have to setup seperately.
+The following describes a setup using GitLab Docker runner, which you have to setup seperately.
 
-1. create a "scalasteward" user in Gitlab
+1. create a "scalasteward" user in GitLab
 2. assign that user "Developer" permissions in every project that should be managed by Scala Steward
 3. login as that user and create a Personal Access Token with `api`, `read_repository` and `write_repository` scopes
-4. create a project and add the following Gitlab CI config
+4. create a project and add the following GitLab CI config
 
 ```yaml
 check:

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SupportedVCS.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SupportedVCS.scala
@@ -25,7 +25,7 @@ sealed trait SupportedVCS {
     case Bitbucket       => "bitbucket"
     case BitbucketServer => "bitbucket-server"
     case GitHub          => "github"
-    case Gitlab          => "gitlab"
+    case GitLab          => "gitlab"
   }
 }
 
@@ -33,9 +33,9 @@ object SupportedVCS {
   case object Bitbucket extends SupportedVCS
   case object BitbucketServer extends SupportedVCS
   case object GitHub extends SupportedVCS
-  case object Gitlab extends SupportedVCS
+  case object GitLab extends SupportedVCS
 
-  val all = List(Bitbucket, BitbucketServer, GitHub, Gitlab)
+  val all = List(Bitbucket, BitbucketServer, GitHub, GitLab)
 
   def parse(s: String): Either[String, SupportedVCS] =
     all.find(_.asString === s) match {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -36,7 +36,6 @@ import org.scalasteward.core.util.{BracketThrow, HttpExistenceClient}
 import org.scalasteward.core.vcs.data.{NewPullRequestData, PullRequestState, Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg}
 import org.scalasteward.core.{git, util, vcs}
-
 import scala.util.control.NonFatal
 
 final class NurtureAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -20,10 +20,9 @@ import cats.effect.Sync
 import cats.syntax.all._
 import io.circe.{Decoder, Encoder}
 import org.http4s.Method.{GET, PATCH, POST, PUT}
+import org.http4s._
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.Client
-import org.http4s._
-
 import scala.util.control.NoStackTrace
 
 final class HttpJsonClient[F[_]: Sync](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -54,7 +54,7 @@ object VCSExtraAlg {
             extractIntAfter(uri.path, "pull")
           case SupportedVCS.Bitbucket | SupportedVCS.BitbucketServer =>
             extractIntAfter(uri.path, "pullrequests")
-          case SupportedVCS.Gitlab =>
+          case SupportedVCS.GitLab =>
             extractIntAfter(uri.path, "merge_requests")
         }
       }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -20,11 +20,11 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, Gitlab}
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow}
-import org.scalasteward.core.vcs.bitbucket.http4s.Http4sBitbucketApiAlg
-import org.scalasteward.core.vcs.bitbucketserver.http4s.Http4sBitbucketServerApiAlg
+import org.scalasteward.core.vcs.bitbucket.BitbucketApiAlg
+import org.scalasteward.core.vcs.bitbucketserver.BitbucketServerApiAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
-import org.scalasteward.core.vcs.github.http4s.Http4sGitHubApiAlg
-import org.scalasteward.core.vcs.gitlab.http4s.Http4sGitLabApiAlg
+import org.scalasteward.core.vcs.github.GitHubApiAlg
+import org.scalasteward.core.vcs.gitlab.GitLabApiAlg
 
 final class VCSSelection[F[_]](implicit
     client: HttpJsonClient[F],
@@ -32,15 +32,15 @@ final class VCSSelection[F[_]](implicit
     logger: Logger[F],
     F: MonadThrow[F]
 ) {
-  private def github(config: Config): Http4sGitHubApiAlg[F] = {
-    import org.scalasteward.core.vcs.github.http4s.authentication.addCredentials
+  private def github(config: Config): GitHubApiAlg[F] = {
+    import org.scalasteward.core.vcs.github.authentication.addCredentials
 
-    new Http4sGitHubApiAlg[F](config.vcsApiHost, _ => addCredentials(user))
+    new GitHubApiAlg[F](config.vcsApiHost, _ => addCredentials(user))
   }
 
-  private def gitlab(config: Config): Http4sGitLabApiAlg[F] = {
-    import org.scalasteward.core.vcs.gitlab.http4s.authentication.addCredentials
-    new Http4sGitLabApiAlg[F](
+  private def gitlab(config: Config): GitLabApiAlg[F] = {
+    import org.scalasteward.core.vcs.gitlab.authentication.addCredentials
+    new GitLabApiAlg[F](
       config.vcsApiHost,
       user,
       _ => addCredentials(user),
@@ -49,16 +49,16 @@ final class VCSSelection[F[_]](implicit
     )
   }
 
-  private def bitbucket(config: Config): Http4sBitbucketApiAlg[F] = {
-    import org.scalasteward.core.vcs.bitbucket.http4s.authentication.addCredentials
+  private def bitbucket(config: Config): BitbucketApiAlg[F] = {
+    import org.scalasteward.core.vcs.bitbucket.authentication.addCredentials
 
-    new Http4sBitbucketApiAlg(config.vcsApiHost, user, _ => addCredentials(user), config.doNotFork)
+    new BitbucketApiAlg(config.vcsApiHost, user, _ => addCredentials(user), config.doNotFork)
   }
 
-  private def bitbucketServer(config: Config): Http4sBitbucketServerApiAlg[F] = {
-    import org.scalasteward.core.vcs.bitbucket.http4s.authentication.addCredentials
+  private def bitbucketServer(config: Config): BitbucketServerApiAlg[F] = {
+    import org.scalasteward.core.vcs.bitbucket.authentication.addCredentials
 
-    new Http4sBitbucketServerApiAlg[F](
+    new BitbucketServerApiAlg[F](
       config.vcsApiHost,
       _ => addCredentials(user),
       config.bitbucketServerUseDefaultReviewers

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.vcs
 
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, Gitlab}
+import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, GitLab}
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow}
 import org.scalasteward.core.vcs.bitbucket.BitbucketApiAlg
 import org.scalasteward.core.vcs.bitbucketserver.BitbucketServerApiAlg
@@ -68,7 +68,7 @@ final class VCSSelection[F[_]](implicit
   def getAlg(config: Config): VCSApiAlg[F] =
     config.vcsType match {
       case GitHub          => github(config)
-      case Gitlab          => gitlab(config)
+      case GitLab          => gitlab(config)
       case Bitbucket       => bitbucket(config)
       case BitbucketServer => bitbucketServer(config)
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import cats.syntax.all._
 import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow, UnexpectedResponse}
 import org.scalasteward.core.vcs.VCSApiAlg
-import org.scalasteward.core.vcs.bitbucket.Url
-import org.scalasteward.core.vcs.bitbucket.http4s.json._
+import org.scalasteward.core.vcs.bitbucket.json._
 import org.scalasteward.core.vcs.data._
 
-class Http4sBitbucketApiAlg[F[_]](
+class BitbucketApiAlg[F[_]](
     bitbucketApiHost: Uri,
     user: AuthenticatedUser,
     modify: Repo => Request[F] => F[Request[F]],

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreatePullRequestRequest.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreatePullRequestRequest.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import io.circe.{Encoder, Json}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.vcs.data.Repo
 
-private[http4s] case class CreatePullRequestRequest(
+private[bitbucket] case class CreatePullRequestRequest(
     title: String,
     sourceBranch: Branch,
     sourceRepo: Repo,
@@ -28,7 +28,7 @@ private[http4s] case class CreatePullRequestRequest(
     description: String
 )
 
-private[http4s] object CreatePullRequestRequest {
+private[bitbucket] object CreatePullRequestRequest {
   implicit val encoder: Encoder[CreatePullRequestRequest] = Encoder.instance { d =>
     Json.obj(
       ("title", Json.fromString(d.title)),

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Page.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Page.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
-import cats.Applicative
-import cats.syntax.all._
-import org.http4s.headers.Authorization
-import org.http4s.{BasicCredentials, Request}
-import org.scalasteward.core.vcs.data.AuthenticatedUser
+import io.circe.Decoder
 
-object authentication {
-  def addCredentials[F[_]: Applicative](user: AuthenticatedUser): Request[F] => F[Request[F]] =
-    _.putHeaders(Authorization(BasicCredentials(user.login, user.accessToken))).pure[F]
+final private[bitbucket] case class Page[A](values: List[A])
+
+private[bitbucket] object Page {
+  implicit def pageDecoder[A: Decoder]: Decoder[Page[A]] =
+    Decoder.instance { c =>
+      c.downField("values").as[List[A]].map(Page(_))
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/RepositoryResponse.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/RepositoryResponse.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import cats.syntax.all._
 import io.circe.{ACursor, Decoder, DecodingFailure, Json}
@@ -24,7 +24,7 @@ import org.scalasteward.core.util.uri._
 import org.scalasteward.core.vcs.data.{Repo, UserOut}
 import scala.annotation.tailrec
 
-final private[http4s] case class RepositoryResponse(
+final private[bitbucket] case class RepositoryResponse(
     name: String,
     mainBranch: Branch,
     owner: UserOut,
@@ -32,7 +32,7 @@ final private[http4s] case class RepositoryResponse(
     parent: Option[Repo]
 )
 
-private[http4s] object RepositoryResponse {
+private[bitbucket] object RepositoryResponse {
   implicit private val repoDecoder: Decoder[Repo] = Decoder.instance { c =>
     c.as[String].map(_.split('/')).flatMap { parts =>
       parts match {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/authentication.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/authentication.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
-import io.circe.Decoder
+import cats.Applicative
+import cats.syntax.all._
+import org.http4s.headers.Authorization
+import org.http4s.{BasicCredentials, Request}
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 
-final private[http4s] case class Page[A](values: List[A])
-
-private[http4s] object Page {
-  implicit def pageDecoder[A: Decoder]: Decoder[Page[A]] =
-    Decoder.instance { c =>
-      c.downField("values").as[List[A]].map(Page(_))
-    }
+object authentication {
+  def addCredentials[F[_]: Applicative](user: AuthenticatedUser): Request[F] => F[Request[F]] =
+    _.putHeaders(Authorization(BasicCredentials(user.login, user.accessToken))).pure[F]
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import io.circe.Decoder
 import org.http4s.Uri
@@ -22,7 +22,7 @@ import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.vcs.data.{BranchOut, CommitOut, PullRequestOut, PullRequestState}
 
-private[http4s] object json {
+private[bitbucket] object json {
   implicit val branchOutDecoder: Decoder[BranchOut] = Decoder.instance { c =>
     for {
       branch <- c.downField("name").as[Branch]

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucketserver.http4s
+package org.scalasteward.core.vcs.bitbucketserver
 
 import cats.syntax.all._
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow}
 import org.scalasteward.core.vcs.VCSApiAlg
-import org.scalasteward.core.vcs.bitbucketserver.http4s.Json.{Reviewer, User}
+import Json.{Reviewer, User}
 import org.scalasteward.core.vcs.data.PullRequestState.Open
 import org.scalasteward.core.vcs.data._
 
-/** https://docs.atlassian.com/bitbucket-server/rest/6.6.1/bitbucket-rest.html
-  */
-class Http4sBitbucketServerApiAlg[F[_]](
+/** https://docs.atlassian.com/bitbucket-server/rest/6.6.1/bitbucket-rest.html */
+class BitbucketServerApiAlg[F[_]](
     bitbucketApiHost: Uri,
     modify: Repo => Request[F] => F[Request[F]],
     useReviewers: Boolean

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -21,7 +21,7 @@ import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow}
 import org.scalasteward.core.vcs.VCSApiAlg
-import Json.{Reviewer, User}
+import org.scalasteward.core.vcs.bitbucketserver.Json.{Reviewer, User}
 import org.scalasteward.core.vcs.data.PullRequestState.Open
 import org.scalasteward.core.vcs.data._
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.bitbucketserver.http4s
+package org.scalasteward.core.vcs.bitbucketserver
 
 import cats.data.NonEmptyList
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.github.http4s
+package org.scalasteward.core.vcs.github
 
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data._
-import org.scalasteward.core.vcs.github._
 
-final class Http4sGitHubApiAlg[F[_]](
+final class GitHubApiAlg[F[_]](
     gitHubApiHost: Uri,
     modify: Repo => Request[F] => F[Request[F]]
 )(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/authentication.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/authentication.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.github.http4s
+package org.scalasteward.core.vcs.github
 
 import cats.Applicative
 import cats.syntax.all._

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.gitlab.http4s
+package org.scalasteward.core.vcs.gitlab
 
 import cats.syntax.all._
 import io.chrisdavenport.log4cats.Logger
@@ -27,10 +27,9 @@ import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.util.{HttpJsonClient, MonadThrow, UnexpectedResponse}
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data._
-import org.scalasteward.core.vcs.gitlab._
 
-final private[http4s] case class ForkPayload(id: String, namespace: String)
-final private[http4s] case class MergeRequestPayload(
+final private[gitlab] case class ForkPayload(id: String, namespace: String)
+final private[gitlab] case class MergeRequestPayload(
     id: String,
     title: String,
     description: String,
@@ -39,12 +38,12 @@ final private[http4s] case class MergeRequestPayload(
     target_branch: Branch
 )
 
-private[http4s] object MergeRequestPayload {
+private[gitlab] object MergeRequestPayload {
   def apply(id: String, projectId: Long, data: NewPullRequestData): MergeRequestPayload =
     MergeRequestPayload(id, data.title, data.body, projectId, data.head, data.base)
 }
 
-final private[http4s] case class MergeRequestOut(
+final private[gitlab] case class MergeRequestOut(
     webUrl: Uri,
     state: PullRequestState,
     title: String,
@@ -54,18 +53,18 @@ final private[http4s] case class MergeRequestOut(
   val pullRequestOut: PullRequestOut = PullRequestOut(webUrl, state, title)
 }
 
-final private[http4s] case class CommitId(id: Sha1) {
+final private[gitlab] case class CommitId(id: Sha1) {
   val commitOut: CommitOut = CommitOut(id)
 }
-final private[http4s] case class ProjectId(id: Long)
+final private[gitlab] case class ProjectId(id: Long)
 
-private[http4s] object GitlabMergeStatus {
+private[gitlab] object GitlabMergeStatus {
   val CanBeMerged = "can_be_merged"
   val CannotBeMerged = "cannot_be_merged"
   val Checking = "checking"
 }
 
-private[http4s] object GitlabJsonCodec {
+private[gitlab] object GitlabJsonCodec {
   // prevent IntelliJ from removing the import of uriDecoder
   locally(uriDecoder)
 
@@ -117,7 +116,7 @@ private[http4s] object GitlabJsonCodec {
   implicit val branchOutDecoder: Decoder[BranchOut] = deriveDecoder[BranchOut]
 }
 
-class Http4sGitLabApiAlg[F[_]](
+class GitLabApiAlg[F[_]](
     gitlabApiHost: Uri,
     user: AuthenticatedUser,
     modify: Repo => Request[F] => F[Request[F]],

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -58,13 +58,13 @@ final private[gitlab] case class CommitId(id: Sha1) {
 }
 final private[gitlab] case class ProjectId(id: Long)
 
-private[gitlab] object GitlabMergeStatus {
+private[gitlab] object GitLabMergeStatus {
   val CanBeMerged = "can_be_merged"
   val CannotBeMerged = "cannot_be_merged"
   val Checking = "checking"
 }
 
-private[gitlab] object GitlabJsonCodec {
+private[gitlab] object GitLabJsonCodec {
   // prevent IntelliJ from removing the import of uriDecoder
   locally(uriDecoder)
 
@@ -127,7 +127,7 @@ class GitLabApiAlg[F[_]](
     logger: Logger[F],
     F: MonadThrow[F]
 ) extends VCSApiAlg[F] {
-  import GitlabJsonCodec._
+  import GitLabJsonCodec._
 
   val url = new Url(gitlabApiHost)
 
@@ -163,7 +163,7 @@ class GitLabApiAlg[F[_]](
       client
         .get[MergeRequestOut](url.existingMergeRequest(repo, internalId), modify(repo))
         .flatMap {
-          case mr if (mr.mergeStatus =!= GitlabMergeStatus.Checking) => F.pure(mr)
+          case mr if (mr.mergeStatus =!= GitLabMergeStatus.Checking) => F.pure(mr)
           case _ if (retries > 0)                                    => waitForMergeRequestStatus(internalId, retries - 1)
           case other                                                 => F.pure(other)
         }
@@ -175,7 +175,7 @@ class GitLabApiAlg[F[_]](
         mergeRequest
           .flatMap(mr => waitForMergeRequestStatus(mr.iid))
           .flatMap {
-            case mr if (mr.mergeStatus === GitlabMergeStatus.CanBeMerged) =>
+            case mr if (mr.mergeStatus === GitLabMergeStatus.CanBeMerged) =>
               for {
                 _ <- logger.info(s"Setting ${mr.webUrl} to merge when pipeline succeeds")
                 res <-

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/authentication.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/authentication.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.gitlab.http4s
+package org.scalasteward.core.vcs.gitlab
 
 import cats.Applicative
 import cats.syntax.all._

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core
 import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.application.SupportedVCS
-import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, Gitlab}
+import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, GitLab}
 import org.scalasteward.core.data.ReleaseRelatedUrl.VersionDiff
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
 import org.scalasteward.core.vcs.data.Repo
@@ -34,7 +34,7 @@ package object vcs {
       case GitHub =>
         s"${fork.show}:${git.branchFor(update).name}"
 
-      case Gitlab | Bitbucket | BitbucketServer =>
+      case GitLab | Bitbucket | BitbucketServer =>
         git.branchFor(update).name
     }
 
@@ -46,7 +46,7 @@ package object vcs {
       case GitHub =>
         s"${fork.owner}:${git.branchFor(update).name}"
 
-      case Gitlab | Bitbucket | BitbucketServer =>
+      case GitLab | Bitbucket | BitbucketServer =>
         git.branchFor(update).name
     }
 
@@ -85,7 +85,7 @@ package object vcs {
       host
         .collect {
           case "github.com" => GitHub
-          case "gitlab.com" => Gitlab
+          case "gitlab.com" => GitLab
         }
         .orElse {
           if (host.contains_("bitbucket.org"))
@@ -105,7 +105,7 @@ package object vcs {
 
     extractRepoVCSType(vcsType, vcsUri, repoUrl)
       .map {
-        case GitHub | Gitlab =>
+        case GitHub | GitLab =>
           possibleTags(from).zip(possibleTags(to)).map { case (from1, to1) =>
             VersionDiff(repoUrl / "compare" / s"$from1...$to1")
           }
@@ -135,7 +135,7 @@ package object vcs {
 
     def files(fileNames: List[String]): List[Uri] = {
       val maybeSegments = repoVCSType.map {
-        case SupportedVCS.GitHub | SupportedVCS.Gitlab             => List("blob", "master")
+        case SupportedVCS.GitHub | SupportedVCS.GitLab             => List("blob", "master")
         case SupportedVCS.Bitbucket | SupportedVCS.BitbucketServer => List("master")
       }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -32,7 +32,7 @@ class CliTest extends AnyFunSuite with Matchers with EitherValues {
         reposFile = File("b"),
         defaultRepoConf = Some(File("c")),
         gitAuthorEmail = "d",
-        vcsType = SupportedVCS.Gitlab,
+        vcsType = SupportedVCS.GitLab,
         vcsApiHost = uri"http://example.com",
         vcsLogin = "e",
         gitAskPass = File("f"),

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -74,7 +74,7 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
     SupportedVCS.Bitbucket -> uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/13",
     SupportedVCS.BitbucketServer -> uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/13",
     SupportedVCS.GitHub -> uri"https://github.com/scala-steward-org/scala-steward/pull/13",
-    SupportedVCS.Gitlab -> uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/13"
+    SupportedVCS.GitLab -> uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/13"
   )
   validExtractPRTestCases.foreach { case (vcs, uri) =>
     test(s"valid - extractPRIdFromUrls for ${vcs.asString}") {
@@ -87,7 +87,7 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
     SupportedVCS.Bitbucket -> uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/",
     SupportedVCS.BitbucketServer -> uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/",
     SupportedVCS.GitHub -> uri"https://github.com/scala-steward-org/scala-steward/pull/",
-    SupportedVCS.Gitlab -> uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/"
+    SupportedVCS.GitLab -> uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/"
   )
   invalidExtractPRTestCases.foreach { case (vcs, uri) =>
     test(s"invalid - extractPRIdFromUrls for ${vcs.asString}") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.vcs
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.SupportedVCS
-import org.scalasteward.core.application.SupportedVCS.{GitHub, Gitlab}
+import org.scalasteward.core.application.SupportedVCS.{GitHub, GitLab}
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
@@ -17,12 +17,12 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
 
   test("listingBranch") {
     listingBranch(GitHub, repo, update) shouldBe "foo/bar:update/logback-classic-1.2.3"
-    listingBranch(Gitlab, repo, update) shouldBe "update/logback-classic-1.2.3"
+    listingBranch(GitLab, repo, update) shouldBe "update/logback-classic-1.2.3"
   }
 
   test("createBranch") {
     createBranch(GitHub, repo, update) shouldBe "foo:update/logback-classic-1.2.3"
-    createBranch(Gitlab, repo, update) shouldBe "update/logback-classic-1.2.3"
+    createBranch(GitLab, repo, update) shouldBe "update/logback-classic-1.2.3"
   }
 
   test("possibleCompareUrls") {
@@ -136,7 +136,7 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
 
   test("possibleChangelogUrls: on-prem gitlab") {
     possibleReleaseRelatedUrls(
-      SupportedVCS.Gitlab,
+      SupportedVCS.GitLab,
       uri"https://gitlab.on-prem.net",
       uri"https://gitlab.on-prem.net/foo/bar",
       update

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import cats.effect.IO
 import io.circe.literal._
@@ -15,7 +15,7 @@ import org.scalasteward.core.vcs.data._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class Http4sBitbucketApiAlgTest extends AnyFunSuite with Matchers {
+class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
   private val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "repositories" / "fthomas" / "base.g8" =>
       Ok(
@@ -139,7 +139,7 @@ class Http4sBitbucketApiAlgTest extends AnyFunSuite with Matchers {
 
   implicit val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
   implicit val httpJsonClient: HttpJsonClient[IO] = new HttpJsonClient[IO]
-  val bitbucketApiAlg = new Http4sBitbucketApiAlg[IO](
+  val bitbucketApiAlg = new BitbucketApiAlg[IO](
     config.vcsApiHost,
     AuthenticatedUser("scala-steward", ""),
     _ => IO.pure,

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/JsonCodecTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.vcs.bitbucket.http4s
+package org.scalasteward.core.vcs.bitbucket
 
 import io.circe.Json
 import org.scalasteward.core.vcs.data.PullRequestState

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.vcs.github.http4s
+package org.scalasteward.core.vcs.github
 
 import cats.effect.IO
 import io.circe.literal._
@@ -15,7 +15,7 @@ import org.scalasteward.core.vcs.data._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class Http4sGitHubApiAlgTest extends AnyFunSuite with Matchers {
+class GitHubApiAlgTest extends AnyFunSuite with Matchers {
   val routes: HttpRoutes[IO] =
     HttpRoutes.of[IO] {
       case GET -> Root / "repos" / "fthomas" / "base.g8" =>
@@ -77,7 +77,7 @@ class Http4sGitHubApiAlgTest extends AnyFunSuite with Matchers {
 
   implicit val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
   implicit val httpJsonClient: HttpJsonClient[IO] = new HttpJsonClient[IO]
-  val gitHubApiAlg = new Http4sGitHubApiAlg[IO](config.vcsApiHost, _ => IO.pure)
+  val gitHubApiAlg = new GitHubApiAlg[IO](config.vcsApiHost, _ => IO.pure)
 
   val repo = Repo("fthomas", "base.g8")
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/authenticationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/authenticationTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.vcs.github.http4s
+package org.scalasteward.core.vcs.github
 
 import cats.Id
 import org.http4s.headers.{Accept, Authorization}

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -1,12 +1,15 @@
-package org.scalasteward.core.vcs.gitlab.http4s
+package org.scalasteward.core.vcs.gitlab
 
 import cats.effect.IO
+import cats.implicits._
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.literal._
 import io.circe.parser._
 import org.http4s.HttpRoutes
 import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.dsl.io._
+import org.http4s.headers.Allow
 import org.http4s.implicits._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update
@@ -18,12 +21,9 @@ import org.scalasteward.core.util.{HttpJsonClient, Nel}
 import org.scalasteward.core.vcs.data._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import org.http4s.headers.Allow
-import cats.implicits._
 
-class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
-  import GitlabJsonCodec._
+class GitLabApiAlgTest extends AnyFunSuite with Matchers {
+  import org.scalasteward.core.vcs.gitlab.GitlabJsonCodec._
 
   object MergeWhenPipelineSucceedsMatcher
       extends QueryParamDecoderMatcher[Boolean]("merge_when_pipeline_succeeds")
@@ -74,7 +74,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
   implicit val httpJsonClient: HttpJsonClient[IO] = new HttpJsonClient[IO]
   implicit val logger = Slf4jLogger.getLogger[IO]
   val gitlabApiAlg =
-    new Http4sGitLabApiAlg[IO](
+    new GitLabApiAlg[IO](
       config.vcsApiHost,
       user,
       _ => IO.pure,
@@ -109,7 +109,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
 
   test("createPullRequest -- no fork") {
     val gitlabApiAlgNoFork =
-      new Http4sGitLabApiAlg[IO](
+      new GitLabApiAlg[IO](
         config.vcsApiHost,
         user,
         _ => IO.pure,
@@ -147,7 +147,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
 
   test("createPullRequest -- auto merge") {
     val gitlabApiAlgNoFork =
-      new Http4sGitLabApiAlg[IO](
+      new GitLabApiAlg[IO](
         config.vcsApiHost,
         user,
         _ => IO.pure,
@@ -180,7 +180,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
       new HttpJsonClient[IO]()(implicitly, errorClient)
 
     val gitlabApiAlgNoFork =
-      new Http4sGitLabApiAlg[IO](
+      new GitLabApiAlg[IO](
         config.vcsApiHost,
         user,
         _ => IO.pure,

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -23,7 +23,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class GitLabApiAlgTest extends AnyFunSuite with Matchers {
-  import org.scalasteward.core.vcs.gitlab.GitlabJsonCodec._
+  import org.scalasteward.core.vcs.gitlab.GitLabJsonCodec._
 
   object MergeWhenPipelineSucceedsMatcher
       extends QueryParamDecoderMatcher[Boolean]("merge_when_pipeline_succeeds")


### PR DESCRIPTION
This removes the `http4s` package and `Http4s` prefix from `VCSApiAlg`
implementations. These are now unnecessary remnants from the time when
we only supported GitHub and `VCSApiAlg` was called `GitHubApiAlg`.