### PR TITLE
Do not use gpg2 with sbt-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,8 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - uses: olafurpg/setup-gpg@v2
+
       - name: Publish JARs
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ val Scala213 = "2.13.3"
 
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala213)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
+ThisBuild / githubWorkflowPublishPreamble +=
+  WorkflowStep.Use("olafurpg", "setup-gpg", "v2")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(
   RefPredicate.Equals(Ref.Branch("master")),
   RefPredicate.StartsWith(Ref.Tag("v"))


### PR DESCRIPTION
While trying to release 0.8.0, I hit an issue with gpg2:
```
Running ci-release.
  branch=refs/tags/v0.8.0
gpg (GnuPG) 2.2.4
libgcrypt 1.8.1
...
gpg: key 96BDF10FFAB8B6A6/96BDF10FFAB8B6A6: error sending to agent: Inappropriate ioctl for device
gpg: error building skey array: Inappropriate ioctl for device
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
...
[error] gpg: no default secret key: No secret key
[error] gpg: signing failed: No secret key
[error] java.lang.RuntimeException: Failure running 'gpg --batch --passphrase *** --detach-sign --armor --use-agent --output /home/runner/work/scala-steward/scala-steward/modules/mill-plugin/.jvm/target/scala-2.12/scala-steward-mill-plugin_2.12-0.8.0.pom.asc /home/runner/work/scala-steward/scala-steward/modules/mill-plugin/.jvm/target/scala-2.12/scala-steward-mill-plugin_2.12-0.8.0.pom'.  Exit code: 2
```
I'm now trying the workaround mentioned in https://github.com/djspiewak/sbt-github-actions#integration-with-sbt-ci-release.