### PR TITLE
Use next version when looking for artifact URLs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -91,15 +91,15 @@ object NewPullRequestData {
     if (releaseRelatedUrls.isEmpty) None
     else
       releaseRelatedUrls
-        .map { url =>
-          url match {
-            case ReleaseRelatedUrl.CustomChangelog(url) => s"[Changelog](${url.renderString})"
-            case ReleaseRelatedUrl.CustomReleaseNotes(url) =>
-              s"[Release Notes](${url.renderString})"
-            case ReleaseRelatedUrl.GitHubReleaseNotes(url) =>
-              s"[GitHub Release Notes](${url.renderString})"
-            case ReleaseRelatedUrl.VersionDiff(url) => s"[Version Diff](${url.renderString})"
-          }
+        .map {
+          case ReleaseRelatedUrl.CustomChangelog(url) =>
+            s"[Changelog](${url.renderString})"
+          case ReleaseRelatedUrl.CustomReleaseNotes(url) =>
+            s"[Release Notes](${url.renderString})"
+          case ReleaseRelatedUrl.GitHubReleaseNotes(url) =>
+            s"[GitHub Release Notes](${url.renderString})"
+          case ReleaseRelatedUrl.VersionDiff(url) =>
+            s"[Version Diff](${url.renderString})"
         }
         .mkString(" - ")
         .some


### PR DESCRIPTION
This uses dependencies with the next version instead of the current
version when querying Coursier for URLs. If a dependency adds URLs to
its `pom.xml` or `ivy.xml` for its next version Scala Steward will be
able to use them immediately when it is creating PRs for this version.
Currently it can only use them on the next version but one since it
uses the current version to find these URLs.