### PR TITLE
Add PR number to PullRequestOut and persist it in PullRequestRepository

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -115,7 +115,8 @@ final class NurtureAlg[F[_]](config: Config)(implicit
           pr.html_url,
           data.baseSha1,
           data.update,
-          pr.state
+          pr.state,
+          pr.number
         )
       }
     } yield result
@@ -216,7 +217,8 @@ final class NurtureAlg[F[_]](config: Config)(implicit
         pr.html_url,
         data.baseSha1,
         data.update,
-        pr.state
+        pr.state,
+        pr.number
       )
       _ <- logger.info(s"Created PR ${pr.html_url}")
     } yield ()

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -24,7 +24,7 @@ import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.update.UpdateAlg
 import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
-import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
+import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState, Repo}
 
 final class PullRequestRepository[F[_]](
     kvStore: KeyValueStore[F, Repo, Map[Uri, PullRequestData]]
@@ -48,7 +48,8 @@ final class PullRequestRepository[F[_]](
       url: Uri,
       baseSha1: Sha1,
       update: Update,
-      state: PullRequestState
+      state: PullRequestState,
+      number: PullRequestNumber
   ): F[Unit] =
     kvStore
       .modifyF(repo) { maybePullRequests =>
@@ -59,7 +60,7 @@ final class PullRequestRepository[F[_]](
             pullRequests.updated(url, data).some.pure[F]
           case None =>
             dateTimeAlg.currentTimestamp.map { now =>
-              val data = PullRequestData(baseSha1, update, state, now)
+              val data = PullRequestData(baseSha1, update, state, now, Some(number))
               pullRequests.updated(url, data).some
             }
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
@@ -39,10 +39,10 @@ private[bitbucket] object json {
 
   implicit val pullRequestOutDecoder: Decoder[PullRequestOut] = Decoder.instance { c =>
     for {
-      id <- c.downField("id").as[Int]
+      id <- c.downField("id").as[PullRequestNumber]
       title <- c.downField("title").as[String]
       state <- c.downField("state").as[PullRequestState]
       html_url <- c.downField("links").downField("self").downField("href").as[Uri]
-    } yield PullRequestOut(html_url, state, PullRequestNumber(id), title)
+    } yield PullRequestOut(html_url, state, id, title)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
@@ -20,7 +20,7 @@ import io.circe.Decoder
 import org.http4s.Uri
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.uri.uriDecoder
-import org.scalasteward.core.vcs.data.{BranchOut, CommitOut, PullRequestOut, PullRequestState}
+import org.scalasteward.core.vcs.data._
 
 private[bitbucket] object json {
   implicit val branchOutDecoder: Decoder[BranchOut] = Decoder.instance { c =>
@@ -39,9 +39,10 @@ private[bitbucket] object json {
 
   implicit val pullRequestOutDecoder: Decoder[PullRequestOut] = Decoder.instance { c =>
     for {
+      id <- c.downField("id").as[Int]
       title <- c.downField("title").as[String]
       state <- c.downField("state").as[PullRequestState]
       html_url <- c.downField("links").downField("self").downField("href").as[Uri]
-    } yield (PullRequestOut(html_url, state, title))
+    } yield PullRequestOut(html_url, state, PullRequestNumber(id), title)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -56,7 +56,7 @@ class BitbucketServerApiAlg[F[_]](
         reviewers = reviewers
       )
       pr <- client.postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify(repo))
-    } yield PullRequestOut(pr.links("self").head.href, pr.state, pr.title)
+    } yield pr.toPullRequestOut
   }
 
   private def useDefaultReviewers(repo: Repo): F[List[Reviewer]] =
@@ -89,7 +89,7 @@ class BitbucketServerApiAlg[F[_]](
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
     client
       .get[Json.Page[Json.PR]](url.listPullRequests(repo, s"refs/heads/$head"), modify(repo))
-      .map(_.values.map(pr => PullRequestOut(pr.links("self").head.href, pr.state, pr.title)))
+      .map(_.values.map(_.toPullRequestOut))
 
   def ni(name: String): Nothing = throw new NotImplementedError(name)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
@@ -34,9 +34,9 @@ object Json {
 
   case class Link(href: Uri, name: Option[String])
 
-  case class PR(id: Int, title: String, state: PullRequestState, links: Links) {
+  case class PR(id: PullRequestNumber, title: String, state: PullRequestState, links: Links) {
     def toPullRequestOut: PullRequestOut =
-      PullRequestOut(links("self").head.href, state, PullRequestNumber(id), title)
+      PullRequestOut(links("self").head.href, state, id, title)
   }
 
   case class NewPR(

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
@@ -21,7 +21,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import org.http4s.Uri
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.vcs.data.PullRequestState
+import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestOut, PullRequestState}
 
 object Json {
   case class Page[A](values: List[A])
@@ -34,7 +34,10 @@ object Json {
 
   case class Link(href: Uri, name: Option[String])
 
-  case class PR(title: String, state: PullRequestState, links: Links)
+  case class PR(id: Int, title: String, state: PullRequestState, links: Links) {
+    def toPullRequestOut: PullRequestOut =
+      PullRequestOut(links("self").head.href, state, PullRequestNumber(id), title)
+  }
 
   case class NewPR(
       title: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestNumber.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestNumber.scala
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.nurture
+package org.scalasteward.core.vcs.data
 
 import io.circe.Codec
-import io.circe.generic.semiauto._
-import org.scalasteward.core.data.Update
-import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.util.Timestamp
-import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState}
+import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
 
-final case class PullRequestData(
-    baseSha1: Sha1,
-    update: Update,
-    state: PullRequestState,
-    entryCreatedAt: Timestamp,
-    number: Option[PullRequestNumber]
-)
+final case class PullRequestNumber(value: Int)
 
-object PullRequestData {
-  implicit val pullRequestDataCodec: Codec[PullRequestData] =
-    deriveCodec
+object PullRequestNumber {
+  implicit val pullRequestNumberCodec: Codec[PullRequestNumber] =
+    deriveUnwrappedCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
@@ -26,6 +26,7 @@ import org.scalasteward.core.vcs.data.PullRequestState.Closed
 final case class PullRequestOut(
     html_url: Uri,
     state: PullRequestState,
+    number: PullRequestNumber,
     title: String
 ) {
   def isClosed: Boolean =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -50,7 +50,7 @@ final private[gitlab] case class MergeRequestOut(
     iid: Int,
     mergeStatus: String
 ) {
-  val pullRequestOut: PullRequestOut = PullRequestOut(webUrl, state, title)
+  val pullRequestOut: PullRequestOut = PullRequestOut(webUrl, state, PullRequestNumber(iid), title)
 }
 
 final private[gitlab] case class CommitId(id: Sha1) {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -98,6 +98,7 @@ class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
     case POST -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" =>
       Ok(
         json"""{
+            "id": 2,
             "title": "scala-steward-pr",
             "state": "OPEN",
             "links": {
@@ -112,6 +113,7 @@ class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
         json"""{
           "values": [
               {
+                  "id": 2,
                   "title": "scala-steward-pr",
                   "state": "OPEN",
                   "links": {
@@ -126,6 +128,7 @@ class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
     case PUT -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" / IntVar(_) =>
       Ok(
         json"""{
+            "id": 2,
             "title": "scala-steward-pr",
             "state": "DECLINED",
             "links": {
@@ -170,7 +173,8 @@ class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
     CommitOut(Sha1(HexString("07eb2a203e297c8340273950e98b2cab68b560c1")))
   )
 
-  val pullRequest = PullRequestOut(prUrl, PullRequestState.Open, "scala-steward-pr")
+  val pullRequest =
+    PullRequestOut(prUrl, PullRequestState.Open, PullRequestNumber(2), "scala-steward-pr")
 
   test("createForkOrGetRepo") {
     val repoOut = bitbucketApiAlg.createForkOrGetRepo(repo, doNotFork = false).unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -1,0 +1,48 @@
+package org.scalasteward.core.vcs.bitbucketserver
+
+import cats.effect.IO
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.http4s.{HttpRoutes, Uri}
+import org.scalasteward.core.git.Branch
+import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.util.HttpJsonClient
+import org.scalasteward.core.vcs.data._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class BitbucketServerApiAlgTest extends AnyFunSuite with Matchers {
+  private val repo = Repo("scala-steward-org", "scala-steward")
+  private val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case GET -> Root / "rest" / "api" / "1.0" / "projects" / repo.owner / "repos" / repo.repo / "pull-requests" =>
+      Ok("""{ "values": [
+           |  {
+           |    "id": 123,
+           |    "title": "Update sbt to 1.4.2",
+           |    "state": "open",
+           |    "links": { "self": [ { "href": "http://example.org" } ] }
+           |  }
+           |]}""".stripMargin)
+  }
+
+  implicit private val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
+  implicit private val httpJsonClient: HttpJsonClient[IO] = new HttpJsonClient[IO]
+  private val bitbucketServerApiAlg: BitbucketServerApiAlg[IO] =
+    new BitbucketServerApiAlg[IO](config.vcsApiHost, _ => IO.pure, useReviewers = false)
+
+  test("listPullRequests") {
+    val pullRequests = bitbucketServerApiAlg
+      .listPullRequests(repo, "update/sbt-1.4.2", Branch("main"))
+      .unsafeRunSync()
+
+    pullRequests shouldBe List(
+      PullRequestOut(
+        Uri.unsafeFromString("http://example.org"),
+        PullRequestState.Open,
+        PullRequestNumber(123),
+        "Update sbt to 1.4.2"
+      )
+    )
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
@@ -14,6 +14,7 @@ class PullRequestOutTest extends AnyFunSuite with Matchers {
         PullRequestOut(
           uri"https://github.com/octocat/Hello-World/pull/1347",
           Open,
+          PullRequestNumber(1347),
           "new-feature"
         )
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -41,6 +41,7 @@ class GitHubApiAlgTest extends AnyFunSuite with Matchers {
           json"""[{
             "html_url": "https://github.com/octocat/Hello-World/pull/1347",
             "state": "open",
+            "number": 1347,
             "title": "new-feature"
           }]"""
         )
@@ -50,6 +51,7 @@ class GitHubApiAlgTest extends AnyFunSuite with Matchers {
           json"""{
             "html_url": "https://github.com/octocat/Hello-World/pull/1347",
             "state": "closed",
+            "number": 1347,
             "title": "new-feature"
           }"""
         )

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -103,6 +103,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
     prOut shouldBe PullRequestOut(
       uri"https://gitlab.com/foo/bar/merge_requests/7115",
       PullRequestState.Open,
+      PullRequestNumber(7115),
       "title"
     )
   }
@@ -124,6 +125,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
     prOut shouldBe PullRequestOut(
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
+      PullRequestNumber(150),
       "title"
     )
   }
@@ -141,6 +143,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
     prOut shouldBe PullRequestOut(
       uri"https://gitlab.com/foo/bar/merge_requests/7115",
       PullRequestState.Closed,
+      PullRequestNumber(7115),
       "title"
     )
   }
@@ -163,6 +166,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
     prOut shouldBe PullRequestOut(
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
+      PullRequestNumber(150),
       "title"
     )
   }
@@ -196,6 +200,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
     prOut shouldBe PullRequestOut(
       uri"https://gitlab.com/foo/bar/merge_requests/150",
       PullRequestState.Open,
+      PullRequestNumber(150),
       "title"
     )
   }


### PR DESCRIPTION
This contains some of the changes that were also in #1631 and is a
follow-up to #1667. This PR stores the pull request number in
`PullRequestOut` and persists it in `PullRequestRepository`. To sidestep
the issue of migrating old `pull_requests.json` files, the PR number is
added as an optional field to `PullRequestData`.

The goal here is to use the persisted PR number instead of
`VCSExtraAlg.extractPRIdFromUrls` in a future release.