### PR TITLE
Extract PR number from URL only if absent in PullRequestData

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -26,7 +26,7 @@ trait VCSApiAlg[F[_]] {
 
   def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut]
 
-  def closePullRequest(repo: Repo, id: Int): F[PullRequestOut]
+  def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut]
 
   def getBranch(repo: Repo, branch: Branch): F[BranchOut]
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -19,14 +19,13 @@ package org.scalasteward.core.vcs
 import cats.Monad
 import cats.syntax.all._
 import org.http4s.Uri
-import org.scalasteward.core.application.{Config, SupportedVCS}
+import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
 import org.scalasteward.core.util.HttpExistenceClient
 import org.scalasteward.core.vcs
 
 trait VCSExtraAlg[F[_]] {
   def getReleaseRelatedUrls(repoUrl: Uri, update: Update): F[List[ReleaseRelatedUrl]]
-  def extractPRIdFromUrls(vsc: SupportedVCS, uri: Uri): Option[Int]
 }
 
 object VCSExtraAlg {
@@ -39,24 +38,5 @@ object VCSExtraAlg {
         vcs
           .possibleReleaseRelatedUrls(config.vcsType, config.vcsApiHost, repoUrl, update)
           .filterA(releaseRelatedUrl => existenceClient.exists(releaseRelatedUrl.url))
-
-      override def extractPRIdFromUrls(vcs: SupportedVCS, uri: Uri): Option[Int] = {
-        def extractIntAfter(value: String, matchPart: String): Option[Int] = {
-          val regex = raw".*/$matchPart/(\d+)".r
-          value match {
-            case regex(id) => scala.util.Try(id.toInt).toOption
-            case _         => None
-          }
-        }
-
-        vcs match {
-          case SupportedVCS.GitHub =>
-            extractIntAfter(uri.path, "pull")
-          case SupportedVCS.Bitbucket | SupportedVCS.BitbucketServer =>
-            extractIntAfter(uri.path, "pullrequests")
-          case SupportedVCS.GitLab =>
-            extractIntAfter(uri.path, "merge_requests")
-        }
-      }
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -87,9 +87,9 @@ class BitbucketApiAlg[F[_]](
       .get[Page[PullRequestOut]](url.listPullRequests(repo, head), modify(repo))
       .map(_.values)
 
-  override def closePullRequest(repo: Repo, id: Int): F[PullRequestOut] =
+  override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.putWithBody[PullRequestOut, UpdateState](
-      url.pullRequest(repo, id),
+      url.pullRequest(repo, number),
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.vcs.bitbucket
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
 
 private[bitbucket] class Url(apiHost: Uri) {
   def forks(rep: Repo): Uri =
@@ -30,8 +30,8 @@ private[bitbucket] class Url(apiHost: Uri) {
   def pullRequests(rep: Repo): Uri =
     repo(rep) / "pullrequests"
 
-  def pullRequest(rep: Repo, id: Int): Uri =
-    repo(rep) / "pullrequests" / id.toString
+  def pullRequest(rep: Repo, number: PullRequestNumber): Uri =
+    repo(rep) / "pullrequests" / number.toString
 
   def branch(rep: Repo, branch: Branch): Uri =
     repo(rep) / "refs" / "branches" / branch.name

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -93,9 +93,9 @@ class BitbucketServerApiAlg[F[_]](
 
   def ni(name: String): Nothing = throw new NotImplementedError(name)
 
-  override def closePullRequest(repo: Repo, id: Int): F[PullRequestOut] =
+  override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.putWithBody[PullRequestOut, UpdateState](
-      url.pullRequest(repo, id),
+      url.pullRequest(repo, number),
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )
@@ -110,7 +110,8 @@ final class StashUrls(base: Uri) {
 
   def pullRequests(r: Repo): Uri = repo(r) / "pull-requests"
 
-  def pullRequest(r: Repo, id: Int): Uri = repo(r) / "pull-requests" / id.toString
+  def pullRequest(r: Repo, number: PullRequestNumber): Uri =
+    repo(r) / "pull-requests" / number.toString
 
   def reviewers(repo: Repo): Uri =
     reviewerApi / "projects" / repo.owner / "repos" / repo.repo / "conditions"

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestNumber.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestNumber.scala
@@ -19,7 +19,9 @@ package org.scalasteward.core.vcs.data
 import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
 
-final case class PullRequestNumber(value: Int)
+final case class PullRequestNumber(value: Int) {
+  override def toString: String = value.toString
+}
 
 object PullRequestNumber {
   implicit val pullRequestNumberCodec: Codec[PullRequestNumber] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
@@ -51,9 +51,9 @@ final class GitHubApiAlg[F[_]](
     client.get(url.listPullRequests(repo, head, base), modify(repo))
 
   /** https://developer.github.com/v3/pulls/#update-a-pull-request */
-  override def closePullRequest(repo: Repo, id: Int): F[PullRequestOut] =
+  override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.patchWithBody[PullRequestOut, UpdateState](
-      url.pull(repo, id),
+      url.pull(repo, number),
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.vcs.github
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
 
 class Url(apiHost: Uri) {
   def branches(repo: Repo, branch: Branch): Uri =
@@ -36,8 +36,8 @@ class Url(apiHost: Uri) {
   def pulls(repo: Repo): Uri =
     repos(repo) / "pulls"
 
-  def pull(repo: Repo, id: Int): Uri =
-    repos(repo) / "pulls" / id.toString
+  def pull(repo: Repo, number: PullRequestNumber): Uri =
+    repos(repo) / "pulls" / number.toString
 
   def repos(repo: Repo): Uri =
     apiHost / "repos" / repo.owner / repo.repo

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.vcs.gitlab
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
 
 class Url(apiHost: Uri) {
   def encodedProjectId(repo: Repo): String = s"${repo.owner}%2F${repo.repo}"
@@ -35,11 +35,11 @@ class Url(apiHost: Uri) {
   def mergeRequest(repo: Repo): Uri =
     repos(repo) / "merge_requests"
 
-  def existingMergeRequest(repo: Repo, internalId: Int): Uri =
-    mergeRequest(repo) / internalId.toString()
+  def existingMergeRequest(repo: Repo, number: PullRequestNumber): Uri =
+    mergeRequest(repo) / number.toString
 
-  def mergeWhenPiplineSucceeds(repo: Repo, internalId: Int) =
-    (existingMergeRequest(repo, internalId) / "merge")
+  def mergeWhenPiplineSucceeds(repo: Repo, number: PullRequestNumber): Uri =
+    (existingMergeRequest(repo, number) / "merge")
       .withQueryParam("merge_when_pipeline_succeeds", "true")
 
   def listMergeRequests(repo: Repo, source: String, target: String): Uri =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -22,9 +22,16 @@ import org.scalasteward.core.application.SupportedVCS
 import org.scalasteward.core.application.SupportedVCS.{Bitbucket, BitbucketServer, GitHub, GitLab}
 import org.scalasteward.core.data.ReleaseRelatedUrl.VersionDiff
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
 
 package object vcs {
+  def extractPullRequestNumberFrom(uri: Uri): Option[PullRequestNumber] = {
+    val regex = raw".*/(pull|pullrequests|merge_requests)/(\d+)".r
+    uri.path match {
+      case regex(_, id) => scala.util.Try(PullRequestNumber(id.toInt)).toOption
+      case _            => None
+    }
+  }
 
   /** Determines the `head` (GitHub) / `source_branch` (GitLab, Bitbucket) parameter for searching
     * for already existing pull requests.

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -55,10 +55,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
       val nextUpdate = TestData.Updates.PortableScala.copy(newerVersions = Nel.of("1.0.1"))
 
       val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          nextUpdate
-        )
+        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
         _ <- pullRequestRepository.createOrUpdate(
           repo,
           url,
@@ -67,23 +64,15 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
           PullRequestState.Open,
           number
         )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          nextUpdate
-        )
+        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
         _ <- pullRequestRepository.changeState(repo, url, PullRequestState.Closed)
-        closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          nextUpdate
-        )
+        closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
       } yield (emptyResult, result, closedResult)
       val (state, (emptyResult, result, closedResult)) = p.run(MockState.empty).unsafeRunSync()
       val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
       emptyResult shouldBe List.empty
       closedResult shouldBe List.empty
-      result shouldBe List(
-        url -> TestData.Updates.PortableScala
-      )
+      result shouldBe List((number, url, TestData.Updates.PortableScala))
 
       checkCommands(
         state,
@@ -103,10 +92,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
       val update = TestData.Updates.PortableScala
 
       val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          update
-        )
+        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
         _ <- pullRequestRepository.createOrUpdate(
           repo,
           url,
@@ -115,10 +101,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
           PullRequestState.Open,
           number
         )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          update
-        )
+        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
       } yield (emptyResult, result)
       val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
       val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
@@ -141,10 +124,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
       val newUpdate = TestData.Updates.CatsCore
 
       val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          updateInStore
-        )
+        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, updateInStore)
         _ <- pullRequestRepository.createOrUpdate(
           repo,
           url,
@@ -153,10 +133,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
           PullRequestState.Open,
           number
         )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(
-          repo,
-          newUpdate
-        )
+        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, newUpdate)
       } yield (emptyResult, result)
       val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
       val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -6,11 +6,33 @@ import org.scalasteward.core.application.SupportedVCS
 import org.scalasteward.core.application.SupportedVCS.{GitHub, GitLab}
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class VCSPackageTest extends AnyFunSuite with Matchers {
+  test(s"extractPullRequestNumberFrom: valid") {
+    val urls = List(
+      uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/13",
+      uri"https://github.com/scala-steward-org/scala-steward/pull/13",
+      uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/13"
+    )
+    urls.foreach { uri =>
+      extractPullRequestNumberFrom(uri) shouldBe Some(PullRequestNumber(13))
+    }
+  }
+
+  test(s"extractPullRequestNumberFrom: invalid") {
+    val urls = List(
+      uri"https://api.bitbucket.org/2.0/repositories/fthomas/base.g8/pullrequests/",
+      uri"https://github.com/scala-steward-org/scala-steward/pull/",
+      uri"https://gitlab.com/inkscape/inkscape/-/merge_requests/"
+    )
+    urls.foreach { uri =>
+      extractPullRequestNumberFrom(uri) shouldBe None
+    }
+  }
+
   val repo: Repo = Repo("foo", "bar")
   val update: Update.Single =
     Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3"))

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -217,7 +217,7 @@ class BitbucketApiAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("closePullRequest") {
-    val pr = bitbucketApiAlg.closePullRequest(repo, 1).unsafeRunSync()
+    val pr = bitbucketApiAlg.closePullRequest(repo, PullRequestNumber(1)).unsafeRunSync()
     pr shouldBe pr.copy(state = PullRequestState.Closed)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -129,7 +129,7 @@ class GitHubApiAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("closePullRequest") {
-    val prOut = gitHubApiAlg.closePullRequest(repo, 1347).unsafeRunSync()
+    val prOut = gitHubApiAlg.closePullRequest(repo, PullRequestNumber(1347)).unsafeRunSync()
     prOut.state shouldBe PullRequestState.Closed
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -137,7 +137,7 @@ class GitLabApiAlgTest extends AnyFunSuite with Matchers {
   test("closePullRequest") {
     val prOut =
       gitlabApiAlg
-        .closePullRequest(Repo("foo", "bar"), 7115)
+        .closePullRequest(Repo("foo", "bar"), PullRequestNumber(7115))
         .unsafeRunSync()
 
     prOut shouldBe PullRequestOut(


### PR DESCRIPTION
This uses `PullRequestData.number` for closing obsolete PRs if it is
present and falls back to `vcs.extractPullRequestNumberFrom` otherwise.
It also uses `PullRequestNumber` in `VCSApiAlg` and its implementations
and moves `extractPRIdFromUrls` from `VCSExtraAlg` to the `vcs` pacakge
since it doesn't have any dependencies.

Follow-up to #1741.