### PR TITLE
Fix the runSteward command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,7 @@ runSteward := Def.taskDyn {
     Seq("--whitelist", s"$home/.mill"),
     Seq("--whitelist", s"$home/.sbt")
   ).flatten.mkString(" ", " ", "")
-  (core.jvm / Compile / run).toTask(args)
+  (core.jvm / run).toTask(args)
 }.value
 
 /// commands


### PR DESCRIPTION
Minor issue with the command. With sbt 1.4+ it fails with some weird class not found.