### PR TITLE
Post-update hooks: do not run scalafmt in a sandbox

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
@@ -24,6 +24,7 @@ final case class PostUpdateHook(
     groupId: GroupId,
     artifactId: ArtifactId,
     command: Nel[String],
+    useSandbox: Boolean,
     commitMessage: Update => String,
     enabledByConfig: RepoConfig => Boolean
 )

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -40,14 +40,12 @@ class HookExecutorTest extends AnyFunSuite with Matchers {
       .runS(initial)
       .unsafeRunSync()
 
-    state shouldBe initial.copy(commands =
-      Vector(
+    state shouldBe initial.copy(
+      commands = Vector(
         List(
+          "VAR1=val1",
+          "VAR2=val2",
           repoDir.toString,
-          "firejail",
-          s"--whitelist=$repoDir",
-          "--env=VAR1=val1",
-          "--env=VAR2=val2",
           "scalafmt",
           "--non-interactive"
         ),
@@ -68,7 +66,8 @@ class HookExecutorTest extends AnyFunSuite with Matchers {
           "-m",
           "Reformat with scalafmt 2.7.5"
         )
-      )
+      ),
+      logs = Vector((None, "Executing post-update hook for org.scalameta:scalafmt-core"))
     )
 
   }
@@ -93,8 +92,8 @@ class HookExecutorTest extends AnyFunSuite with Matchers {
       .runS(MockState.empty)
       .unsafeRunSync()
 
-    state shouldBe MockState.empty.copy(commands =
-      Vector(
+    state shouldBe MockState.empty.copy(
+      commands = Vector(
         List(
           repoDir.toString,
           "firejail",
@@ -112,7 +111,8 @@ class HookExecutorTest extends AnyFunSuite with Matchers {
           "--untracked-files=no",
           "--ignore-submodules"
         )
-      )
+      ),
+      logs = Vector((None, "Executing post-update hook for com.codecommit:sbt-github-actions"))
     )
   }
 }


### PR DESCRIPTION
It is not necessary to run scalafmt in a sandbox.