### PR TITLE
Add signingKey to git.Author

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -33,6 +33,7 @@ object Cli {
       defaultRepoConf: Option[File] = None,
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
+      gitAuthorSigningKey: Option[String] = None,
       vcsType: SupportedVCS = SupportedVCS.GitHub,
       vcsApiHost: Uri = uri"https://api.github.com",
       vcsLogin: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -107,7 +107,7 @@ object Config {
       workspace = args.workspace,
       reposFile = args.reposFile,
       defaultRepoConfigFile = args.defaultRepoConf,
-      gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail, args.gitAuthorSigningkey),
+      gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail, args.gitAuthorSigningKey),
       vcsType = args.vcsType,
       vcsApiHost = args.vcsApiHost,
       vcsLogin = args.vcsLogin,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -107,7 +107,7 @@ object Config {
       workspace = args.workspace,
       reposFile = args.reposFile,
       defaultRepoConfigFile = args.defaultRepoConf,
-      gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
+      gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail, args.gitAuthorSigningkey),
       vcsType = args.vcsType,
       vcsApiHost = args.vcsApiHost,
       vcsLogin = args.vcsLogin,

--- a/modules/core/src/main/scala/org/scalasteward/core/git/Author.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Author.scala
@@ -16,4 +16,4 @@
 
 package org.scalasteward.core.git
 
-final case class Author(name: String, email: String)
+final case class Author(name: String, email: String, signingKey: Option[String])

--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -105,6 +105,7 @@ final class FileGitAlg[F[_]](config: Config)(implicit
     for {
       _ <- git("config", "user.email", author.email)(repo)
       _ <- git("config", "user.name", author.name)(repo)
+      _ <- author.signingKey.traverse_(key => git("config", "user.signingKey", key)(repo))
     } yield ()
 
   override def syncFork(repo: File, upstreamUrl: Uri, defaultBranch: Branch): F[Unit] =


### PR DESCRIPTION
This allows to set the Git config option [`user.signingKey`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey) which helps
Git to select the correct GPG key if it has trouble to choose one
itself. The key can be passed via `--git-author-signing-key $KEY` to
Scala Steward.