### PR TITLE
Don't replace version numbers in comments

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
@@ -37,37 +37,42 @@ package object edit {
       case (part, false) => Unchanged(part)
     }
 
-  private[edit] def splitByOffOnMarker(target: String): Nel[(String, Boolean)] =
-    if (!target.contains("scala-steward:off"))
-      Nel.of((target, true))
-    else {
-      val buffer = mutable.ListBuffer.empty[(String, Boolean)]
-      val on = new StringBuilder()
-      val off = new StringBuilder()
-      val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
-      def flush(builder: StringBuilder, canReplace: Boolean): Unit =
-        if (builder.nonEmpty) {
-          buffer.append((builder.toString(), canReplace))
-          builder.clear()
-        }
-      target.linesWithSeparators.foreach { line =>
-        if (off.nonEmpty)
-          if (line.contains("scala-steward:on")) {
-            flush(off, false)
-            on.append(line)
-          } else
-            off.append(line)
-        else if (line.contains("scala-steward:off")) {
-          flush(on, true)
-          if (regexIgnoreMultiLinesBegins.findFirstIn(line).isDefined)
-            off.append(line)
-          else
-            // single line off
-            buffer.append((line, false))
-        } else on.append(line)
+  private[edit] def splitByOffOnMarker(target: String): Nel[(String, Boolean)] = {
+    val buffer = mutable.ListBuffer.empty[(String, Boolean)]
+    val on = new StringBuilder()
+    val off = new StringBuilder()
+    val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
+    def flush(builder: StringBuilder, canReplace: Boolean): Unit =
+      if (builder.nonEmpty) {
+        buffer.append((builder.toString(), canReplace))
+        builder.clear()
       }
-      flush(on, true)
-      flush(off, false)
-      Nel.fromListUnsafe(buffer.toList)
+    target.linesWithSeparators.foreach { line =>
+      if (off.nonEmpty)
+        if (line.contains("scala-steward:on")) {
+          flush(off, false)
+          on.append(line)
+        } else
+          off.append(line)
+      else if (line.contains("scala-steward:off")) {
+        flush(on, true)
+        if (regexIgnoreMultiLinesBegins.findFirstIn(line).isDefined)
+          off.append(line)
+        else
+          // single line off
+          buffer.append((line, false))
+      } else if (line.contains("//")) {
+        val beforeAfter = line.split("//", 2)
+        on.append(beforeAfter(0))
+        flush(on, true)
+        buffer.append(("//" + beforeAfter(1), false))
+      } else on.append(line)
     }
+    flush(on, true)
+    flush(off, false)
+    if (buffer.isEmpty)
+      Nel.of((target, true))
+    else
+      Nel.fromListUnsafe(buffer.toList)
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -459,15 +459,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         "scala-opentracing-http4s-server-tapir"
       ) % "2.4.1",
       Nel.of("2.5.0")
-    )
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.sliding.name)
-  }
-
-  test("fail on versions duplicated in a comment") {
-    val original = """val scalajsJqueryVersion = "0.9.3" // val scalajsJqueryVersion = "0.9.3""""
-    val expected = """val scalajsJqueryVersion = "0.9.3" // val scalajsJqueryVersion = "0.9.4""""
-    Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.sliding.name)
   }
 
   test("issue 1489: ignore word: scala") {
@@ -499,6 +491,15 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """.add("scalatestplus", version = "2.2.0.3", org = "org.scalatestplus", "scalacheck-1-14")"""
     Single("org.typelevel" % "cats-effect" % "2.2.0", Nel.of("2.3.0"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
+  }
+
+  test("issue #1651: don't update in comments") {
+    val original =
+      """val scalaTest = "3.2.0"  // scalaTest 3.2.0-M2 is causing a failure on scala 2.13..."""
+    val expected =
+      """val scalaTest = "3.2.2"  // scalaTest 3.2.0-M2 is causing a failure on scala 2.13..."""
+    Single("org.scalatest" % "scalatest" % "3.2.0", Nel.of("3.2.2"))
+      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 }
 


### PR DESCRIPTION
Version numbers in single line comments (`//`) are no longer changed

Fixes #1651