### PR TITLE
Minor refinement to `updates.limit` documentation

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -52,7 +52,7 @@ updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." }
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
-# If set, Scala Steward will only attempt to create or update `n` PRs.
+# If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: None
 updates.limit = 5


### PR DESCRIPTION
Based on feedback https://github.com/scala-steward-org/scala-steward/issues/1788#issuecomment-740158243 -

We bumped into this recently, expecting `updates.limit` to be a global limit on how many PRs scala-steward would make, rather than how many it would make *per run*. Hopefully this wording change makes that distinction a little bit clearer.