### PR TITLE
Ignore errors when executing post-update hooks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
@@ -37,6 +37,14 @@ trait ProcessAlg[F[_]] {
       extraEnv: (String, String)*
   ): F[List[String]] =
     exec(command, workingDirectory, extraEnv: _*)
+
+  final def execMaybeSandboxed(sandboxed: Boolean)(
+      command: Nel[String],
+      workingDirectory: File,
+      extraEnv: (String, String)*
+  ): F[List[String]] =
+    if (sandboxed) execSandboxed(command, workingDirectory, extraEnv: _*)
+    else exec(command, workingDirectory, extraEnv: _*)
 }
 
 object ProcessAlg {


### PR DESCRIPTION
If executing a post-update hook fails, Scala Steward aborts the current
update and other pending updates of the current repository. With this
change Scala Steward ignores errors from executing post-update hooks
instead. Changes in the working copy are committed as if the post-update
hook executed without errors.