### PR TITLE
Do not sort updates by Scalafix migrations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -79,11 +79,10 @@ final class NurtureAlg[F[_]](config: Config)(implicit
     for {
       repoConfig <- repoConfigAlg.readRepoConfigWithDefault(repo)
       grouped = Update.groupByGroupId(updates)
-      sorted = grouped.sortBy(migrationAlg.findMigrations(_).size)
-      _ <- logger.info(util.logger.showUpdates(sorted))
+      _ <- logger.info(util.logger.showUpdates(grouped))
       baseSha1 <- gitAlg.latestSha1(repo, baseBranch)
       _ <- NurtureAlg.processUpdates(
-        sorted,
+        grouped,
         update => {
           val updateData =
             UpdateData(repo, fork, repoConfig, update, baseBranch, baseSha1, git.branchFor(update))


### PR DESCRIPTION
Updates were sorted by Scalafix migrations so that a failing migration
does not prevent other updates (#1065). Later we changed that a failing
Scalafix migration aborts all other pending updates (#1121) so this
sorting by migrations is not necessary any more.