### PR TITLE
Remove remnants of http4s-async-http-client from the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,9 +113,6 @@ lazy val core = myCrossProject("core")
       {
         case PathList(ps @ _*) if nativeSuffix.findFirstMatchIn(ps.last).isDefined =>
           MergeStrategy.first
-        case PathList(ps @ _*) if ps.last == "io.netty.versions.properties" =>
-          // This is included in Netty JARs which are pulled in by http4s-async-http-client.
-          MergeStrategy.first
         case PathList("org", "fusesource", _*) =>
           // (core / assembly) deduplicate: different file contents found in the following:
           // https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar:org/fusesource/hawtjni/runtime/Callback.class
@@ -156,13 +153,11 @@ lazy val core = myCrossProject("core")
       import _root_.io.chrisdavenport.log4cats.Logger
       import _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger
       import org.http4s.client.Client
-      import org.http4s.client.asynchttpclient.AsyncHttpClient
       import scala.concurrent.ExecutionContext
 
       implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
       implicit val ioTimer: Timer[IO] = IO.timer(ExecutionContext.global)
       implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
-      implicit val client: Client[IO] = AsyncHttpClient.allocate[IO]().map(_._1).unsafeRunSync()
     """,
     fork in run := true,
     fork in Test := true,


### PR DESCRIPTION
I forgot to do this in https://github.com/scala-steward-org/scala-steward/pull/1701.