### PR TITLE
Run Scalafix migrations only if version can be bumped

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -66,6 +66,9 @@ final class FileGitAlg[F[_]](config: Config)(implicit
     git("rev-parse", "--abbrev-ref", Branch.head.name)(repo)
       .map(lines => Branch(lines.mkString.trim))
 
+  override def discardChanges(repo: File): F[Unit] =
+    git("checkout", "--", ".")(repo).void
+
   override def findFilesContaining(repo: File, string: String): F[List[String]] =
     git("grep", "-I", "--fixed-strings", "--files-with-matches", string)(repo)
       .handleError(_ => List.empty[String])

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
@@ -42,6 +42,8 @@ trait GenGitAlg[F[_], Repo] {
 
   def currentBranch(repo: Repo): F[Branch]
 
+  def discardChanges(repo: Repo): F[Unit]
+
   def findFilesContaining(repo: Repo, string: String): F[List[String]]
 
   /** Returns `true` if merging `branch` into `base` results in merge conflicts. */
@@ -98,6 +100,9 @@ trait GenGitAlg[F[_], Repo] {
 
       override def currentBranch(repo: A): F[Branch] =
         f(repo).flatMap(self.currentBranch)
+
+      override def discardChanges(repo: A): F[Unit] =
+        f(repo).flatMap(self.discardChanges)
 
       override def findFilesContaining(repo: A, string: String): F[List[String]] =
         f(repo).flatMap(self.findFilesContaining(_, string))

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
@@ -42,6 +42,7 @@ trait GenGitAlg[F[_], Repo] {
 
   def currentBranch(repo: Repo): F[Branch]
 
+  /** Discards unstaged changes. */
   def discardChanges(repo: Repo): F[Unit]
 
   def findFilesContaining(repo: Repo, string: String): F[List[String]]

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -6,6 +6,7 @@ import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.{config, editAlg}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.scalafmt.scalafmtBinary
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
@@ -79,6 +80,8 @@ class EditAlgTest extends AnyFunSuite with Matchers {
         List("read", scalafmtConf.pathAsString),
         List("read", scalafmtConf.pathAsString),
         List("write", scalafmtConf.pathAsString),
+        envVars ++ (repoDir.toString :: gitStatus),
+        List("VAR1=val1", "VAR2=val2", repoDir.toString, scalafmtBinary, "--non-interactive"),
         envVars ++ (repoDir.toString :: gitStatus)
       ),
       logs = Vector(
@@ -89,7 +92,8 @@ class EditAlgTest extends AnyFunSuite with Matchers {
         (None, "Trying heuristic 'sliding'"),
         (None, "Trying heuristic 'completeGroupId'"),
         (None, "Trying heuristic 'groupId'"),
-        (None, "Trying heuristic 'specific'")
+        (None, "Trying heuristic 'specific'"),
+        (None, "Executing post-update hook for org.scalameta:scalafmt-core")
       ),
       files = Map(
         scalafmtConf ->

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -70,6 +70,24 @@ class FileGitAlgTest extends AnyFunSuite with Matchers {
     p.unsafeRunSync() shouldBe master
   }
 
+  test("discardChanges") {
+    val repo = rootDir / "discardChanges"
+    val p = for {
+      _ <- supplement.createRepo(repo)
+      file = repo / "test.txt"
+      _ <- ioFileAlg.writeFile(file, "hello")
+      _ <- supplement.git("add", "test.txt")(repo)
+      _ <- ioGitAlg.commitAll(repo, "Add test.txt")
+      _ <- ioFileAlg.writeFile(file, "world")
+      before <- ioFileAlg.readFile(file)
+      _ <- ioGitAlg.discardChanges(repo)
+      after <- ioFileAlg.readFile(file)
+    } yield (before, after)
+    val (before, after) = p.unsafeRunSync()
+    before shouldBe Some("world")
+    after shouldBe Some("hello")
+  }
+
   test("findFilesContaining") {
     val repo = rootDir / "findFilesContaining"
     val p = for {


### PR DESCRIPTION
This does not run any Scalafix migration if the version cannot be
bumped. It prevents PRs that only contains changes from Scalafix
migrations.