### PR TITLE
Pass RepoCache from RepoCacheAlg to PruningAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -87,8 +87,8 @@ final class StewardAlg[F[_]](config: Config)(implicit
       logger.attemptLogInfo(util.string.lineLeftRight(label), Some(label)) {
         F.guarantee {
           for {
-            fork <- repoCacheAlg.checkCache(repo)
-            (attentionNeeded, updates) <- pruningAlg.needsAttention(repo)
+            (cache, fork) <- repoCacheAlg.checkCache(repo)
+            (attentionNeeded, updates) <- pruningAlg.needsAttention(repo, cache)
             _ <- if (attentionNeeded) nurtureAlg.nurture(repo, fork, updates) else F.unit
           } yield ()
         }(gitAlg.removeClone(repo))

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
@@ -17,17 +17,12 @@
 package org.scalasteward.core.repocache
 
 import cats.Applicative
-import cats.syntax.all._
-import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.vcs.data.Repo
 
 final class RepoCacheRepository[F[_]: Applicative](kvStore: KeyValueStore[F, Repo, RepoCache]) {
   def findCache(repo: Repo): F[Option[RepoCache]] =
     kvStore.get(repo)
-
-  def findSha1(repo: Repo): F[Option[Sha1]] =
-    findCache(repo).map(_.map(_.sha1))
 
   def updateCache(repo: Repo, repoCache: RepoCache): F[Unit] =
     kvStore.put(repo, repoCache)


### PR DESCRIPTION
This avoids parsing the `RepoCache` in `PruningAlg.needsAttention` again
since it has already been parsed or computed in `RepoCacheAlg`.