### PR TITLE
Allow arbitrary punctuation before scala-steward:off

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
@@ -41,7 +41,7 @@ package object edit {
     val buffer = mutable.ListBuffer.empty[(String, Boolean)]
     val on = new StringBuilder()
     val off = new StringBuilder()
-    val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
+    val regexIgnoreMultiLinesBegins = """\s*\p{Punct}+\s*scala-steward:off""".r
     def flush(builder: StringBuilder, canReplace: Boolean): Unit =
       if (builder.nonEmpty) {
         buffer.append((builder.toString(), canReplace))
@@ -56,7 +56,7 @@ package object edit {
           off.append(line)
       else if (line.contains("scala-steward:off")) {
         flush(on, true)
-        if (regexIgnoreMultiLinesBegins.findFirstIn(line).isDefined)
+        if (regexIgnoreMultiLinesBegins.findPrefixOf(line).isDefined)
           off.append(line)
         else
           // single line off

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -409,6 +409,15 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
+  test("hash before `off`") {
+    val original =
+      """# scala-steward:off
+        |sbt.version=1.2.8
+        |""".stripMargin
+    Single("org.scala-sbt" % "sbt" % "1.2.8", Nel.of("1.4.3"))
+      .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
+  }
+
   test("similar artifactIds and same version") {
     val original =
       """ "org.typelevel" %%% "cats-core" % "2.0.0-M4",


### PR DESCRIPTION
This supports using `scala-steward:off` in files that do not use `//` for single line comments.

Motivated by https://github.com/broadinstitute/cromwell/pull/6053.