### PR TITLE
Init Git submodules after syncing with upstream repo

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -78,7 +78,7 @@ object Context {
         new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "1", kvsPrefix))
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
-      implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config)
+      implicit val vcsRepoAlg: VCSRepoAlg[F] = new VCSRepoAlg[F](config)
       implicit val vcsExtraAlg: VCSExtraAlg[F] = VCSExtraAlg.create[F](config)
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "2", kvsPrefix))

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -64,8 +64,7 @@ final class NurtureAlg[F[_]](config: Config)(implicit
   def cloneAndSync(repo: Repo, fork: RepoOut): F[Branch] =
     for {
       _ <- logger.info(s"Clone and synchronize ${repo.show}")
-      cloneAndSync = vcsRepoAlg.clone(repo, fork) >> vcsRepoAlg.syncFork(repo, fork)
-      _ <- gitAlg.cloneExists(repo).ifM(F.unit, cloneAndSync)
+      _ <- gitAlg.cloneExists(repo).ifM(F.unit, vcsRepoAlg.cloneAndSync(repo, fork))
       baseBranch <- vcsApiAlg.parentOrRepo(fork, config.doNotFork).map(_.default_branch)
     } yield baseBranch
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -61,8 +61,7 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
   private def cloneAndRefreshCache(repo: Repo, repoOut: RepoOut): F[RepoCache] =
     for {
       _ <- logger.info(s"Refresh cache of ${repo.show}")
-      _ <- vcsRepoAlg.clone(repo, repoOut)
-      _ <- vcsRepoAlg.syncFork(repo, repoOut)
+      _ <- vcsRepoAlg.cloneAndSync(repo, repoOut)
       cache <- refreshCache(repo)
     } yield cache
 

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -67,7 +67,7 @@ object MockContext {
   implicit val gitAlg: GitAlg[MockEff] = GenGitAlg.create(config)
   implicit val hookExecutor: HookExecutor[MockEff] = new HookExecutor[MockEff]
   implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
-  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config)
+  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = new VCSRepoAlg[MockEff](config)
   implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
   val migrationsLoader: MigrationsLoader[MockEff] = new MigrationsLoader[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -3,8 +3,8 @@ package org.scalasteward.core.vcs
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.mock.MockContext.{config, gitAlg, vcsRepoAlg}
-import org.scalasteward.core.mock.{MockContext, MockState}
+import org.scalasteward.core.mock.MockContext.{config, gitAlg, mockLogger, vcsRepoAlg}
+import org.scalasteward.core.mock.{MockContext, MockEff, MockState}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 
 class VCSRepoAlgTest extends FunSuite {
@@ -28,60 +28,41 @@ class VCSRepoAlgTest extends FunSuite {
     Branch("master")
   )
 
-  test("clone") {
-    val state = vcsRepoAlg.clone(repo, forkRepoOut).runS(MockState.empty).unsafeRunSync()
-    val url = s"https://${config.vcsLogin}@github.com/scala-steward/datapackage"
+  test("cloneAndSync") {
+    val state = vcsRepoAlg.cloneAndSync(repo, forkRepoOut).runS(MockState.empty).unsafeRunSync()
+    val url0 = s"https://${config.vcsLogin}@github.com/fthomas/datapackage"
+    val url1 = s"https://${config.vcsLogin}@github.com/scala-steward/datapackage"
     val expected = MockState.empty.copy(
       commands = Vector(
-        envVars ++ List(config.workspace.toString, "git", "clone", url, repoDir),
-        envVars ++ List(repoDir, "git", "submodule", "update", "--init", "--recursive"),
+        envVars ++ List(config.workspace.toString, "git", "clone", url1, repoDir),
         envVars ++ List(repoDir, "git", "config", "user.email", "bot@example.org"),
-        envVars ++ List(repoDir, "git", "config", "user.name", "Bot Doe")
+        envVars ++ List(repoDir, "git", "config", "user.name", "Bot Doe"),
+        envVars ++ List(repoDir, "git", "remote", "add", "upstream", url0),
+        envVars ++ List(repoDir, "git", "fetch", "--tags", "upstream", "master"),
+        envVars ++ List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
+        envVars ++ List(repoDir, "git", "merge", "upstream/master"),
+        envVars ++ List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master"),
+        envVars ++ List(repoDir, "git", "submodule", "update", "--init", "--recursive")
       )
     )
     assertEquals(state, expected)
   }
 
   test("syncFork should throw an exception when doNotFork = false and there is no parent") {
-    assert(
-      vcsRepoAlg
-        .syncFork(repo, parentRepoOut)
-        .runS(MockState.empty)
-        .attempt
-        .map(_.isLeft)
-        .unsafeRunSync()
-    )
-  }
-
-  test("syncFork should sync when doNotFork = false and there is a parent") {
-    val state = vcsRepoAlg.syncFork(repo, forkRepoOut).runS(MockState.empty).unsafeRunSync()
-    val expected = MockState.empty.copy(
-      commands = Vector(
-        envVars ++ List(
-          repoDir,
-          "git",
-          "remote",
-          "add",
-          "upstream",
-          s"https://${config.vcsLogin}@github.com/fthomas/datapackage"
-        ),
-        envVars ++ List(repoDir, "git", "fetch", "--tags", "upstream", "master"),
-        envVars ++ List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
-        envVars ++ List(repoDir, "git", "merge", "upstream/master"),
-        envVars ++ List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
-      )
-    )
-    assertEquals(state, expected)
+    val result = vcsRepoAlg
+      .syncFork(repo, parentRepoOut)
+      .runS(MockState.empty)
+      .attempt
+      .unsafeRunSync()
+    assert(clue(result).isLeft)
   }
 
   test("syncFork should do nothing when doNotFork = true") {
     val config = MockContext.config.copy(doNotFork = true)
-    val state = VCSRepoAlg
-      .create(config)
+    val state = new VCSRepoAlg[MockEff](config)
       .syncFork(repo, parentRepoOut)
       .runS(MockState.empty)
       .unsafeRunSync()
-
     assertEquals(state, MockState.empty)
   }
 }


### PR DESCRIPTION
Git submodules are now initialized after the latest changes from the
upstream repo are merged into Scala Steward's fork instead of directly
after cloning our fork and before changes are synced. I hope that this
is enough to ensure that our submodules are always in sync with the
submodules of the upstream repos.

If we're lucky, this closes #339.