### PR TITLE
Allow updates.limit option to be zero

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.nurture
 import cats.Applicative
 import cats.effect.BracketThrow
 import cats.implicits._
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import org.http4s.Uri
@@ -239,7 +239,7 @@ object NurtureAlg {
   def processUpdates[F[_]](
       updates: List[Update],
       updateF: Update => F[ProcessResult],
-      updatesLimit: Option[PosInt]
+      updatesLimit: Option[NonNegInt]
   )(implicit streamCompiler: Stream.Compiler[F, F], F: Applicative[F]): F[Unit] =
     updatesLimit match {
       case None => updates.traverse_(updateF)
@@ -247,7 +247,7 @@ object NurtureAlg {
         Stream
           .emits(updates)
           .evalMap(updateF)
-          .through(util.takeUntil(limit.value) {
+          .through(util.takeUntil(0, limit.value) {
             case Ignored => 0
             case Updated => 1
           })

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.implicits._
 import cats.kernel.Semigroup
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.refined._
@@ -36,7 +36,7 @@ final case class UpdatesConfig(
     pin: List[UpdatePattern] = List.empty,
     allow: List[UpdatePattern] = List.empty,
     ignore: List[UpdatePattern] = List.empty,
-    limit: Option[PosInt] = None,
+    limit: Option[NonNegInt] = None,
     includeScala: Option[Boolean] = None,
     fileExtensions: Option[List[String]] = None
 ) {
@@ -186,5 +186,5 @@ object UpdatesConfig {
     combineOptions(x, y)(_.intersect(_))
 
   // prevent IntelliJ from removing the import of io.circe.refined._
-  locally(refinedDecoder: Decoder[PosInt])
+  locally(refinedDecoder: Decoder[NonNegInt])
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.nurture
 
 import cats.data.StateT
 import cats.effect.IO
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop._
 import org.scalasteward.core.TestInstances._
@@ -35,7 +35,7 @@ class NurtureAlgTest extends ScalaCheckSuite {
         .processUpdates(
           ignorableUpdates ++ appliableUpdates,
           f,
-          PosInt.unapply(appliableUpdates.size)
+          NonNegInt.unapply(appliableUpdates.size)
         )
         .runS(0)
         .unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
@@ -62,7 +62,7 @@ class RepoConfigAlgTest extends FunSuite {
         ignore = List(
           UpdatePattern(GroupId("org.acme"), None, Some(UpdatePattern.Version(Some("1.0"), None)))
         ),
-        limit = Some(PosInt.unsafeFrom(4)),
+        limit = Some(NonNegInt.unsafeFrom(4)),
         includeScala = Some(true),
         fileExtensions = Some(List(".txt"))
       ),

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import cats.syntax.semigroup._
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.repoconfig.UpdatePattern.Version
@@ -30,7 +30,7 @@ class UpdatesConfigTest extends FunSuite {
       pin = List(aa0),
       allow = List(aa0),
       ignore = List(aa0),
-      limit = Some(PosInt.unsafeFrom(10)),
+      limit = Some(NonNegInt.unsafeFrom(10)),
       includeScala = Some(false),
       fileExtensions = Some(List(".txt", ".scala", ".sbt"))
     )
@@ -43,7 +43,7 @@ class UpdatesConfigTest extends FunSuite {
       pin = List(ab0),
       allow = List(ab0),
       ignore = List(ab0),
-      limit = Some(PosInt.unsafeFrom(20)),
+      limit = Some(NonNegInt.unsafeFrom(20)),
       includeScala = Some(true),
       fileExtensions = Some(List(".sbt", ".scala"))
     )
@@ -54,7 +54,7 @@ class UpdatesConfigTest extends FunSuite {
         pin = List(aa0, ab0),
         allow = UpdatesConfig.nonExistingUpdatePattern,
         ignore = List(aa0, ab0),
-        limit = Some(PosInt.unsafeFrom(10)),
+        limit = Some(NonNegInt.unsafeFrom(10)),
         includeScala = Some(false),
         fileExtensions = Some(List(".scala", ".sbt"))
       )
@@ -66,7 +66,7 @@ class UpdatesConfigTest extends FunSuite {
         pin = List(ab0, aa0),
         allow = UpdatesConfig.nonExistingUpdatePattern,
         ignore = List(ab0, aa0),
-        limit = Some(PosInt.unsafeFrom(20)),
+        limit = Some(NonNegInt.unsafeFrom(20)),
         includeScala = Some(true),
         fileExtensions = Some(List(".sbt", ".scala"))
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
@@ -1,9 +1,12 @@
 package org.scalasteward.core.util
 
-import munit.FunSuite
+import cats.effect.IO
+import munit.ScalaCheckSuite
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
 import scala.collection.mutable.ListBuffer
 
-class utilTest extends FunSuite {
+class utilTest extends ScalaCheckSuite {
   test("appendBounded") {
     val lb = new ListBuffer[Int]
     lb.appendAll(List(1, 2, 3))
@@ -34,5 +37,14 @@ class utilTest extends FunSuite {
   test("intersects") {
     assert(!intersects(List(1, 3, 5), Vector(2, 4, 6)))
     assert(intersects(List(1, 3, 5), Vector(2, 3, 6)))
+  }
+
+  test("takeUntil") {
+    forAll(Gen.choose(0, 16)) { (n: Int) =>
+      var count = 0
+      val s = fs2.Stream.eval(IO(count += 1)).repeat.through(takeUntil(0, n)(_ => 1))
+      s.compile.drain.unsafeRunSync()
+      assertEquals(count, n)
+    }
   }
 }


### PR DESCRIPTION
This allows the repo config option `updates.limit` to be zero so that it
can now be zero or positive instead of positive only. A zero
`updates.limit` means that Scala Steward will not create or update PRs.
It can be used to temporarily disable Scala Steward in a repo or if it
is used in the default repo config it would be similar to a hypothetical
dry-run option.