### PR TITLE
Add a comment: "Superseded by #" on old PRs when closing them

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -34,6 +34,9 @@ trait VCSApiAlg[F[_]] {
 
   def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]]
 
+  def referencePullRequest(number: PullRequestNumber): String =
+    s"#${number.value}"
+
   def commentPullRequest(repo: Repo, number: PullRequestNumber, comment: String): F[Comment]
 
   final def createForkOrGetRepo(repo: Repo, doNotFork: Boolean): F[RepoOut] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -34,6 +34,8 @@ trait VCSApiAlg[F[_]] {
 
   def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]]
 
+  def commentPullRequest(repo: Repo, number: PullRequestNumber, comment: String): F[Comment]
+
   final def createForkOrGetRepo(repo: Repo, doNotFork: Boolean): F[RepoOut] =
     if (doNotFork) getRepo(repo) else createFork(repo)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -25,6 +25,7 @@ import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.bitbucket.json._
 import org.scalasteward.core.vcs.data._
 
+/** https://developer.atlassian.com/bitbucket/api/2/reference/ */
 class BitbucketApiAlg[F[_]](
     bitbucketApiHost: Uri,
     user: AuthenticatedUser,
@@ -94,4 +95,17 @@ class BitbucketApiAlg[F[_]](
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )
+
+  override def commentPullRequest(
+      repo: Repo,
+      number: PullRequestNumber,
+      comment: String
+  ): F[Comment] =
+    client
+      .postWithBody[CreateComment, CreateComment](
+        url.comments(repo, number),
+        CreateComment(comment),
+        modify(repo)
+      )
+      .map((cc: CreateComment) => Comment(cc.content.raw))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreateComment.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreateComment.scala
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.data
+package org.scalasteward.core.vcs.bitbucket
 
-import org.scalasteward.core.vcs.data.PullRequestNumber
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
 
-sealed trait ProcessResult extends Product with Serializable
+final private[bitbucket] case class CreateComment(content: CommentContent)
+final private[bitbucket] case class CommentContent(raw: String)
 
-object ProcessResult {
-  case object Ignored extends ProcessResult
-  case object Updated extends ProcessResult
-  case class Created(prNumber: PullRequestNumber) extends ProcessResult
+private[bitbucket] object CreateComment {
+  def apply(text: String): CreateComment =
+    CreateComment(CommentContent(text))
+
+  implicit val createCommentCodec: Codec[CreateComment] = deriveCodec
+  implicit val commentContentCodec: Codec[CommentContent] = deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
@@ -38,4 +38,7 @@ private[bitbucket] class Url(apiHost: Uri) {
 
   def repo(repo: Repo): Uri =
     apiHost / "repositories" / repo.owner / repo.repo
+
+  def comments(rep: Repo, number: PullRequestNumber): Uri =
+    pullRequest(rep, number) / "comments"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -100,6 +100,19 @@ class BitbucketServerApiAlg[F[_]](
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )
+
+  override def commentPullRequest(
+      repo: Repo,
+      number: PullRequestNumber,
+      comment: String
+  ): F[Comment] =
+    client
+      .postWithBody[Json.Comment, Json.Comment](
+        url.comments(repo, number),
+        Json.Comment(comment),
+        modify(repo)
+      )
+      .map((c: Json.Comment) => Comment(c.text))
 }
 
 final class StashUrls(base: Uri) {
@@ -127,4 +140,7 @@ final class StashUrls(base: Uri) {
 
   def listBranch(r: Repo, branch: Branch): Uri =
     branches(r).withQueryParam("filterText", branch.name)
+
+  def comments(repo: Repo, number: PullRequestNumber): Uri =
+    pullRequest(repo, number) / "comments"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Json.scala
@@ -67,6 +67,8 @@ object Json {
 
   case class Branch(id: String, latestCommit: Sha1)
 
+  case class Comment(text: String)
+
   implicit def pageDecode[A: Decoder]: Decoder[Page[A]] = deriveDecoder
   implicit val repoDecode: Decoder[Repo] = deriveDecoder
   implicit val projectDecode: Decoder[Project] = deriveDecoder
@@ -79,6 +81,7 @@ object Json {
   implicit val conditionDecoder: Decoder[Condition] = deriveDecoder
   implicit val branchDecoder: Decoder[Branch] = deriveDecoder
   implicit val branchesDecoder: Decoder[Branches] = deriveDecoder
+  implicit val commentDecoder: Decoder[Comment] = deriveDecoder
 
   implicit val encodeNewPR: Encoder[NewPR] = deriveEncoder
   implicit val encodeRef: Encoder[Ref] = deriveEncoder
@@ -86,4 +89,5 @@ object Json {
   implicit val encodeProject: Encoder[Project] = deriveEncoder
   implicit val encodeReviewer: Encoder[Reviewer] = deriveEncoder
   implicit val encodeUser: Encoder[User] = deriveEncoder
+  implicit val encodeComment: Encoder[Comment] = deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Comment.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Comment.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.data
+package org.scalasteward.core.vcs.data
 
-import org.scalasteward.core.vcs.data.PullRequestNumber
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
 
-sealed trait ProcessResult extends Product with Serializable
+final case class Comment(
+    body: String
+)
 
-object ProcessResult {
-  case object Ignored extends ProcessResult
-  case object Updated extends ProcessResult
-  case class Created(prNumber: PullRequestNumber) extends ProcessResult
+object Comment {
+  implicit val commentCodec: Codec[Comment] = deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
@@ -57,4 +57,14 @@ final class GitHubApiAlg[F[_]](
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )
+
+  /** https://developer.github.com/v3/issues#create-an-issue-comment */
+  override def commentPullRequest(
+      repo: Repo,
+      number: PullRequestNumber,
+      comment: String
+  ): F[Comment] =
+    client
+      .postWithBody(url.comments(repo, number), Comment(comment), modify(repo))
+
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
@@ -41,4 +41,7 @@ class Url(apiHost: Uri) {
 
   def repos(repo: Repo): Uri =
     apiHost / "repos" / repo.owner / repo.repo
+
+  def comments(repo: Repo, number: PullRequestNumber): Uri =
+    repos(repo) / "issues" / number.toString / "comments"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -218,6 +218,9 @@ class GitLabApiAlg[F[_]](
   def getRepo(repo: Repo): F[RepoOut] =
     client.get(url.repos(repo), modify(repo))
 
+  override def referencePullRequest(number: PullRequestNumber): String =
+    s"!${number.value}"
+
   // https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note
   override def commentPullRequest(
       repo: Repo,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -217,4 +217,13 @@ class GitLabApiAlg[F[_]](
 
   def getRepo(repo: Repo): F[RepoOut] =
     client.get(url.repos(repo), modify(repo))
+
+  // https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note
+  override def commentPullRequest(
+      repo: Repo,
+      number: PullRequestNumber,
+      comment: String
+  ): F[Comment] =
+    client.postWithBody(url.comments(repo, number), Comment(comment), modify(repo))
+
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
@@ -49,4 +49,7 @@ class Url(apiHost: Uri) {
 
   def repos(repo: Repo): Uri =
     apiHost / "projects" / s"${repo.owner}/${repo.repo}"
+
+  def comments(repo: Repo, number: PullRequestNumber): Uri =
+    existingMergeRequest(repo, number) / "notes"
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -137,6 +137,13 @@ class BitbucketApiAlgTest extends FunSuite {
             }
         }"""
       )
+    case POST -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" /
+        IntVar(_) / "comments" =>
+      Created(json"""{
+                  "content": { 
+                      "raw": "Superseded by #1234"
+                  } 
+          }""")
   }
 
   implicit val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
@@ -218,5 +225,12 @@ class BitbucketApiAlgTest extends FunSuite {
   test("closePullRequest") {
     val pr = bitbucketApiAlg.closePullRequest(repo, PullRequestNumber(1)).unsafeRunSync()
     assertEquals(pr, pr.copy(state = PullRequestState.Closed))
+  }
+
+  test("commentPullRequest") {
+    val comment = bitbucketApiAlg
+      .commentPullRequest(repo, PullRequestNumber(1), "Superseded by #1234")
+      .unsafeRunSync()
+    assertEquals(comment, Comment("Superseded by #1234"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -23,6 +23,11 @@ class BitbucketServerApiAlgTest extends FunSuite {
            |    "links": { "self": [ { "href": "http://example.org" } ] }
            |  }
            |]}""".stripMargin)
+
+    case POST -> Root / "rest" / "api" / "1.0" / "projects" / repo.owner / "repos" / repo.repo / "pull-requests" / IntVar(
+          _
+        ) / "comments" =>
+      Created("""{ "text": "Superseded by #1234" }""")
   }
 
   implicit private val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
@@ -45,5 +50,12 @@ class BitbucketServerApiAlgTest extends FunSuite {
     )
 
     assertEquals(pullRequests, expected)
+  }
+
+  test("commentPullRequest") {
+    val comment = bitbucketServerApiAlg
+      .commentPullRequest(repo, PullRequestNumber(1347), "Superseded by #1234")
+      .unsafeRunSync()
+    assertEquals(comment, Comment("Superseded by #1234"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -138,6 +138,11 @@ class GitHubApiAlgTest extends FunSuite {
   }
 
   test("commentPullRequest") {
+    val reference = gitHubApiAlg.referencePullRequest(PullRequestNumber(1347))
+    assertEquals(reference, "#1347")
+  }
+
+  test("commentPullRequest") {
     val comment = gitHubApiAlg
       .commentPullRequest(repo, PullRequestNumber(1347), "Superseded by #1234")
       .unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -71,6 +71,11 @@ class GitHubApiAlgTest extends FunSuite {
           } """
         )
 
+      case POST -> Root / "repos" / "fthomas" / "base.g8" / "issues" / IntVar(_) / "comments" =>
+        Created(json"""  {
+            "body": "Superseded by #1234"
+          } """)
+
       case req =>
         println(req.toString())
         NotFound()
@@ -130,5 +135,12 @@ class GitHubApiAlgTest extends FunSuite {
   test("closePullRequest") {
     val prOut = gitHubApiAlg.closePullRequest(repo, PullRequestNumber(1347)).unsafeRunSync()
     assertEquals(prOut.state, PullRequestState.Closed)
+  }
+
+  test("commentPullRequest") {
+    val comment = gitHubApiAlg
+      .commentPullRequest(repo, PullRequestNumber(1347), "Superseded by #1234")
+      .unsafeRunSync()
+    assertEquals(comment, Comment("Superseded by #1234"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -64,6 +64,11 @@ class GitLabApiAlgTest extends FunSuite {
           )
         )
 
+      case POST -> Root / "projects" / "foo/bar" / "merge_requests" / "150" / "notes" =>
+        Ok(json"""  {
+            "body": "Superseded by #1234"
+          } """)
+
       case req =>
         println(req.toString())
         NotFound()
@@ -203,6 +208,13 @@ class GitLabApiAlgTest extends FunSuite {
     )
 
     assertEquals(prOut, expected)
+  }
+
+  test("commentPullRequest") {
+    val comment = gitlabApiAlg
+      .commentPullRequest(Repo("foo", "bar"), PullRequestNumber(150), "Superseded by #1234")
+      .unsafeRunSync()
+    assertEquals(comment, Comment("Superseded by #1234"))
   }
 
   val getMr = json"""

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -211,6 +211,11 @@ class GitLabApiAlgTest extends FunSuite {
   }
 
   test("commentPullRequest") {
+    val reference = gitlabApiAlg.referencePullRequest(PullRequestNumber(1347))
+    assertEquals(reference, "!1347")
+  }
+
+  test("commentPullRequest") {
     val comment = gitlabApiAlg
       .commentPullRequest(Repo("foo", "bar"), PullRequestNumber(150), "Superseded by #1234")
       .unsafeRunSync()


### PR DESCRIPTION
Before closing an obsolete PR add a comment to reference the newer PR.

I'm not sure if the `commentPullRequest` should have a return value. But at least is simplifies the testing.

Fixes #1674