### PR TITLE
KVStore: delete JSON file when setting no value

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
@@ -52,7 +52,12 @@ final class JsonKeyValueStore[F[_], K, V](
     }
 
   override def set(key: K, value: Option[V]): F[Unit] =
-    jsonFile(key).flatMap(fileAlg.writeFile(_, value.asJson.toString))
+    jsonFile(key).flatMap { file =>
+      value match {
+        case Some(v) => fileAlg.writeFile(file, v.asJson.toString)
+        case None    => fileAlg.deleteForce(file)
+      }
+    }
 
   private def jsonFile(key: K): F[File] = {
     val keyPath = maybePrefix.fold("")(_ + "/") + keyEncoder(key)

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -15,11 +15,11 @@ class JsonKeyValueStoreTest extends FunSuite {
       v3 <- kvStore.get("k3")
     } yield (v1, v3)
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
+    assertEquals(value, (Some("v1"), None))
 
     val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
     val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
     val k3File = config.workspace / "store" / "test" / "v0" / "k3" / "test.json"
-    assertEquals(value, Some("v1") -> None)
     val expected = MockState.empty.copy(
       commands = Vector(
         List("write", k1File.toString),


### PR DESCRIPTION
Subsequent reads will not need to read a file that only contains `null`.