### PR TITLE
Add caching layer to pull requests store

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/CachingKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/CachingKeyValueStore.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2020 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.persistence
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import cats.{Eq, Monad}
+
+final class CachingKeyValueStore[F[_], K, V](
+    underlying: KeyValueStore[F, K, V],
+    cache: Ref[F, Option[(K, Option[V])]]
+)(implicit kEq: Eq[K], F: Monad[F])
+    extends KeyValueStore[F, K, V] {
+  override def get(key: K): F[Option[V]] =
+    cache.get.flatMap {
+      case Some((cachedKey, cachedValue)) if cachedKey === key =>
+        F.pure(cachedValue)
+      case _ =>
+        underlying.get(key).flatTap(value => cache.set(Some(key -> value)))
+    }
+
+  override def set(key: K, value: Option[V]): F[Unit] =
+    underlying.set(key, value) >> cache.set(Some(key -> value))
+}
+
+object CachingKeyValueStore {
+  def wrap[F[_], K, V](
+      underlying: KeyValueStore[F, K, V]
+  )(implicit kEq: Eq[K], F: Sync[F]): F[KeyValueStore[F, K, V]] =
+    Ref[F].of(Option.empty[(K, Option[V])]).map(new CachingKeyValueStore[F, K, V](underlying, _))
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -16,6 +16,7 @@
 
 package org.scalasteward.core.vcs.data
 
+import cats.Eq
 import io.circe.{KeyDecoder, KeyEncoder}
 
 final case class Repo(
@@ -26,6 +27,9 @@ final case class Repo(
 }
 
 object Repo {
+  implicit val repoEq: Eq[Repo] =
+    Eq.fromUniversalEquals
+
   implicit val repoKeyDecoder: KeyDecoder[Repo] = {
     val / = s"(.+)/([^/]+)".r
     KeyDecoder.instance {

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -64,13 +64,15 @@ class JsonKeyValueStoreTest extends FunSuite {
       )
       _ <- kvStore.put("k1", "v1")
       v1 <- kvStore.get("k1")
-    } yield v1
+      v2 <- kvStore.get("k2")
+    } yield (v1, v2)
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
-    assertEquals(value, Some("v1"))
+    assertEquals(value, (Some("v1"), None))
 
     val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
+    val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
     val expected = MockState.empty.copy(
-      commands = Vector(List("write", k1File.toString)),
+      commands = Vector(List("write", k1File.toString), List("read", k2File.toString)),
       files = Map(k1File -> """"v1"""")
     )
     assertEquals(state, expected)


### PR DESCRIPTION
The `pull_requests` key value store is repeatedly accessed in
`PruningAlg` with the same key. This happens when we're looking for
already existing PRs which means that the same JSON file is repeatedly
read and decoded. This PR adds a caching layer to the `pull_requests`
store that caches the value of last accessed key.