### PR TITLE
Add note and label for old version numbers

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -178,6 +178,7 @@ final class NurtureAlg[F[_]](config: Config)(implicit
         existingArtifactUrlsMap
           .get(data.update.mainArtifactId)
           .traverse(vcsExtraAlg.getReleaseRelatedUrls(_, data.update))
+      filesWithOldVersion <- gitAlg.findFilesContaining(data.repo, data.update.currentVersion)
       branchName = vcs.createBranch(config.vcsType, data.fork, data.update)
       migrations = migrationAlg.findMigrations(data.update)
       requestData = NewPullRequestData.from(
@@ -185,7 +186,8 @@ final class NurtureAlg[F[_]](config: Config)(implicit
         branchName,
         existingArtifactUrlsMap,
         releaseRelatedUrls.getOrElse(List.empty),
-        migrations
+        migrations,
+        filesWithOldVersion
       )
       pr <- vcsApiAlg.createPullRequest(data.repo, requestData)
       _ <- pullRequestRepository.createOrUpdate(

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -180,4 +180,35 @@ class NewPullRequestDataTest extends FunSuite {
       "scalafix-rule-update"
     )
   }
+
+  test("oldVersionNote without files") {
+    val files = List.empty
+    val update = Update.Single("com.example" % "foo" % "0.1", Nel.of("0.2"))
+
+    assertEquals(NewPullRequestData.oldVersionNote(files, update), (None, None))
+  }
+
+  test("oldVersionNote with files") {
+    val files = List("Readme.md", "travis.yml")
+    val update = Update.Single("com.example" % "foo" % "0.1", Nel.of("0.2"))
+
+    val (label, note) = NewPullRequestData.oldVersionNote(files, update)
+
+    assertEquals(label, Some("old-version-remains"))
+    assertEquals(
+      note.fold("")(_.toHtml),
+      """<details>
+        |<summary>Files still referring to the old version number</summary>
+        |
+        |The following files still refer to the old version number (0.2).
+        |You might want to review and update them manually.
+        |```
+        |Readme.md
+        |travis.yml
+        |```
+        |
+        |</details>
+      """.stripMargin.trim
+    )
+  }
 }


### PR DESCRIPTION
Add a note and a label to a pull request, if the source still contains the old version number.

Fixes #1006 

thanks @DStranger for starting this