### PR TITLE
Remove branch if PR is closed by project maintainer

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -100,7 +100,8 @@ final class NurtureAlg[F[_]](config: Config)(implicit
       pullRequests <- vcsApiAlg.listPullRequests(data.repo, head, data.baseBranch)
       result <- pullRequests.headOption match {
         case Some(pr) if pr.isClosed =>
-          logger.info(s"PR ${pr.html_url} is closed") >> F.pure[ProcessResult](Ignored)
+          logger.info(s"PR ${pr.html_url} is closed") >>
+            gitAlg.removeBranch(data.repo, data.updateBranch).as(Ignored)
         case Some(pr) =>
           logger.info(s"Found PR ${pr.html_url}") >> updatePullRequest(data)
         case None =>


### PR DESCRIPTION
Removes the remote update branch if we detect that a PR has been closed without merging.

See also #1793.