### PR TITLE
Show duration a repo is skipped in RefreshErrorAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -16,40 +16,56 @@
 
 package org.scalasteward.core.repocache
 
-import cats.Monad
+import cats.effect.MonadThrow
 import cats.syntax.all._
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.repocache.RefreshErrorAlg.Entry
+import org.scalasteward.core.util.dateTime.showDuration
 import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
 import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 final class RefreshErrorAlg[F[_]](kvStore: KeyValueStore[F, Repo, Entry])(implicit
     dateTimeAlg: DateTimeAlg[F],
-    F: Monad[F]
+    F: MonadThrow[F]
 ) {
-  def failedRecently(repo: Repo): F[Boolean] =
-    kvStore.get(repo).flatMap {
-      case None => F.pure(false)
-      case Some(entry) =>
-        dateTimeAlg.currentTimestamp.flatMap { now =>
-          if (entry.hasExpired(now)) kvStore.set(repo, None).as(false)
-          else F.pure(true)
-        }
+  def skipIfFailedRecently[A](repo: Repo)(fa: F[A]): F[A] =
+    failedRecently(repo).flatMap {
+      case None => fa
+      case Some(fd) =>
+        val msg = s"Skipping due to previous error for ${showDuration(fd)}"
+        F.raiseError[A](new Throwable(msg) with NoStackTrace)
     }
 
-  def persistError(repo: Repo, throwable: Throwable): F[Unit] =
-    dateTimeAlg.currentTimestamp.flatMap { now =>
-      kvStore.put(repo, Entry(now, throwable.getMessage))
+  def persistError[A](repo: Repo)(fa: F[A]): F[A] =
+    fa.handleErrorWith { t =>
+      dateTimeAlg.currentTimestamp.flatMap { now =>
+        kvStore.put(repo, Entry(now, t.getMessage))
+      } >> F.raiseError[A](t)
+    }
+
+  private def failedRecently(repo: Repo): F[Option[FiniteDuration]] =
+    kvStore.get(repo).flatMap {
+      case None => F.pure(None)
+      case Some(entry) =>
+        dateTimeAlg.currentTimestamp.flatMap { now =>
+          entry.expiresIn(now) match {
+            case some @ Some(_) => F.pure(some)
+            case None           => kvStore.set(repo, None).as(None)
+          }
+        }
     }
 }
 
 object RefreshErrorAlg {
   final case class Entry(failedAt: Timestamp, message: String) {
-    def hasExpired(now: Timestamp): Boolean =
-      failedAt.until(now) > 7.days
+    def expiresIn(now: Timestamp): Option[FiniteDuration] = {
+      val duration = 7.days - failedAt.until(now)
+      if (duration.length > 0L) Some(duration) else None
+    }
   }
 
   object Entry {


### PR DESCRIPTION
If there has been a previous error during `RepoCacheAlg.computeCache`, we now log something like this:
```
Skipping due to previous error for 6d 23h 43m 46s 440ms
```
instead of just
```
Skipping due to previous error
```