### PR TITLE
Check Monoid laws for all repoconfig classes

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.{Eq, Semigroup}
+import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
@@ -40,6 +40,6 @@ object CommitsConfig {
   implicit val commitsConfigCodec: Codec[CommitsConfig] =
     deriveConfiguredCodec
 
-  implicit val commitsConfigSemigroup: Semigroup[CommitsConfig] =
-    Semigroup.instance((x, y) => CommitsConfig(message = x.message.orElse(y.message)))
+  implicit val commitsConfigMonoid: Monoid[CommitsConfig] =
+    Monoid.instance(CommitsConfig(), (x, y) => CommitsConfig(message = x.message.orElse(y.message)))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.{Eq, Semigroup}
+import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
@@ -40,6 +40,9 @@ object PullRequestsConfig {
   implicit val pullRequestsConfigCodec: Codec[PullRequestsConfig] =
     deriveConfiguredCodec
 
-  implicit val pullRequestsConfigSemigroup: Semigroup[PullRequestsConfig] =
-    Semigroup.instance((x, y) => PullRequestsConfig(frequency = x.frequency.orElse(y.frequency)))
+  implicit val pullRequestsConfigMonoid: Monoid[PullRequestsConfig] =
+    Monoid.instance(
+      PullRequestsConfig(),
+      (x, y) => PullRequestsConfig(frequency = x.frequency.orElse(y.frequency))
+    )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.{Eq, Semigroup}
+import cats.{Eq, Monoid}
 import cats.syntax.all._
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
@@ -45,19 +45,21 @@ object RepoConfig {
   implicit val repoConfigCodec: Codec[RepoConfig] =
     deriveConfiguredCodec
 
-  implicit val repoConfigSemigroup: Semigroup[RepoConfig] =
-    Semigroup.instance { (x, y) =>
-      () match {
-        case _ if x === empty => y
-        case _ if y === empty => x
-        case _ =>
-          RepoConfig(
-            commits = x.commits |+| y.commits,
-            pullRequests = x.pullRequests |+| y.pullRequests,
-            scalafmt = x.scalafmt |+| y.scalafmt,
-            updates = x.updates |+| y.updates,
-            updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests)
-          )
-      }
-    }
+  implicit val repoConfigMonoid: Monoid[RepoConfig] =
+    Monoid.instance(
+      empty,
+      (x, y) =>
+        () match {
+          case _ if x === empty => y
+          case _ if y === empty => x
+          case _ =>
+            RepoConfig(
+              commits = x.commits |+| y.commits,
+              pullRequests = x.pullRequests |+| y.pullRequests,
+              scalafmt = x.scalafmt |+| y.scalafmt,
+              updates = x.updates |+| y.updates,
+              updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests)
+            )
+        }
+    )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.{Eq, Semigroup}
+import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
@@ -40,8 +40,9 @@ object ScalafmtConfig {
   implicit val scalafmtConfigCodec: Codec[ScalafmtConfig] =
     deriveConfiguredCodec
 
-  implicit val scalafmtConfigSemigroup: Semigroup[ScalafmtConfig] =
-    Semigroup.instance { (x, y) =>
-      ScalafmtConfig(runAfterUpgrading = x.runAfterUpgrading.orElse(y.runAfterUpgrading))
-    }
+  implicit val scalafmtConfigMonoid: Monoid[ScalafmtConfig] =
+    Monoid.instance(
+      ScalafmtConfig(),
+      (x, y) => ScalafmtConfig(runAfterUpgrading = x.runAfterUpgrading.orElse(y.runAfterUpgrading))
+    )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.repoconfig
 
+import cats.Eq
 import cats.implicits._
-import cats.kernel.Eq
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder, HCursor}
 import org.scalasteward.core.data.{GroupId, Update}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CommitsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CommitsConfigTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.laws.discipline.SemigroupTests
+import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
 import org.scalasteward.core.TestInstances._
 
 class CommitsConfigTest extends DisciplineSuite {
-  checkAll("Semigroup[CommitsConfig]", SemigroupTests[CommitsConfig].semigroup)
+  checkAll("Monoid[CommitsConfig]", MonoidTests[CommitsConfig].monoid)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.laws.discipline.SemigroupTests
+import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
 import org.scalasteward.core.TestInstances._
 
 class PullRequestsConfigTest extends DisciplineSuite {
-  checkAll("Semigroup[PullRequestsConfig]", SemigroupTests[PullRequestsConfig].semigroup)
+  checkAll("Monoid[PullRequestsConfig]", MonoidTests[PullRequestsConfig].monoid)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -122,8 +122,8 @@ class RepoConfigAlgTest extends FunSuite {
     val content = """updatePullRequests = foo """
     val config = RepoConfigAlg.parseRepoConfig(content)
     assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.default)))
+      config.map(_.updatePullRequestsOrDefault),
+      Right(PullRequestUpdateStrategy.default)
     )
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
@@ -1,46 +1,9 @@
 package org.scalasteward.core.repoconfig
 
-import cats.syntax.semigroup._
-import munit.FunSuite
-import org.scalasteward.core.data.GroupId
-import scala.concurrent.duration._
+import cats.kernel.laws.discipline.MonoidTests
+import munit.DisciplineSuite
+import org.scalasteward.core.TestInstances._
 
-class RepoConfigTest extends FunSuite {
-  test("RepoConfig: semigroup") {
-    assertEquals(RepoConfig.empty |+| RepoConfig.empty, RepoConfig.empty)
-
-    val cfg = RepoConfig(
-      commits = CommitsConfig(Some("a")),
-      pullRequests = PullRequestsConfig(Some(PullRequestFrequency.Asap)),
-      updates = UpdatesConfig(
-        allow =
-          List(UpdatePattern(GroupId("A"), None, None), UpdatePattern(GroupId("B"), None, None))
-      ),
-      updatePullRequests = Some(PullRequestUpdateStrategy.Always)
-    )
-
-    assertEquals(cfg |+| RepoConfig.empty, cfg)
-    assertEquals(RepoConfig.empty |+| cfg, cfg)
-    assertEquals(cfg |+| cfg, cfg)
-
-    val cfg2 = RepoConfig(
-      commits = CommitsConfig(Some("b")),
-      pullRequests = PullRequestsConfig(Some(PullRequestFrequency.Timespan(1.day))),
-      updates = UpdatesConfig(
-        allow =
-          List(UpdatePattern(GroupId("B"), None, None), UpdatePattern(GroupId("C"), None, None))
-      ),
-      updatePullRequests = Some(PullRequestUpdateStrategy.OnConflicts)
-    )
-
-    assertEquals(
-      cfg |+| cfg2,
-      cfg.copy(updates = UpdatesConfig(allow = List(UpdatePattern(GroupId("B"), None, None))))
-    )
-
-    assertEquals(
-      cfg2 |+| cfg,
-      cfg2.copy(updates = UpdatesConfig(allow = List(UpdatePattern(GroupId("B"), None, None))))
-    )
-  }
+class RepoConfigTest extends DisciplineSuite {
+  checkAll("Monoid[RepoConfig]", MonoidTests[RepoConfig].monoid)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ScalafmtConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ScalafmtConfigTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.repoconfig
 
-import cats.kernel.laws.discipline.SemigroupTests
+import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
 import org.scalasteward.core.TestInstances._
 
 class ScalafmtConfigTest extends DisciplineSuite {
-  checkAll("Semigroup[ScalafmtConfig]", SemigroupTests[ScalafmtConfig].semigroup)
+  checkAll("Monoid[ScalafmtConfig]", MonoidTests[ScalafmtConfig].monoid)
 }


### PR DESCRIPTION
Repoconfig classes are not only semigroups (because they can be merged
with the global repoconfig) but also monoids because the empty
`RepoConfig` should be the identity element with regards to merging
configs. That means that merging with the empty `RepoConfig` should not
change a repo-specific config.

This change promotes all `Semigroup` instances of config classes to
`Monoid`s and checks the monoid laws for all of them.
`UpdatesConfig.mergePin` and `UpdatesConfig.mergeIgnore` needed small
adjustments so that they satisfy the left and right identity laws.