### PR TITLE
Rename HttpExistenceClient to UrlChecker

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -56,8 +56,7 @@ object Context {
       _ <- Resource.liftF(printBanner[F])
       config <- Resource.pure(Config.from(args))
       implicit0(client: Client[F]) <- OkHttpBuilder.withDefaultClient[F](blocker).map(_.create)
-      implicit0(httpExistenceClient: HttpExistenceClient[F]) <-
-        HttpExistenceClient.create[F](config)
+      implicit0(urlChecker: UrlChecker[F]) <- UrlChecker.create[F](config)
       implicit0(user: AuthenticatedUser) <- Resource.liftF(config.vcsUser[F])
       implicit0(fileAlg: FileAlg[F]) = FileAlg.create[F]
       implicit0(migrationAlg: MigrationAlg) <-

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -21,7 +21,7 @@ import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
-import org.scalasteward.core.util.HttpExistenceClient
+import org.scalasteward.core.util.UrlChecker
 import org.scalasteward.core.vcs
 
 trait VCSExtraAlg[F[_]] {
@@ -30,13 +30,13 @@ trait VCSExtraAlg[F[_]] {
 
 object VCSExtraAlg {
   def create[F[_]](config: Config)(implicit
-      existenceClient: HttpExistenceClient[F],
+      urlChecker: UrlChecker[F],
       F: Monad[F]
   ): VCSExtraAlg[F] =
     new VCSExtraAlg[F] {
       override def getReleaseRelatedUrls(repoUrl: Uri, update: Update): F[List[ReleaseRelatedUrl]] =
         vcs
           .possibleReleaseRelatedUrls(config.vcsType, config.vcsApiHost, repoUrl, update)
-          .filterA(releaseRelatedUrl => existenceClient.exists(releaseRelatedUrl.url))
+          .filterA(releaseRelatedUrl => urlChecker.exists(releaseRelatedUrl.url))
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -11,7 +11,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.SupportedVCS
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
 import org.scalasteward.core.mock.MockContext
-import org.scalasteward.core.util.{HttpExistenceClient, Nel}
+import org.scalasteward.core.util.{Nel, UrlChecker}
 
 class VCSExtraAlgTest extends FunSuite {
   val routes: HttpRoutes[IO] =
@@ -22,8 +22,8 @@ class VCSExtraAlgTest extends FunSuite {
     }
 
   implicit val client: Client[IO] = Client.fromHttpApp[IO](routes.orNotFound)
-  implicit val httpExistenceClient: HttpExistenceClient[IO] =
-    HttpExistenceClient.create[IO](MockContext.config).allocated.map(_._1).unsafeRunSync()
+  implicit val urlChecker: UrlChecker[IO] =
+    UrlChecker.create[IO](MockContext.config).allocated.map(_._1).unsafeRunSync()
 
   private val updateFoo = Update.Single("com.example" % "foo" % "0.1.0", Nel.of("0.2.0"))
   private val updateBar = Update.Single("com.example" % "bar" % "0.1.0", Nel.of("0.2.0"))


### PR DESCRIPTION
The new name is shorter and IMO better expresses what the class is about: it **checks** if **url**s exist.