### PR TITLE
Do not read RepoCache and RepoConfig twice

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -17,20 +17,21 @@
 package org.scalasteward.core.application
 
 import better.files.File
-import cats.effect.BracketThrow
-import cats.effect.ExitCode
+import cats.effect.{BracketThrow, ExitCode}
 import cats.syntax.all._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.buildtool.sbt.SbtAlg
+import org.scalasteward.core.data.RepoData
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
 import org.scalasteward.core.repocache.RepoCacheAlg
+import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.update.PruningAlg
 import org.scalasteward.core.util
-import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.util.DateTimeAlg
+import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.vcs.github.{GitHubApp, GitHubAppApiAlg, GitHubAuthAlg}
 import scala.concurrent.duration._
@@ -45,6 +46,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
     nurtureAlg: NurtureAlg[F],
     pruningAlg: PruningAlg[F],
     repoCacheAlg: RepoCacheAlg[F],
+    repoConfigAlg: RepoConfigAlg[F],
     sbtAlg: SbtAlg[F],
     selfCheckAlg: SelfCheckAlg[F],
     streamCompiler: Stream.Compiler[F, F],
@@ -89,8 +91,10 @@ final class StewardAlg[F[_]](config: Config)(implicit
         F.guarantee {
           for {
             (cache, fork) <- repoCacheAlg.checkCache(repo)
-            (attentionNeeded, updates) <- pruningAlg.needsAttention(repo, cache)
-            _ <- if (attentionNeeded) nurtureAlg.nurture(repo, fork, updates) else F.unit
+            config <- repoConfigAlg.mergeWithDefault(cache.maybeRepoConfig)
+            data = RepoData(repo, cache, config)
+            (attentionNeeded, updates) <- pruningAlg.needsAttention(data)
+            _ <- if (attentionNeeded) nurtureAlg.nurture(data, fork, updates) else F.unit
           } yield ()
         }(gitAlg.removeClone(repo))
       }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018-2021 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.data
+
+import org.scalasteward.core.repocache.RepoCache
+import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.vcs.data.Repo
+
+final case class RepoData(
+    repo: Repo,
+    cache: RepoCache,
+    config: RepoConfig
+)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.nurture
+package org.scalasteward.core.data
 
-import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.vcs.data.Repo
 
 final case class UpdateData(
-    repo: Repo,
+    repoData: RepoData,
     fork: Repo,
-    repoConfig: RepoConfig,
     update: Update,
     baseBranch: Branch,
     baseSha1: Sha1,
     updateBranch: Branch
-)
+) {
+  def repo: Repo = repoData.repo
+  def repoConfig: RepoConfig = repoData.config
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -34,9 +34,6 @@ final class RepoConfigAlg[F[_]](config: Config)(implicit
     workspaceAlg: WorkspaceAlg[F],
     F: MonadThrow[F]
 ) {
-  def readRepoConfigWithDefault(repo: Repo): F[RepoConfig] =
-    readRepoConfig(repo).flatMap(mergeWithDefault)
-
   def mergeWithDefault(maybeRepoConfig: Option[RepoConfig]): F[RepoConfig] =
     readDefaultRepoConfig.map { maybeDefault =>
       (maybeRepoConfig |+| maybeDefault).getOrElse(RepoConfig.empty)

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -20,10 +20,9 @@ import cats.syntax.all._
 import io.circe.Encoder
 import io.circe.generic.semiauto._
 import org.http4s.Uri
-import org.scalasteward.core.data.{GroupId, ReleaseRelatedUrl, SemVer, Update}
+import org.scalasteward.core.data.{GroupId, ReleaseRelatedUrl, SemVer, Update, UpdateData}
 import org.scalasteward.core.git
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Details

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -9,6 +9,9 @@ import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.data.{GroupId, Resolver, Scope, Update, Version}
+import org.scalasteward.core.git.Sha1
+import org.scalasteward.core.git.Sha1.HexString
+import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
 import org.scalasteward.core.repoconfig._
 import org.scalasteward.core.util.Change.{Changed, Unchanged}
@@ -17,6 +20,13 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 object TestInstances {
+  val dummyRepoCache: RepoCache =
+    RepoCache(
+      Sha1(HexString.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709")),
+      List.empty,
+      Option.empty
+    )
+
   implicit def changeArbitrary[T](implicit arbT: Arbitrary[T]): Arbitrary[Change[T]] =
     Arbitrary(arbT.arbitrary.flatMap(t => Gen.oneOf(Changed(t), Unchanged(t))))
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -31,7 +31,7 @@ class RepoConfigAlgTest extends FunSuite {
          |commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
          |""".stripMargin
     val initialState = MockState.empty.add(configFile, content)
-    val config = repoConfigAlg.readRepoConfigWithDefault(repo).runA(initialState).unsafeRunSync()
+    val config = repoConfigAlg.readRepoConfig(repo).runA(initialState).unsafeRunSync()
 
     val expected = RepoConfig(
       pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(7.days))),
@@ -70,146 +70,113 @@ class RepoConfigAlgTest extends FunSuite {
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
       )
     )
-    assertEquals(config, expected)
+    assertEquals(config, Some(expected))
   }
 
   test("config with 'updatePullRequests = false'") {
     val content = "updatePullRequests = false"
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Never)))
-    )
+    val expected = RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Never))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = true'") {
     val content = "updatePullRequests = true"
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.OnConflicts)))
-    )
+    val expected = RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.OnConflicts))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = always'") {
     val content = """updatePullRequests = "always" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Always)))
-    )
+    val expected = RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Always))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = on-conflicts'") {
     val content = """updatePullRequests = "on-conflicts" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.OnConflicts)))
-    )
+    val expected = RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.OnConflicts))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = never'") {
     val content = """updatePullRequests = "never" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Never)))
-    )
+    val expected = RepoConfig(updatePullRequests = Some(PullRequestUpdateStrategy.Never))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = foo'") {
     val content = """updatePullRequests = foo """
-    val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config.map(_.updatePullRequestsOrDefault),
-      Right(PullRequestUpdateStrategy.default)
-    )
+    val obtained = RepoConfigAlg.parseRepoConfig(content).map(_.updatePullRequestsOrDefault)
+    val expected = PullRequestUpdateStrategy.default
+    assertEquals(obtained, Right(expected))
   }
 
   test("config with 'pullRequests.frequency = @asap'") {
     val content = """pullRequests.frequency = "@asap" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(
-        RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Asap)))
-      )
-    )
+    val expected =
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Asap)))
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'pullRequests.frequency = @daily'") {
     val content = """pullRequests.frequency = "@daily" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(
-        RepoConfig(pullRequests =
-          PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(1.day)))
-        )
-      )
+    val expected = RepoConfig(pullRequests =
+      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(1.day)))
     )
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'pullRequests.frequency = @monthly'") {
     val content = """pullRequests.frequency = "@monthly" """
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(
-        RepoConfig(pullRequests =
-          PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(30.days)))
-        )
-      )
+    val expected = RepoConfig(pullRequests =
+      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(30.days)))
     )
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'scalafmt.runAfterUpgrading = true'") {
     val content = "scalafmt.runAfterUpgrading = true"
     val config = RepoConfigAlg.parseRepoConfig(content)
-    assertEquals(
-      config,
-      Right(
-        RepoConfig(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(true)))
-      )
-    )
+    val expected = RepoConfig(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(true)))
+    assertEquals(config, Right(expected))
   }
 
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
     val initialState = MockState.empty.add(configFile, """updates.ignore = [ "foo """)
-    val (state, config) =
-      repoConfigAlg.readRepoConfigWithDefault(repo).run(initialState).unsafeRunSync()
+    val (state, config) = repoConfigAlg.readRepoConfig(repo).run(initialState).unsafeRunSync()
 
-    assertEquals(config, RepoConfig())
+    assertEquals(config, None)
     val log = state.logs.headOption.map { case (_, msg) => msg }.getOrElse("")
     assert(clue(log).startsWith("Failed to parse .scala-steward.conf"))
   }
 
   test("configToIgnoreFurtherUpdates with single update") {
     val update = Update.Single("a" % "b" % "c", Nel.of("d"))
-    val repoConfig = RepoConfigAlg
+    val config = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
-
-    assertEquals(
-      repoConfig,
-      RepoConfig(updates =
-        UpdatesConfig(ignore = List(UpdatePattern(GroupId("a"), Some("b"), None)))
-      )
+    val expected = RepoConfig(updates =
+      UpdatesConfig(ignore = List(UpdatePattern(GroupId("a"), Some("b"), None)))
     )
+    assertEquals(config, expected)
   }
 
   test("configToIgnoreFurtherUpdates with group update") {
     val update = Update.Group("a" % Nel.of("b", "e") % "c", Nel.of("d"))
-    val repoConfig = RepoConfigAlg
+    val config = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
-
-    assertEquals(
-      repoConfig,
+    val expected =
       RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern(GroupId("a"), None, None))))
-    )
+    assertEquals(config, expected)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -31,7 +31,11 @@ class RepoConfigAlgTest extends FunSuite {
          |commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
          |""".stripMargin
     val initialState = MockState.empty.add(configFile, content)
-    val config = repoConfigAlg.readRepoConfig(repo).runA(initialState).unsafeRunSync()
+    val config = repoConfigAlg
+      .readRepoConfig(repo)
+      .flatMap(repoConfigAlg.mergeWithDefault)
+      .runA(initialState)
+      .unsafeRunSync()
 
     val expected = RepoConfig(
       pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(7.days))),
@@ -70,7 +74,7 @@ class RepoConfigAlgTest extends FunSuite {
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
       )
     )
-    assertEquals(config, Some(expected))
+    assertEquals(config, expected)
   }
 
   test("config with 'updatePullRequests = false'") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -3,11 +3,11 @@ package org.scalasteward.core.vcs.data
 import io.circe.syntax._
 import munit.FunSuite
 import org.http4s.syntax.literals._
+import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data.{ReleaseRelatedUrl, Update, Version}
+import org.scalasteward.core.data._
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Nel
@@ -15,9 +15,8 @@ import org.scalasteward.core.util.Nel
 class NewPullRequestDataTest extends FunSuite {
   test("asJson") {
     val data = UpdateData(
-      Repo("foo", "bar"),
+      RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),
-      RepoConfig(),
       Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3")),
       Branch("master"),
       Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -13,12 +13,12 @@ import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.headers.Allow
 import org.http4s.implicits._
+import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{RepoData, Update, UpdateData}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockContext.{config, user}
-import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.{HttpJsonClient, Nel}
 import org.scalasteward.core.vcs.data._
@@ -88,9 +88,8 @@ class GitLabApiAlgTest extends FunSuite {
     )
 
   private val data = UpdateData(
-    Repo("foo", "bar"),
+    RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
     Repo("scala-steward", "bar"),
-    RepoConfig(),
     Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3")),
     Branch("master"),
     Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),


### PR DESCRIPTION
This removes `RepoCacheAlg` and `RepoConfigAlg` from `NurtureAlg` which were used to read the repo cache and repo config again. Both have been read before in `RepoCacheAlg` and `PruningAlg` and it is wasteful to do the same again in `NurtureAlg`. Both are now passed as part of a new `RepoData` class to `NurtureAlg`.