### PR TITLE
Create commit for Scalafix migration even if it failed

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -30,6 +30,7 @@ import org.scalasteward.core.io.{isSourceFile, FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafix.{Migration, MigrationAlg}
 import org.scalasteward.core.util._
+import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.vcs.data.Repo
 
 final class EditAlg[F[_]](implicit
@@ -83,15 +84,15 @@ final class EditAlg[F[_]](implicit
 
   private def runScalafixMigrations(repo: Repo, migrations: List[Migration]): F[List[Commit]] =
     migrations.traverseFilter { migration =>
-      logger.info(s"Running migration $migration") >>
-        buildToolDispatcher.runMigrations(repo, Nel.one(migration)).attempt.flatMap {
-          case Right(_) =>
-            val msg1 = s"Run Scalafix rule(s) ${migration.rewriteRules.mkString_(", ")}"
-            val msg2 = migration.doc.map(url => s"See $url for details").toList
-            gitAlg.commitAllIfDirty(repo, msg1, msg2: _*)
-          case Left(throwable) =>
-            logger.error(throwable)("Scalafix migration failed").as(None)
+      for {
+        _ <- logger.info(s"Running migration $migration")
+        _ <- logger.attemptLogWarn_("Scalafix migration failed") {
+          buildToolDispatcher.runMigrations(repo, Nel.one(migration))
         }
+        msg1 = s"Run Scalafix rule(s) ${migration.rewriteRules.mkString_(", ")}"
+        msg2 = migration.doc.map(url => s"See $url for details").toList
+        maybeCommit <- gitAlg.commitAllIfDirty(repo, msg1, msg2: _*)
+      } yield maybeCommit
     }
 
   private def bumpVersion(update: Update, files: Nel[File]): F[Boolean] = {


### PR DESCRIPTION
https://github.com/johnynek/bosatsu/pull/648 contains changes from a
Scalafix migration that exited with a non-zero status code in the same
commit as the version bump. Migration changes and the version bump
are supposed to be in separate commits but weren't because we're
currently only creating the Scalafix commit if it exited without an
error. This change always commits after a Scalafix migration regardless
of its exit status.