### PR TITLE
Make RepoConfig.buildRoots optional

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -48,9 +48,8 @@ object BuildToolDispatcher {
       private def buildRootsForRepo(repo: Repo): F[List[BuildRoot]] = for {
         repoConfigOpt <- repoConfigAlg.readRepoConfig(repo)
         repoConfig <- repoConfigAlg.mergeWithDefault(repoConfigOpt)
-        buildRoots = repoConfig.buildRoots.map(config =>
-          BuildRoot(repo, config.relativeBuildRootPath)
-        )
+        buildRoots = repoConfig.buildRootsOrDefault
+          .map(config => BuildRoot(repo, config.relativePath))
       } yield buildRoots
 
       override def containsBuild(repo: Repo): F[Boolean] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
@@ -19,17 +19,17 @@ package org.scalasteward.core.repoconfig
 import cats.Eq
 import io.circe.{Decoder, Encoder}
 
-final case class BuildRootConfig(relativeBuildRootPath: String)
+final case class BuildRootConfig(relativePath: String)
 
 object BuildRootConfig {
-  val current = BuildRootConfig(".")
+  val repoRoot: BuildRootConfig = BuildRootConfig(".")
 
   implicit val buildRootConfigDecoder: Decoder[BuildRootConfig] =
     Decoder[String].map(BuildRootConfig.apply)
 
-  implicit val buildRootConfigStrategyEncoder: Encoder[BuildRootConfig] =
-    Encoder[String].contramap(_.relativeBuildRootPath)
+  implicit val buildRootConfigEncoder: Encoder[BuildRootConfig] =
+    Encoder[String].contramap(_.relativePath)
 
-  implicit val buildRootConfigStrategyEq: Eq[BuildRootConfig] =
+  implicit val buildRootConfigEq: Eq[BuildRootConfig] =
     Eq.fromUniversalEquals
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -28,8 +28,11 @@ final case class RepoConfig(
     scalafmt: ScalafmtConfig = ScalafmtConfig(),
     updates: UpdatesConfig = UpdatesConfig(),
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
-    buildRoots: List[BuildRootConfig] = List(BuildRootConfig.current)
+    buildRoots: Option[List[BuildRootConfig]] = None
 ) {
+  def buildRootsOrDefault: List[BuildRootConfig] =
+    buildRoots.getOrElse(List(BuildRootConfig.repoRoot))
+
   def updatePullRequestsOrDefault: PullRequestUpdateStrategy =
     updatePullRequests.getOrElse(PullRequestUpdateStrategy.default)
 }
@@ -59,7 +62,8 @@ object RepoConfig {
               pullRequests = x.pullRequests |+| y.pullRequests,
               scalafmt = x.scalafmt |+| y.scalafmt,
               updates = x.updates |+| y.updates,
-              updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests)
+              updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests),
+              buildRoots = x.buildRoots |+| y.buildRoots
             )
         }
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -74,7 +74,7 @@ class RepoConfigAlgTest extends FunSuite {
       commits = CommitsConfig(
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
       ),
-      buildRoots = List(BuildRootConfig("."), BuildRootConfig("subfolder/subfolder"))
+      buildRoots = Some(List(BuildRootConfig.repoRoot, BuildRootConfig("subfolder/subfolder")))
     )
     assertEquals(config, expected)
   }


### PR DESCRIPTION
For the same reason as given in #1339.