### PR TITLE
BuildToolAlg.runMigrations -> runMigration

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
@@ -18,12 +18,11 @@ package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.scalafix.Migration
-import org.scalasteward.core.util.Nel
 
 trait BuildToolAlg[F[_], R] {
   def containsBuild(r: R): F[Boolean]
 
   def getDependencies(r: R): F[List[Scope.Dependencies]]
 
-  def runMigrations(r: R, migrations: Nel[Migration]): F[Unit]
+  def runMigration(r: R, migration: Migration): F[Unit]
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -24,7 +24,6 @@ import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.data.{Resolver, Scope}
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.vcs.data.BuildRoot
@@ -70,10 +69,10 @@ object BuildToolDispatcher {
           )
         } yield result
 
-      override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] =
+      override def runMigration(repo: Repo, migration: Migration): F[Unit] =
         buildRootsForRepo(repo).flatMap(buildRoots =>
           buildRoots.traverse_(buildRoot =>
-            foundBuildTools(buildRoot).flatMap(_.traverse_(_.runMigrations(buildRoot, migrations)))
+            foundBuildTools(buildRoot).flatMap(_.traverse_(_.runMigration(buildRoot, migration)))
           )
         )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -57,7 +57,7 @@ object MavenAlg {
           resolvers = parser.parseResolvers(repositoriesRaw).distinct
         } yield List(Scope(dependencies, resolvers))
 
-      override def runMigrations(buildRoot: BuildRoot, migrations: Nel[Migration]): F[Unit] =
+      override def runMigration(buildRoot: BuildRoot, migration: Migration): F[Unit] =
         F.unit
 
       def exec(command: Nel[String], repoDir: File): F[List[String]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -67,6 +67,6 @@ object MillAlg {
           )
         } yield parsed.map(module => Scope(module.dependencies, module.repositories))
 
-      override def runMigrations(buildRoot: BuildRoot, migrations: Nel[Migration]): F[Unit] = F.unit
+      override def runMigration(buildRoot: BuildRoot, migration: Migration): F[Unit] = F.unit
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -87,7 +87,7 @@ final class EditAlg[F[_]](implicit
       for {
         _ <- logger.info(s"Running migration $migration")
         _ <- logger.attemptLogWarn_("Scalafix migration failed") {
-          buildToolDispatcher.runMigrations(repo, Nel.one(migration))
+          buildToolDispatcher.runMigration(repo, migration)
         }
         msg1 = s"Run Scalafix rule(s) ${migration.rewriteRules.mkString_(", ")}"
         msg2 = migration.doc.map(url => s"See $url for details").toList

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -63,17 +63,15 @@ class SbtAlgTest extends FunSuite {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.show
-    val migrations = Nel.of(
-      Migration(
-        GroupId("co.fs2"),
-        Nel.of("fs2-core"),
-        Version("1.0.0"),
-        Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"),
-        None,
-        None
-      )
+    val migration = Migration(
+      GroupId("co.fs2"),
+      Nel.of("fs2-core"),
+      Version("1.0.0"),
+      Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"),
+      None,
+      None
     )
-    val state = sbtAlg.runMigrations(buildRoot, migrations).runS(MockState.empty).unsafeRunSync()
+    val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       commands = Vector(
         List("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
@@ -102,17 +100,15 @@ class SbtAlgTest extends FunSuite {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.show
-    val migrations = Nel.of(
-      Migration(
-        GroupId("org.typelevel"),
-        Nel.of("cats-core"),
-        Version("2.2.0"),
-        Nel.of("github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"),
-        None,
-        Some(Nel.of("-P:semanticdb:synthetics:on"))
-      )
+    val migration = Migration(
+      GroupId("org.typelevel"),
+      Nel.of("cats-core"),
+      Version("2.2.0"),
+      Nel.of("github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"),
+      None,
+      Some(Nel.of("-P:semanticdb:synthetics:on"))
     )
-    val state = sbtAlg.runMigrations(buildRoot, migrations).runS(MockState.empty).unsafeRunSync()
+    val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       commands = Vector(
         List("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),


### PR DESCRIPTION
`runMigrations` was always called with a `Nel` of size one because we
want to have a separate commit for each migration. So there is no point
in having `runMigrations` taking a list of migratios instead of only
one.