### PR TITLE
Reuse Context in tests

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -22,7 +22,7 @@ import org.scalasteward.core.application.{Cli, Context}
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     Cli.parseArgs(args) match {
-      case Cli.ParseResult.Success(args) => Context.create[IO](args).use(_.runF)
+      case Cli.ParseResult.Success(args) => Context.resource[IO](args).use(_.stewardAlg.runF)
       case Cli.ParseResult.Help(help)    => IO(Console.out.println(help)).as(ExitCode.Success)
       case Cli.ParseResult.Error(error)  => IO(Console.err.println(error)).as(ExitCode.Error)
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -22,7 +22,7 @@ import org.scalasteward.core.application.{Cli, Context}
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     Cli.parseArgs(args) match {
-      case Cli.ParseResult.Success(args) => Context.resource[IO](args).use(_.stewardAlg.runF)
+      case Cli.ParseResult.Success(args) => Context.step0[IO](args).use(_.stewardAlg.runF)
       case Cli.ParseResult.Help(help)    => IO(Console.out.println(help)).as(ExitCode.Success)
       case Cli.ParseResult.Error(error)  => IO(Console.err.println(error)).as(ExitCode.Error)
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -4,7 +4,8 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Resolver, Scope, Version}
-import org.scalasteward.core.mock.MockContext.{buildToolDispatcher, config}
+import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.buildtool.maven
 import better.files.File
 import munit.FunSuite
 import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.mavenAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -2,7 +2,8 @@ package org.scalasteward.core.buildtool.mill
 
 import munit.FunSuite
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
-import org.scalasteward.core.mock.MockContext.{config, millAlg}
+import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.context.millAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -4,7 +4,8 @@ import cats.data.StateT
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.sbtAlg
+import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -5,7 +5,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.coursierAlg
 import org.scalasteward.core.mock.MockState
 
 class CoursierAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -4,7 +4,8 @@ import better.files.File
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
-import org.scalasteward.core.mock.MockContext.{config, editAlg, envVars}
+import org.scalasteward.core.mock.MockContext.context.editAlg
+import org.scalasteward.core.mock.MockContext.{config, envVars}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtBinary

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -3,7 +3,8 @@ package org.scalasteward.core.edit.hooks
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update
-import org.scalasteward.core.mock.MockContext.{envVars, hookExecutor, workspaceAlg}
+import org.scalasteward.core.mock.MockContext.context.{hookExecutor, workspaceAlg}
+import org.scalasteward.core.mock.MockContext.envVars
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, ScalafmtConfig}
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -7,7 +7,7 @@ import org.http4s.Uri
 import org.scalacheck.Arbitrary
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
-import org.scalasteward.core.mock.MockContext.fileAlg
+import org.scalasteward.core.mock.MockContext.context.fileAlg
 import org.scalasteward.core.mock.MockState
 
 class FileAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,19 +1,16 @@
 package org.scalasteward.core.mock
 
 import better.files.File
-import cats.Parallel
 import cats.effect.{BracketThrow, Sync}
+import cats.{Applicative, Parallel}
 import io.chrisdavenport.log4cats.Logger
-import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioContextShift
 import org.scalasteward.core.application.Cli.EnvVar
-import org.scalasteward.core.application.{Cli, Config, SupportedVCS}
-import org.scalasteward.core.buildtool.BuildToolDispatcher
+import org.scalasteward.core.application.{Cli, Config, Context, SupportedVCS}
 import org.scalasteward.core.buildtool.maven.MavenAlg
-import org.scalasteward.core.buildtool.mill.MillAlg
-import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
-import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.edit.hooks.HookExecutor
 import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io._
@@ -21,48 +18,49 @@ import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.persistence.JsonKeyValueStore
 import org.scalasteward.core.repocache.RepoCacheRepository
 import org.scalasteward.core.repoconfig.RepoConfigAlg
-import org.scalasteward.core.scalafix.{MigrationAlg, MigrationsLoader, MigrationsLoaderTest}
+import org.scalasteward.core.scalafix.MigrationsLoaderTest
 import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.update.{ArtifactMigrations, FilterAlg, PruningAlg, UpdateAlg}
+import org.scalasteward.core.update.{ArtifactMigrations, FilterAlg, UpdateAlg}
 import org.scalasteward.core.util.uri._
-import org.scalasteward.core.util.DateTimeAlg
+import org.scalasteward.core.util.{DateTimeAlg, UrlChecker}
 import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
 object MockContext {
-  val config: Config =
-    Config.from(
-      Cli.Args(
-        workspace = File.temp / "ws",
-        reposFile = File.temp / "repos.md",
-        defaultRepoConf = Some(File.temp / "default.scala-steward.conf"),
-        gitAuthorName = "Bot Doe",
-        gitAuthorEmail = "bot@example.org",
-        vcsType = SupportedVCS.GitHub,
-        vcsApiHost = Uri(),
-        vcsLogin = "bot-doe",
-        gitAskPass = File.temp / "askpass.sh",
-        enableSandbox = Some(true),
-        envVar = List(
-          EnvVar("VAR1", "val1"),
-          EnvVar("VAR2", "val2")
-        ),
-        cacheTtl = 1.hour,
-        githubAppId = Some(12345678),
-        githubAppKeyFile = Some(File("example_app_key"))
-      )
-    )
+  val args: Cli.Args = Cli.Args(
+    workspace = File.temp / "ws",
+    reposFile = File.temp / "repos.md",
+    defaultRepoConf = Some(File.temp / "default.scala-steward.conf"),
+    gitAuthorName = "Bot Doe",
+    gitAuthorEmail = "bot@example.org",
+    vcsType = SupportedVCS.GitHub,
+    vcsApiHost = Uri(),
+    vcsLogin = "bot-doe",
+    gitAskPass = File.temp / "askpass.sh",
+    enableSandbox = Some(true),
+    envVar = List(EnvVar("VAR1", "val1"), EnvVar("VAR2", "val2")),
+    cacheTtl = 1.hour,
+    githubAppId = Some(12345678),
+    githubAppKeyFile = Some(File("example_app_key"))
+  )
+
+  val config: Config = Config.from(args)
 
   val envVars = List(s"GIT_ASKPASS=${config.gitCfg.gitAskPass}", "VAR1=val1", "VAR2=val2")
 
   implicit val mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
   implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
 
+  implicit val client: Client[MockEff] = Client.fromHttpApp(HttpApp.notFound)
   implicit val fileAlg: FileAlg[MockEff] = new MockFileAlg
   implicit val mockLogger: Logger[MockEff] = new MockLogger
   implicit val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
+  implicit val urlChecker: UrlChecker[MockEff] = _ => Applicative[MockEff].pure(false)
   implicit val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
+
+  val context: Context[MockEff] =
+    Context.effect[MockEff](config).runA(MigrationsLoaderTest.mockState).unsafeRunSync()
 
   implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
   implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
@@ -72,12 +70,6 @@ object MockContext {
   implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = new VCSRepoAlg[MockEff](config)
   implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
-  val migrationsLoader: MigrationsLoader[MockEff] = new MigrationsLoader[MockEff]
-  implicit val migrationAlg: MigrationAlg = migrationsLoader
-    .loadAll(config.scalafixCfg)
-    .map(new MigrationAlg(_))
-    .runA(MigrationsLoaderTest.mockState)
-    .unsafeRunSync()
   implicit val cacheRepository: RepoCacheRepository[MockEff] =
     new RepoCacheRepository[MockEff](new JsonKeyValueStore("repo_cache", "1"))
   implicit val filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
@@ -87,11 +79,6 @@ object MockContext {
     ArtifactMigrations.create[MockEff](config).runA(MockState.empty).unsafeRunSync()
   implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
   implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create(config)
-  implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create(config)
-  implicit val millAlg: MillAlg[MockEff] = MillAlg.create
-  implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
-  implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
   implicit val pullRequestRepository: PullRequestRepository[MockEff] =
     new PullRequestRepository[MockEff](new JsonKeyValueStore("pull_requests", "2"))
-  implicit val pruningAlg: PruningAlg[MockEff] = new PruningAlg[MockEff]
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -9,21 +9,9 @@ import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioContextShift
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.{Cli, Config, Context, SupportedVCS}
-import org.scalasteward.core.buildtool.maven.MavenAlg
-import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
-import org.scalasteward.core.edit.hooks.HookExecutor
-import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io._
-import org.scalasteward.core.nurture.PullRequestRepository
-import org.scalasteward.core.persistence.JsonKeyValueStore
-import org.scalasteward.core.repocache.RepoCacheRepository
-import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.scalafix.MigrationsLoaderTest
-import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.update.{ArtifactMigrations, FilterAlg, UpdateAlg}
-import org.scalasteward.core.util.uri._
-import org.scalasteward.core.util.{DateTimeAlg, UrlChecker}
-import org.scalasteward.core.vcs.VCSRepoAlg
+import org.scalasteward.core.util.UrlChecker
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
@@ -44,41 +32,20 @@ object MockContext {
     githubAppId = Some(12345678),
     githubAppKeyFile = Some(File("example_app_key"))
   )
-
   val config: Config = Config.from(args)
-
   val envVars = List(s"GIT_ASKPASS=${config.gitCfg.gitAskPass}", "VAR1=val1", "VAR2=val2")
+  val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
 
   implicit val mockEffBracketThrow: BracketThrow[MockEff] = Sync[MockEff]
   implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
 
-  implicit val client: Client[MockEff] = Client.fromHttpApp(HttpApp.notFound)
-  implicit val fileAlg: FileAlg[MockEff] = new MockFileAlg
-  implicit val mockLogger: Logger[MockEff] = new MockLogger
-  implicit val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
-  implicit val urlChecker: UrlChecker[MockEff] = _ => Applicative[MockEff].pure(false)
-  implicit val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
+  implicit private val client: Client[MockEff] = Client.fromHttpApp(HttpApp.notFound)
+  implicit private val fileAlg: FileAlg[MockEff] = new MockFileAlg
+  implicit private val logger: Logger[MockEff] = new MockLogger
+  implicit private val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
+  implicit private val urlChecker: UrlChecker[MockEff] = _ => Applicative[MockEff].pure(false)
+  implicit private val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
 
   val context: Context[MockEff] =
-    Context.effect[MockEff](config).runA(MigrationsLoaderTest.mockState).unsafeRunSync()
-
-  implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
-  implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
-  implicit val gitAlg: GitAlg[MockEff] = GenGitAlg.create(config.gitCfg)
-  implicit val hookExecutor: HookExecutor[MockEff] = new HookExecutor[MockEff]
-  implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
-  implicit val vcsRepoAlg: VCSRepoAlg[MockEff] = new VCSRepoAlg[MockEff](config)
-  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff](config)
-  implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
-  implicit val cacheRepository: RepoCacheRepository[MockEff] =
-    new RepoCacheRepository[MockEff](new JsonKeyValueStore("repo_cache", "1"))
-  implicit val filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
-  implicit val versionsCache: VersionsCache[MockEff] =
-    new VersionsCache[MockEff](config.cacheTtl, new JsonKeyValueStore("versions", "1"))
-  implicit val artifactMigrations: ArtifactMigrations =
-    ArtifactMigrations.create[MockEff](config).runA(MockState.empty).unsafeRunSync()
-  implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
-  implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create(config)
-  implicit val pullRequestRepository: PullRequestRepository[MockEff] =
-    new PullRequestRepository[MockEff](new JsonKeyValueStore("pull_requests", "2"))
+    Context.step1[MockEff](config).runA(MigrationsLoaderTest.mockState).unsafeRunSync()
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -1,13 +1,13 @@
 package org.scalasteward.core.nurture
 
 import munit.FunSuite
-import org.http4s.Uri
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.git.Sha1.HexString
-import org.scalasteward.core.mock.MockContext.{config, pullRequestRepository}
+import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.context.pullRequestRepository
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState, Repo}
@@ -16,148 +16,135 @@ class PullRequestRepositoryTest extends FunSuite {
   private def checkCommands(state: MockState, commands: Vector[List[String]]): Unit =
     assertEquals(state.copy(files = Map.empty), MockState.empty.copy(commands = commands))
 
-  withStoreData { (repo, url, sha1, number) =>
-    test("createOrUpdate >> findPullRequest >> lastPullRequestCreatedAt") {
-      val update = TestData.Updates.PortableScala
+  private val url = uri"https://github.com/typelevel/cats/pull/3291"
+  private val sha1 = Sha1(HexString.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))
+  private val number = PullRequestNumber(3291)
 
-      val p = for {
-        _ <- pullRequestRepository.createOrUpdate(
-          repo,
-          url,
-          sha1,
-          update,
-          PullRequestState.Open,
-          number
-        )
-        result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0")
-        createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
-      } yield (result, createdAt)
-      val (state, (result, createdAt)) = p.run(MockState.empty).unsafeRunSync()
+  test("createOrUpdate >> findPullRequest >> lastPullRequestCreatedAt") {
+    val repo = Repo("pr-repo-test", "repo1")
+    val update = TestData.Updates.PortableScala
 
-      val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
-      assertEquals(result, Some((url, sha1, PullRequestState.Open)))
-      assert(createdAt.isDefined)
-
-      checkCommands(
-        state,
-        Vector(
-          List("read", store.toString),
-          List("write", store.toString),
-          List("read", store.toString),
-          List("read", store.toString)
-        )
+    val p = for {
+      _ <- pullRequestRepository.createOrUpdate(
+        repo,
+        url,
+        sha1,
+        update,
+        PullRequestState.Open,
+        number
       )
-    }
+      result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0")
+      createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
+    } yield (result, createdAt)
+    val (state, (result, createdAt)) = p.run(MockState.empty).unsafeRunSync()
 
-    test("getObsoleteOpenPullRequests for single update") {
-      val update = TestData.Updates.PortableScala
-      val nextUpdate = TestData.Updates.PortableScala.copy(newerVersions = Nel.of("1.0.1"))
+    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    assertEquals(result, Some((url, sha1, PullRequestState.Open)))
+    assert(createdAt.isDefined)
 
-      val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
-        _ <- pullRequestRepository.createOrUpdate(
-          repo,
-          url,
-          sha1,
-          update,
-          PullRequestState.Open,
-          number
-        )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
-        _ <- pullRequestRepository.changeState(repo, url, PullRequestState.Closed)
-        closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
-      } yield (emptyResult, result, closedResult)
-      val (state, (emptyResult, result, closedResult)) = p.run(MockState.empty).unsafeRunSync()
-      val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
-      assertEquals(emptyResult, List.empty)
-      assertEquals(closedResult, List.empty)
-      assertEquals(result, List((number, url, TestData.Updates.PortableScala)))
-
-      checkCommands(
-        state,
-        Vector(
-          List("read", store.toString),
-          List("read", store.toString),
-          List("write", store.toString),
-          List("read", store.toString),
-          List("read", store.toString),
-          List("write", store.toString),
-          List("read", store.toString)
-        )
+    checkCommands(
+      state,
+      Vector(
+        List("read", store.toString),
+        List("write", store.toString)
       )
-    }
-
-    test("getObsoleteOpenPullRequests for the same single update") {
-      val update = TestData.Updates.PortableScala
-
-      val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
-        _ <- pullRequestRepository.createOrUpdate(
-          repo,
-          url,
-          sha1,
-          update,
-          PullRequestState.Open,
-          number
-        )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
-      } yield (emptyResult, result)
-      val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
-      val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
-      assertEquals(emptyResult, List.empty)
-      assertEquals(result, List.empty)
-
-      checkCommands(
-        state,
-        Vector(
-          List("read", store.toString),
-          List("read", store.toString),
-          List("write", store.toString),
-          List("read", store.toString)
-        )
-      )
-    }
-
-    test("getObsoleteOpenPullRequests for the another single update and ignore closed") {
-      val updateInStore = TestData.Updates.PortableScala
-      val newUpdate = TestData.Updates.CatsCore
-
-      val p = for {
-        emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, updateInStore)
-        _ <- pullRequestRepository.createOrUpdate(
-          repo,
-          url,
-          sha1,
-          updateInStore,
-          PullRequestState.Open,
-          number
-        )
-        result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, newUpdate)
-      } yield (emptyResult, result)
-      val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
-      val store = config.workspace / "store/pull_requests/v2/typelevel/cats/pull_requests.json"
-      assertEquals(emptyResult, List.empty)
-      assertEquals(result, List.empty)
-
-      checkCommands(
-        state,
-        Vector(
-          List("read", store.toString),
-          List("read", store.toString),
-          List("write", store.toString),
-          List("read", store.toString)
-        )
-      )
-    }
+    )
   }
 
-  private def withStoreData(f: (Repo, Uri, Sha1, PullRequestNumber) => Unit): Unit = {
-    val repo = Repo("typelevel", "cats")
-    val url = uri"https://github.com/typelevel/cats/pull/3291"
-    val sha1 = Sha1(HexString.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))
-    val number = PullRequestNumber(3291)
+  test("getObsoleteOpenPullRequests for single update") {
+    val repo = Repo("pr-repo-test", "repo2")
+    val update = TestData.Updates.PortableScala
+    val nextUpdate = TestData.Updates.PortableScala.copy(newerVersions = Nel.of("1.0.1"))
 
-    f(repo, url, sha1, number)
+    val p = for {
+      emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
+      _ <- pullRequestRepository.createOrUpdate(
+        repo,
+        url,
+        sha1,
+        update,
+        PullRequestState.Open,
+        number
+      )
+      result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
+      _ <- pullRequestRepository.changeState(repo, url, PullRequestState.Closed)
+      closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
+    } yield (emptyResult, result, closedResult)
+    val (state, (emptyResult, result, closedResult)) = p.run(MockState.empty).unsafeRunSync()
+    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    assertEquals(emptyResult, List.empty)
+    assertEquals(closedResult, List.empty)
+    assertEquals(result, List((number, url, TestData.Updates.PortableScala)))
+
+    checkCommands(
+      state,
+      Vector(
+        List("read", store.toString),
+        List("write", store.toString),
+        List("write", store.toString)
+      )
+    )
+  }
+
+  test("getObsoleteOpenPullRequests for the same single update") {
+    val repo = Repo("pr-repo-test", "repo3")
+    val update = TestData.Updates.PortableScala
+
+    val p = for {
+      emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
+      _ <- pullRequestRepository.createOrUpdate(
+        repo,
+        url,
+        sha1,
+        update,
+        PullRequestState.Open,
+        number
+      )
+      result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
+    } yield (emptyResult, result)
+    val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
+    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    assertEquals(emptyResult, List.empty)
+    assertEquals(result, List.empty)
+
+    checkCommands(
+      state,
+      Vector(
+        List("read", store.toString),
+        List("write", store.toString)
+      )
+    )
+  }
+
+  test("getObsoleteOpenPullRequests for the another single update and ignore closed") {
+    val repo = Repo("pr-repo-test", "repo4")
+    val updateInStore = TestData.Updates.PortableScala
+    val newUpdate = TestData.Updates.CatsCore
+
+    val p = for {
+      emptyResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, updateInStore)
+      _ <- pullRequestRepository.createOrUpdate(
+        repo,
+        url,
+        sha1,
+        updateInStore,
+        PullRequestState.Open,
+        number
+      )
+      result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, newUpdate)
+    } yield (emptyResult, result)
+    val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
+    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    assertEquals(emptyResult, List.empty)
+    assertEquals(result, List.empty)
+
+    checkCommands(
+      state,
+      Vector(
+        List("read", store.toString),
+        List("write", store.toString)
+      )
+    )
   }
 }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -2,7 +2,8 @@ package org.scalasteward.core.persistence
 
 import cats.syntax.all._
 import munit.FunSuite
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.{MockEff, MockState}
 
 class JsonKeyValueStoreTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
-import org.scalasteward.core.mock.MockContext.repoConfigAlg
+import org.scalasteward.core.mock.MockContext.context.repoConfigAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.scalafix
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update, Version}
-import org.scalasteward.core.mock.MockContext.migrationAlg
+import org.scalasteward.core.mock.MockContext.context.migrationAlg
 import org.scalasteward.core.util.Nel
 
 class MigrationAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
@@ -5,7 +5,7 @@ import org.http4s.Uri
 import org.scalasteward.core.application.Config.ScalafixCfg
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.migrationsLoader
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.scalafix.MigrationsLoaderTest.mockState
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.scalafmt
 import munit.FunSuite
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.scalafmtAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/ArtifactMigrationsTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/ArtifactMigrationsTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.update
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context.updateAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.update.ArtifactMigrations.ArtifactChange
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -4,7 +4,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
-import org.scalasteward.core.mock.MockContext.filterAlg
+import org.scalasteward.core.mock.MockContext.context.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
 import org.scalasteward.core.update.FilterAlg._

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.util
 
 import cats.{Applicative, ApplicativeThrow}
 import munit.FunSuite
-import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.util.logger.LoggerOps
 
@@ -10,7 +10,7 @@ class loggerTest extends FunSuite {
   test("attemptLog") {
     final case class Err(msg: String) extends Throwable(msg)
     val err = Err("hmm?")
-    val state = mockLogger
+    val state = logger
       .attemptLogLabel("run")(ApplicativeThrow[MockEff].raiseError(err))
       .runS(MockState.empty)
       .unsafeRunSync()
@@ -18,15 +18,15 @@ class loggerTest extends FunSuite {
   }
 
   test("infoTimed") {
-    val state = mockLogger
-      .infoTimed(_ => "timed")(mockLogger.info("inner"))
+    val state = logger
+      .infoTimed(_ => "timed")(logger.info("inner"))
       .runS(MockState.empty)
       .unsafeRunSync()
     assertEquals(state.logs, Vector((None, "inner"), (None, "timed")))
   }
 
   test("infoTotalTime") {
-    val state = mockLogger
+    val state = logger
       .infoTotalTime("run")(Applicative[MockEff].unit)
       .runS(MockState.empty)
       .unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -3,7 +3,8 @@ package org.scalasteward.core.vcs
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.mock.MockContext.{config, envVars, gitAlg, mockLogger, vcsRepoAlg}
+import org.scalasteward.core.mock.MockContext.context.{gitAlg, logger, vcsRepoAlg}
+import org.scalasteward.core.mock.MockContext.{config, envVars}
 import org.scalasteward.core.mock.{MockContext, MockEff, MockState}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 


### PR DESCRIPTION
This reduces duplication in `Context` and `MockContext` which both contained code to initialize classes. The first does it for the production `F` while the latter does it for `MockEff`. This change splits `Context.create` into two functions, `step0` and `step1`, such that `step1` takes the classes we want or need to mock in tests as parameters. `step1` is then used in `MockContext` to create a `Context[MockEff]` whose members are used in test classes instead of the previously manually initialized instances in `MockContext`.