### PR TITLE
Use Blocker for Process#waitFor in slurp

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
@@ -51,7 +51,7 @@ object process {
             .drain
         }
 
-        val result = readOut >> F.delay(process.waitFor()) >>= { exitValue =>
+        val result = readOut >> blocker.delay(process.waitFor()) >>= { exitValue =>
           if (exitValue === 0) F.pure(buffer.toList)
           else {
             val msg = s"'${showCmd(args)}' exited with code $exitValue"


### PR DESCRIPTION
`waitFor` [blocks the calling thread][1] so it is appropriate to
evaluate it on the available `Blocker`.

[1]: https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html#waitFor--