### PR TITLE
fix closing a pull request in bitbucket cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Thanks goes to these wonderful people for contributing to Scala Steward:
 * [Erik Erlandson](https://github.com/erikerlandson)
 * [Erlend Hamnaberg](https://github.com/hamnis)
 * [eugeniyk](https://github.com/eugeniyk)
-* [Fabian](https://github.com/fg-devs)
+* [Fabian Grutsch](https://github.com/fgrutsch)
 * [Felix Dietze](https://github.com/fdietze)
 * [Filipe Regadas](https://github.com/regadas)
 * [Frank S. Thomas](https://github.com/fthomas)

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -90,9 +90,8 @@ class BitbucketApiAlg[F[_]](
       .map(_.values)
 
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
-    client.postWithBody[PullRequestOut, UpdateState](
+    client.post[PullRequestOut](
       url.decline(repo, number),
-      UpdateState(PullRequestState.Closed),
       modify(repo)
     )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -90,8 +90,8 @@ class BitbucketApiAlg[F[_]](
       .map(_.values)
 
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
-    client.putWithBody[PullRequestOut, UpdateState](
-      url.pullRequest(repo, number),
+    client.postWithBody[PullRequestOut, UpdateState](
+      url.decline(repo, number),
       UpdateState(PullRequestState.Closed),
       modify(repo)
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
@@ -41,4 +41,7 @@ private[bitbucket] class Url(apiHost: Uri) {
 
   def comments(rep: Repo, number: PullRequestNumber): Uri =
     pullRequest(rep, number) / "comments"
+
+  def decline(rep: Repo, number: PullRequestNumber): Uri =
+    pullRequest(rep, number) / "decline"
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -124,7 +124,9 @@ class BitbucketApiAlgTest extends FunSuite {
           ]
       }"""
       )
-    case PUT -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" / IntVar(_) =>
+    case POST -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" / IntVar(
+          _
+        ) / "decline" =>
       Ok(
         json"""{
             "id": 2,


### PR DESCRIPTION
This PR fixes closing a superseded PR for the bitbucket cloud VCS. The current implementation fails due to the following API error:

```
2021-01-27 21:55:16,362 INFO  Create branch update/kinesis-2.15.71
2021-01-27 21:55:16,385 INFO  Push 1 commit(s)
2021-01-27 21:55:18,183 INFO  Create PR update/kinesis-2.15.71
2021-01-27 21:55:19,067 INFO  Created PR https://api.bitbucket.org/2.0/repositories/xxx/xxx/pullrequests/380
2021-01-27 21:55:19,086 INFO  Closing obsolete PR https://api.bitbucket.org/2.0/repositories/xxx/xxx/pullrequests/379 for software.amazon.awssdk:{kinesis, sqs} : 2.15.69 -> 2.15.70
2021-01-27 21:55:19,665 WARN  Closing PR #379 failed
org.scalasteward.core.util.UnexpectedResponse: uri: https://api.bitbucket.org/2.0/repositories/xxx/xxx/pullrequests/379
method: PUT
status: 400 Bad Request
headers: Headers(cache-control: no-cache, no-store, must-revalidate, max-age=0, content-length: 123, content-type: application/json; charset=utf-8, date: Wed, 27 Jan 2021 21:55:19 GMT, expires: Wed, 27 Jan 2021 21:55:19 GMT, server: nginx, strict-transport-security: max-age=31536000; includeSubDomains; preload, vary: Authorization, cookie, user-context, x-accepted-oauth-scopes: pullrequest:write, x-b3-traceid: b3412ae5f25992a4, x-credential-type: password, x-dc-location: ash2, x-frame-options: SAMEORIGIN, x-render-time: 0.113293886185, x-request-count: 348, x-served-by: app-3018, x-static-version: 7729c0c1c684, x-version: 7729c0c1c684)
body: {"type": "error", "error": {"fields": {"title": ["This field is required."]}, "message": "title: This field is required."}}
```

The problem is that in the current implementation the update PR request is only setting the `state` field, but bitbucket cloud, for some reason requires the `title` field as well to be present in the request (we don't have the title field in scope in the `closePullRequest` method). Since bitbucket doesn't have a status like **close** anyway, we can just decline the PR.

I updated the endpoint to use the `decline` endpoint instead, which doesn't require the `title` field and properly "closes" a PR now.