### PR TITLE
Do not wrap UrlChecker in Resource

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.mock
 
 import better.files.File
+import cats.Parallel
 import cats.effect.{BracketThrow, Sync}
-import cats.{Applicative, Parallel}
 import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 import org.http4s.{HttpApp, Uri}
@@ -11,7 +11,6 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.{Cli, Config, Context, SupportedVCS}
 import org.scalasteward.core.io._
 import org.scalasteward.core.scalafix.MigrationsLoaderTest
-import org.scalasteward.core.util.UrlChecker
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
@@ -41,7 +40,6 @@ object MockContext {
   implicit private val fileAlg: FileAlg[MockEff] = new MockFileAlg
   implicit private val logger: Logger[MockEff] = new MockLogger
   implicit private val processAlg: ProcessAlg[MockEff] = MockProcessAlg.create(config.processCfg)
-  implicit private val urlChecker: UrlChecker[MockEff] = _ => Applicative[MockEff].pure(false)
   implicit private val workspaceAlg: WorkspaceAlg[MockEff] = new MockWorkspaceAlg
 
   val context: Context[MockEff] =

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -23,7 +23,7 @@ class VCSExtraAlgTest extends FunSuite {
 
   implicit val client: Client[IO] = Client.fromHttpApp[IO](routes.orNotFound)
   implicit val urlChecker: UrlChecker[IO] =
-    UrlChecker.create[IO](MockContext.config).allocated.map(_._1).unsafeRunSync()
+    UrlChecker.create[IO](MockContext.config).unsafeRunSync()
 
   private val updateFoo = Update.Single("com.example" % "foo" % "0.1.0", Nel.of("0.2.0"))
   private val updateBar = Update.Single("com.example" % "bar" % "0.1.0", Nel.of("0.2.0"))


### PR DESCRIPTION
Using `Resource` for `UrlChecker` is not necessary because
`CaffeineCache#close` is a no-op.