### PR TITLE
BitbucketServer: list also declined and merged PRs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Url.scala
@@ -44,6 +44,7 @@ final class Url(apiHost: Uri) {
       .withQueryParam("at", head)
       .withQueryParam("limit", "1000")
       .withQueryParam("direction", "outgoing")
+      .withQueryParam("state", "all")
 
   def pullRequest(repo: Repo, number: PullRequestNumber): Uri =
     pullRequests(repo) / number.toString


### PR DESCRIPTION
The default state is `open` but if only open PRs are listed, Scala
Steward recreates PRs of updates that have been declined before.

API doc: https://docs.atlassian.com/bitbucket-server/rest/7.10.0/bitbucket-rest.html#idp29