### PR TITLE
Remove effect from JsonKeyValueStore#jsonFile

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
@@ -25,42 +25,53 @@ import io.circe.syntax._
 import io.circe.{Decoder, Encoder, KeyEncoder}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 
-final class JsonKeyValueStore[F[_], K, V](
-    name: String,
-    schemaVersion: String,
-    maybePrefix: Option[String] = None
-)(implicit
+final class JsonKeyValueStore[F[_], K, V](storeRoot: File, name: String)(implicit
     fileAlg: FileAlg[F],
     keyEncoder: KeyEncoder[K],
     logger: Logger[F],
     valueDecoder: Decoder[V],
     valueEncoder: Encoder[V],
-    workspaceAlg: WorkspaceAlg[F],
     F: Monad[F]
 ) extends KeyValueStore[F, K, V] {
-  override def get(key: K): F[Option[V]] =
-    jsonFile(key).flatMap { file =>
-      fileAlg.readFile(file).flatMap {
-        case None => F.pure(Option.empty[V])
-        case Some(content) =>
-          decode[Option[V]](content) match {
-            case Right(maybeValue) => F.pure(maybeValue)
-            case Left(error) =>
-              logger.error(error)(s"Failed to parse or decode JSON from $file").as(Option.empty[V])
-          }
-      }
+  override def get(key: K): F[Option[V]] = {
+    val file = jsonFile(key)
+    fileAlg.readFile(file).flatMap {
+      case None => F.pure(Option.empty[V])
+      case Some(content) =>
+        decode[Option[V]](content) match {
+          case Right(maybeValue) => F.pure(maybeValue)
+          case Left(error) =>
+            logger.error(error)(s"Failed to parse or decode JSON from $file").as(Option.empty[V])
+        }
     }
+  }
 
-  override def set(key: K, value: Option[V]): F[Unit] =
-    jsonFile(key).flatMap { file =>
-      value match {
-        case Some(v) => fileAlg.writeFile(file, v.asJson.toString)
-        case None    => fileAlg.deleteForce(file)
-      }
+  override def set(key: K, value: Option[V]): F[Unit] = {
+    val file = jsonFile(key)
+    value match {
+      case Some(v) => fileAlg.writeFile(file, v.asJson.spaces2)
+      case None    => fileAlg.deleteForce(file)
     }
+  }
 
-  private def jsonFile(key: K): F[File] = {
-    val keyPath = maybePrefix.fold("")(_ + "/") + keyEncoder(key)
-    workspaceAlg.rootDir.map(_ / "store" / name / s"v$schemaVersion" / keyPath / s"$name.json")
+  private def jsonFile(key: K): File =
+    storeRoot / keyEncoder(key) / s"$name.json"
+}
+
+object JsonKeyValueStore {
+  def create[F[_], K, V](name: String, schemaVersion: String, maybePrefix: Option[String] = None)(
+      implicit
+      fileAlg: FileAlg[F],
+      keyEncoder: KeyEncoder[K],
+      logger: Logger[F],
+      valueDecoder: Decoder[V],
+      valueEncoder: Encoder[V],
+      workspaceAlg: WorkspaceAlg[F],
+      F: Monad[F]
+  ): F[JsonKeyValueStore[F, K, V]] = {
+    val prefix = maybePrefix.fold("")("/" + _)
+    workspaceAlg.rootDir
+      .map(_ / "store" / name / s"v$schemaVersion$prefix")
+      .map(storeRoot => new JsonKeyValueStore(storeRoot, name))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -8,8 +8,8 @@ import org.scalasteward.core.mock.{MockEff, MockState}
 
 class JsonKeyValueStoreTest extends FunSuite {
   test("put, get") {
-    val kvStore = new JsonKeyValueStore[MockEff, String, String]("test", "0")
     val p = for {
+      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test", "0")
       _ <- kvStore.put("k1", "v1")
       v1 <- kvStore.get("k1")
       _ <- kvStore.put("k2", "v2")
@@ -37,8 +37,8 @@ class JsonKeyValueStoreTest extends FunSuite {
   }
 
   test("modifyF, get, set") {
-    val kvStore = new JsonKeyValueStore[MockEff, String, String]("test", "0")
     val p = for {
+      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test", "0")
       _ <- kvStore.modifyF("k1")(_ => Option("v0").pure[MockEff])
       v1 <- kvStore.get("k1")
       _ <- kvStore.set("k1", None)
@@ -60,9 +60,9 @@ class JsonKeyValueStoreTest extends FunSuite {
 
   test("cached") {
     val p = for {
-      kvStore <- CachingKeyValueStore.wrap(
-        new JsonKeyValueStore[MockEff, String, String]("test", "0")
-      )
+      kvStore <- JsonKeyValueStore
+        .create[MockEff, String, String]("test", "0")
+        .flatMap(CachingKeyValueStore.wrap(_))
       _ <- kvStore.put("k1", "v1")
       v1 <- kvStore.get("k1")
       v2 <- kvStore.get("k2")


### PR DESCRIPTION
It is unnecessary to compute the root directory on every call to
`jsonFile`. This change does it only once at the creation of the store.