### PR TITLE
fix sbt-release version in artifact-migrations

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -3,7 +3,7 @@ changes = [
     groupIdBefore = com.github.gseitz
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-release
-    initialVersion = 1.0.14
+    initialVersion = 1.0.15
   },
   {
     groupIdBefore = com.jsuereth


### PR DESCRIPTION
Can't use sbt-release 1.0.14 due to `publishMavenStyle := false` 🙇 

I have published new version

https://github.com/sbt/sbt-release/compare/v1.0.14...v1.0.15
https://github.com/pulls?q=sbt-release+1.0.14+is%3Apr+author%3Ascala-steward+archived%3Afalse

```
[error]   not found: https://repo1.maven.org/maven2/com/github/sbt/sbt-release_2.12_1.0/1.0.14/sbt-release-1.0.14.pom
```