### PR TITLE
Merge MockState#{commands, logs} to MockState#trace

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -7,6 +7,7 @@ import org.scalasteward.core.data.{Resolver, Scope, Version}
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.vcs.data.Repo
 
@@ -22,14 +23,14 @@ class BuildToolDispatcherTest extends FunSuite {
     val (state, deps) =
       buildToolDispatcher.getDependencies(repo).run(initial).unsafeRunSync()
 
-    val expectedState = initial.copy(commands =
+    val expectedState = initial.copy(trace =
       Vector(
-        List("read", s"$repoDir/.scala-steward.conf"),
-        List("read", s"/tmp/default.scala-steward.conf"),
-        List("test", "-f", s"$repoDir/pom.xml"),
-        List("test", "-f", s"$repoDir/build.sc"),
-        List("test", "-f", s"$repoDir/build.sbt"),
-        List(
+        Cmd("read", s"$repoDir/.scala-steward.conf"),
+        Cmd("read", s"/tmp/default.scala-steward.conf"),
+        Cmd("test", "-f", s"$repoDir/pom.xml"),
+        Cmd("test", "-f", s"$repoDir/build.sc"),
+        Cmd("test", "-f", s"$repoDir/build.sbt"),
+        Cmd(
           repoDir.toString,
           "firejail",
           "--quiet",
@@ -42,8 +43,8 @@ class BuildToolDispatcherTest extends FunSuite {
           "-Dsbt.supershell=false",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
-        List("read", s"$repoDir/project/build.properties"),
-        List("read", s"$repoDir/.scalafmt.conf")
+        Cmd("read", s"$repoDir/project/build.properties"),
+        Cmd("read", s"$repoDir/.scalafmt.conf")
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.buildtool.maven
 
-import better.files.File
 import munit.FunSuite
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockContext.context.mavenAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class MavenAlgTest extends FunSuite {
@@ -12,16 +12,11 @@ class MavenAlgTest extends FunSuite {
     val repo = Repo("namespace", "repo-name")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.show
-    val files: Map[File, String] = Map.empty
 
-    val state =
-      mavenAlg.getDependencies(buildRoot).runS(MockState.empty.copy(files = files)).unsafeRunSync()
-
+    val state = mavenAlg.getDependencies(buildRoot).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
-      files = files,
-      logs = Vector.empty,
-      commands = Vector(
-        List(
+      trace = Vector(
+        Cmd(
           repoDir.toString,
           "firejail",
           "--quiet",
@@ -32,7 +27,7 @@ class MavenAlgTest extends FunSuite {
           "--batch-mode",
           command.listDependencies
         ),
-        List(
+        Cmd(
           repoDir.toString,
           "firejail",
           "--quiet",

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -5,6 +5,7 @@ import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context.millAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class MillAlgTest extends FunSuite {
@@ -29,10 +30,10 @@ class MillAlgTest extends FunSuite {
     val initial = MockState.empty.copy(commandOutputs = Map(millCmd -> List("""{"modules":[]}""")))
     val state = millAlg.getDependencies(buildRoot).runS(initial).unsafeRunSync()
     val expected = initial.copy(
-      commands = Vector(
-        List("write", predef),
-        repoDir.toString :: millCmd,
-        List("rm", "-rf", predef)
+      trace = Vector(
+        Cmd("write", predef),
+        Cmd(repoDir.toString :: millCmd),
+        Cmd("rm", "-rf", predef)
       )
     )
     assertEquals(state, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -7,6 +7,7 @@ import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.context.editAlg
 import org.scalasteward.core.mock.MockContext.{config, envVars}
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtBinary
 import org.scalasteward.core.util.Nel
@@ -29,21 +30,19 @@ class EditAlgTest extends FunSuite {
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("test", "-f", file1.pathAsString),
-        List("read", file1.pathAsString),
-        List("test", "-f", file2.pathAsString),
-        List("read", file2.pathAsString),
-        List("read", file1.pathAsString),
-        List("read", file1.pathAsString),
-        List("read", file1.pathAsString),
-        List("write", file1.pathAsString),
-        envVars ++ (repoDir.toString :: gitStatus)
-      ),
-      logs = Vector(
-        (None, "Trying heuristic 'moduleId'"),
-        (None, "Trying heuristic 'strict'"),
-        (None, "Trying heuristic 'original'")
+      trace = Vector(
+        Cmd("test", "-f", file1.pathAsString),
+        Cmd("read", file1.pathAsString),
+        Cmd("test", "-f", file2.pathAsString),
+        Cmd("read", file2.pathAsString),
+        Log("Trying heuristic 'moduleId'"),
+        Cmd("read", file1.pathAsString),
+        Log("Trying heuristic 'strict'"),
+        Cmd("read", file1.pathAsString),
+        Log("Trying heuristic 'original'"),
+        Cmd("read", file1.pathAsString),
+        Cmd("write", file1.pathAsString),
+        Cmd(envVars ++ (repoDir.toString :: gitStatus))
       ),
       files = Map(file1 -> """val catsVersion = "1.3.0"""", file2 -> "")
     )
@@ -68,33 +67,31 @@ class EditAlgTest extends FunSuite {
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("test", "-f", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("test", "-f", buildSbt.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("read", scalafmtConf.pathAsString),
-        List("write", scalafmtConf.pathAsString),
-        envVars ++ (repoDir.toString :: gitStatus),
-        List("VAR1=val1", "VAR2=val2", repoDir.toString, scalafmtBinary, "--non-interactive"),
-        envVars ++ (repoDir.toString :: gitStatus)
-      ),
-      logs = Vector(
-        (None, "Trying heuristic 'moduleId'"),
-        (None, "Trying heuristic 'strict'"),
-        (None, "Trying heuristic 'original'"),
-        (None, "Trying heuristic 'relaxed'"),
-        (None, "Trying heuristic 'sliding'"),
-        (None, "Trying heuristic 'completeGroupId'"),
-        (None, "Trying heuristic 'groupId'"),
-        (None, "Trying heuristic 'specific'"),
-        (None, "Executing post-update hook for org.scalameta:scalafmt-core")
+      trace = Vector(
+        Cmd("test", "-f", scalafmtConf.pathAsString),
+        Cmd("read", scalafmtConf.pathAsString),
+        Cmd("test", "-f", buildSbt.pathAsString),
+        Log("Trying heuristic 'moduleId'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'strict'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'original'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'relaxed'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'sliding'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'completeGroupId'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'groupId'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Log("Trying heuristic 'specific'"),
+        Cmd("read", scalafmtConf.pathAsString),
+        Cmd("write", scalafmtConf.pathAsString),
+        Cmd(envVars ++ (repoDir.toString :: gitStatus)),
+        Log("Executing post-update hook for org.scalameta:scalafmt-core"),
+        Cmd("VAR1=val1", "VAR2=val2", repoDir.toString, scalafmtBinary, "--non-interactive"),
+        Cmd(envVars ++ (repoDir.toString :: gitStatus))
       ),
       files = Map(
         scalafmtConf ->
@@ -126,19 +123,17 @@ class EditAlgTest extends FunSuite {
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("test", "-f", file1.pathAsString),
-        List("read", file1.pathAsString),
-        List("test", "-f", file2.pathAsString),
-        List("read", file2.pathAsString),
-        List("read", file1.pathAsString),
-        List("write", file1.pathAsString),
-        List("read", file2.pathAsString),
-        List("write", file2.pathAsString),
-        envVars ++ (repoDir.toString :: gitStatus)
-      ),
-      logs = Vector(
-        (None, "Trying heuristic 'moduleId'")
+      trace = Vector(
+        Cmd("test", "-f", file1.pathAsString),
+        Cmd("read", file1.pathAsString),
+        Cmd("test", "-f", file2.pathAsString),
+        Cmd("read", file2.pathAsString),
+        Log("Trying heuristic 'moduleId'"),
+        Cmd("read", file1.pathAsString),
+        Cmd("write", file1.pathAsString),
+        Cmd("read", file2.pathAsString),
+        Cmd("write", file2.pathAsString),
+        Cmd(envVars ++ (repoDir.toString :: gitStatus))
       ),
       files = Map(
         file1 -> """import $ivy.`org.typelevel::cats-core:1.3.0`, cats.implicits._"""",

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -9,6 +9,7 @@ import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.mock.MockContext.context.fileAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 
 class FileAlgTest extends FunSuite {
   test("createTemporarily") {
@@ -59,7 +60,7 @@ class FileAlgTest extends FunSuite {
     } yield edited).run(MockState.empty).unsafeRunSync()
 
     val expected =
-      MockState.empty.copy(commands = Vector(List("read", "/tmp/steward/does-not-exists.txt")))
+      MockState.empty.copy(trace = Vector(Cmd("read", "/tmp/steward/does-not-exists.txt")))
     assertEquals(state, expected)
     assert(!edited)
   }
@@ -73,10 +74,10 @@ class FileAlgTest extends FunSuite {
     } yield edited).run(MockState.empty).unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("write", file.pathAsString),
-        List("read", file.pathAsString),
-        List("write", file.pathAsString)
+      trace = Vector(
+        Cmd("write", file.pathAsString),
+        Cmd("read", file.pathAsString),
+        Cmd("write", file.pathAsString)
       ),
       files = Map(file -> "143")
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -9,6 +9,7 @@ import org.scalasteward.core.application.Config.{ProcessCfg, SandboxCfg}
 import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
 import scala.concurrent.duration.Duration
 
@@ -39,9 +40,7 @@ class ProcessAlgTest extends FunSuite {
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List(File.temp.toString, "echo", "hello")
-      )
+      trace = Vector(Cmd(File.temp.toString, "echo", "hello"))
     )
 
     assertEquals(state, expected)
@@ -56,15 +55,8 @@ class ProcessAlgTest extends FunSuite {
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List(
-          File.temp.toString,
-          "firejail",
-          "--quiet",
-          s"--whitelist=${File.temp}",
-          "echo",
-          "hello"
-        )
+      trace = Vector(
+        Cmd(File.temp.toString, "firejail", "--quiet", s"--whitelist=${File.temp}", "echo", "hello")
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -9,12 +9,14 @@ import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context.pullRequestRepository
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState, Repo}
 
 class PullRequestRepositoryTest extends FunSuite {
-  private def checkCommands(state: MockState, commands: Vector[List[String]]): Unit =
-    assertEquals(state.copy(files = Map.empty), MockState.empty.copy(commands = commands))
+  private def checkTrace(state: MockState, trace: Vector[TraceEntry]): Unit =
+    assertEquals(state.copy(files = Map.empty), MockState.empty.copy(trace = trace))
 
   private val url = uri"https://github.com/typelevel/cats/pull/3291"
   private val sha1 = Sha1(HexString.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))
@@ -42,11 +44,11 @@ class PullRequestRepositoryTest extends FunSuite {
     assertEquals(result, Some((url, sha1, PullRequestState.Open)))
     assert(createdAt.isDefined)
 
-    checkCommands(
+    checkTrace(
       state,
       Vector(
-        List("read", store.toString),
-        List("write", store.toString)
+        Cmd("read", store.toString),
+        Cmd("write", store.toString)
       )
     )
   }
@@ -76,12 +78,12 @@ class PullRequestRepositoryTest extends FunSuite {
     assertEquals(closedResult, List.empty)
     assertEquals(result, List((number, url, TestData.Updates.PortableScala)))
 
-    checkCommands(
+    checkTrace(
       state,
       Vector(
-        List("read", store.toString),
-        List("write", store.toString),
-        List("write", store.toString)
+        Cmd("read", store.toString),
+        Cmd("write", store.toString),
+        Cmd("write", store.toString)
       )
     )
   }
@@ -107,11 +109,11 @@ class PullRequestRepositoryTest extends FunSuite {
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)
 
-    checkCommands(
+    checkTrace(
       state,
       Vector(
-        List("read", store.toString),
-        List("write", store.toString)
+        Cmd("read", store.toString),
+        Cmd("write", store.toString)
       )
     )
   }
@@ -138,11 +140,11 @@ class PullRequestRepositoryTest extends FunSuite {
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)
 
-    checkCommands(
+    checkTrace(
       state,
       Vector(
-        List("read", store.toString),
-        List("write", store.toString)
+        Cmd("read", store.toString),
+        Cmd("write", store.toString)
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -4,6 +4,7 @@ import cats.syntax.all._
 import munit.FunSuite
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.mock.{MockEff, MockState}
 
 class JsonKeyValueStoreTest extends FunSuite {
@@ -22,11 +23,11 @@ class JsonKeyValueStoreTest extends FunSuite {
     val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
     val k3File = config.workspace / "store" / "test" / "v0" / "k3" / "test.json"
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("write", k1File.toString),
-        List("read", k1File.toString),
-        List("write", k2File.toString),
-        List("read", k3File.toString)
+      trace = Vector(
+        Cmd("write", k1File.toString),
+        Cmd("read", k1File.toString),
+        Cmd("write", k2File.toString),
+        Cmd("read", k3File.toString)
       ),
       files = Map(
         k1File -> """"v1"""",
@@ -48,11 +49,11 @@ class JsonKeyValueStoreTest extends FunSuite {
 
     val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
     val expected = MockState.empty.copy(
-      commands = Vector(
-        List("read", k1File.toString),
-        List("write", k1File.toString),
-        List("read", k1File.toString),
-        List("rm", "-rf", k1File.toString)
+      trace = Vector(
+        Cmd("read", k1File.toString),
+        Cmd("write", k1File.toString),
+        Cmd("read", k1File.toString),
+        Cmd("rm", "-rf", k1File.toString)
       )
     )
     assertEquals(state, expected)
@@ -73,7 +74,7 @@ class JsonKeyValueStoreTest extends FunSuite {
     val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
     val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
     val expected = MockState.empty.copy(
-      commands = Vector(List("write", k1File.toString), List("read", k2File.toString)),
+      trace = Vector(Cmd("write", k1File.toString), Cmd("read", k2File.toString)),
       files = Map(k1File -> """"v1"""")
     )
     assertEquals(state, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -7,6 +7,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.context.repoConfigAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
@@ -161,7 +162,7 @@ class RepoConfigAlgTest extends FunSuite {
     val (state, config) = repoConfigAlg.readRepoConfig(repo).run(initialState).unsafeRunSync()
 
     assertEquals(config, None)
-    val log = state.logs.headOption.map { case (_, msg) => msg }.getOrElse("")
+    val log = state.trace.collectFirst { case Log((_, msg)) => msg }.getOrElse("")
     assert(clue(log).startsWith("Failed to parse .scala-steward.conf"))
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -5,6 +5,7 @@ import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockContext.context.scalafmtAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class ScalafmtAlgTest extends FunSuite {
@@ -23,7 +24,7 @@ class ScalafmtAlgTest extends FunSuite {
     val (state, maybeVersion) =
       scalafmtAlg.getScalafmtVersion(buildRoot).run(initialState).unsafeRunSync()
     val expectedState = MockState.empty.copy(
-      commands = Vector(List("read", s"$repoDir/.scalafmt.conf")),
+      trace = Vector(Cmd("read", s"$repoDir/.scalafmt.conf")),
       files = Map(
         scalafmtConf ->
           """maxColumn = 100

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -6,6 +6,7 @@ import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext.context.filterAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
 import org.scalasteward.core.update.FilterAlg._
 import org.scalasteward.core.util.Nel
@@ -67,9 +68,7 @@ class FilterAlgTest extends FunSuite {
 
     assertEquals(filtered, List(update1))
     val expected = initialState.copy(
-      logs = Vector(
-        (None, "Ignore eu.timepit:refined : 0.8.0 -> 0.8.1 (reason: ignored by config)")
-      )
+      trace = Vector(Log("Ignore eu.timepit:refined : 0.8.0 -> 0.8.1 (reason: ignored by config)"))
     )
     assertEquals(state, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -6,6 +6,7 @@ import org.scalasteward.core.data.RepoData
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockContext.context.pruningAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.vcs.data.Repo
@@ -60,11 +61,11 @@ class PruningAlgTest extends FunSuite {
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(
-      commands = Vector(List("read", pullRequestsFile.toString)),
-      logs = Vector(
-        (None, "Find updates for fthomas/scalafix-test"),
-        (None, "Found 0 updates"),
-        (None, "fthomas/scalafix-test is up-to-date")
+      trace = Vector(
+        Log("Find updates for fthomas/scalafix-test"),
+        Log("Found 0 updates"),
+        Cmd("read", pullRequestsFile.toString),
+        Log("fthomas/scalafix-test is up-to-date")
       )
     )
     assertEquals(state, expected)
@@ -163,11 +164,11 @@ class PruningAlgTest extends FunSuite {
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(
-      commands = Vector(List("read", pullRequestsFile.toString)),
-      logs = Vector(
-        (None, s"Find updates for ${repo.show}"),
-        (None, "Found 0 updates"),
-        (None, s"${repo.show} is up-to-date")
+      trace = Vector(
+        Log(s"Find updates for ${repo.show}"),
+        Log("Found 0 updates"),
+        Cmd("read", pullRequestsFile.toString),
+        Log(s"${repo.show} is up-to-date")
       )
     )
     assertEquals(state, expected)
@@ -266,16 +267,13 @@ class PruningAlgTest extends FunSuite {
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(
-      commands = Vector(
-        List("read", versionsFile.toString),
-        List("read", pullRequestsFile.toString),
-        List("read", versionsFile.toString)
-      ),
-      logs = Vector(
-        (None, s"Find updates for ${repo.show}"),
-        (None, "Found 1 update:\n  org.scala-lang:scala-library : 2.12.10 -> 2.12.11"),
-        (
-          None,
+      trace = Vector(
+        Log(s"Find updates for ${repo.show}"),
+        Cmd("read", versionsFile.toString),
+        Cmd("read", pullRequestsFile.toString),
+        Cmd("read", versionsFile.toString),
+        Log("Found 1 update:\n  org.scala-lang:scala-library : 2.12.10 -> 2.12.11"),
+        Log(
           s"${repo.show} is outdated:\n  new version: org.scala-lang:scala-library : 2.12.10 -> 2.12.11"
         )
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.util
 import cats.{Applicative, ApplicativeThrow}
 import munit.FunSuite
 import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.util.logger.LoggerOps
 
@@ -14,7 +15,7 @@ class loggerTest extends FunSuite {
       .attemptLogLabel("run")(ApplicativeThrow[MockEff].raiseError(err))
       .runS(MockState.empty)
       .unsafeRunSync()
-    assertEquals(state.logs, Vector((None, "run"), (Some(err), "run failed")))
+    assertEquals(state.trace, Vector(Log("run"), Log((Some(err), "run failed"))))
   }
 
   test("infoTimed") {
@@ -22,7 +23,7 @@ class loggerTest extends FunSuite {
       .infoTimed(_ => "timed")(logger.info("inner"))
       .runS(MockState.empty)
       .unsafeRunSync()
-    assertEquals(state.logs, Vector((None, "inner"), (None, "timed")))
+    assertEquals(state.trace, Vector(Log("inner"), Log("timed")))
   }
 
   test("infoTotalTime") {
@@ -30,6 +31,6 @@ class loggerTest extends FunSuite {
       .infoTotalTime("run")(Applicative[MockEff].unit)
       .runS(MockState.empty)
       .unsafeRunSync()
-    assertEquals(state.logs.size, 1)
+    assertEquals(state.trace.size, 1)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -5,6 +5,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockContext.context.{gitAlg, logger, vcsRepoAlg}
 import org.scalasteward.core.mock.MockContext.{config, envVars}
+import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.mock.{MockContext, MockEff, MockState}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 
@@ -32,18 +33,22 @@ class VCSRepoAlgTest extends FunSuite {
     val url0 = s"https://${config.vcsLogin}@github.com/fthomas/datapackage"
     val url1 = s"https://${config.vcsLogin}@github.com/scala-steward/datapackage"
     val expected = MockState.empty.copy(
-      commands = Vector(
-        envVars ++ List(config.workspace.toString, "git", "clone", url1, repoDir),
-        envVars ++ List(repoDir, "git", "config", "user.email", "bot@example.org"),
-        envVars ++ List(repoDir, "git", "config", "user.name", "Bot Doe"),
-        envVars ++ List(repoDir, "git", "remote", "add", "upstream", url0),
-        envVars ++ List(repoDir, "git", "fetch", "--force", "--tags", "upstream", "master"),
-        envVars ++ List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
-        envVars ++ List(repoDir, "git", "merge", "upstream/master"),
-        envVars ++ List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master"),
-        envVars ++ List(repoDir, "git", "submodule", "update", "--init", "--recursive")
-      ),
-      logs = Vector((None, "Clone and synchronize fthomas/datapackage"))
+      trace = Vector(
+        Log("Clone and synchronize fthomas/datapackage"),
+        Cmd(envVars ++ List(config.workspace.toString, "git", "clone", url1, repoDir)),
+        Cmd(envVars ++ List(repoDir, "git", "config", "user.email", "bot@example.org")),
+        Cmd(envVars ++ List(repoDir, "git", "config", "user.name", "Bot Doe")),
+        Cmd(envVars ++ List(repoDir, "git", "remote", "add", "upstream", url0)),
+        Cmd(envVars ++ List(repoDir, "git", "fetch", "--force", "--tags", "upstream", "master")),
+        Cmd(
+          envVars ++ List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master")
+        ),
+        Cmd(envVars ++ List(repoDir, "git", "merge", "upstream/master")),
+        Cmd(
+          envVars ++ List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
+        ),
+        Cmd(envVars ++ List(repoDir, "git", "submodule", "update", "--init", "--recursive"))
+      )
     )
     assertEquals(state, expected)
   }


### PR DESCRIPTION
This merges the `commands` and `logs` field of `MockState` into one
`trace` field that is a `Vector` of `Cmd`s and `Log`s. The advantage of
this change is that commands and logs in `MockState` are now interleaved
so that we can check their order in the tests.