### PR TITLE
Use default FileAlg to implement MockFileAlg, take 2

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -13,13 +13,14 @@ import org.scalasteward.core.vcs.data.Repo
 
 class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {
-    val repo = Repo("typelevel", "cats")
+    val repo = Repo("build-tool-dispatcher", "test-1")
     val repoDir = config.workspace / repo.show
-    val files = Map(
-      repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
-      repoDir / ".scalafmt.conf" -> "version=2.0.0"
-    )
-    val initial = MockState.empty.copy(files = files)
+    val initial = MockState.empty
+      .addFiles(
+        repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
+        repoDir / ".scalafmt.conf" -> "version=2.0.0"
+      )
+      .unsafeRunSync()
     val (state, deps) =
       buildToolDispatcher.getDependencies(repo).run(initial).unsafeRunSync()
 

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
@@ -3,45 +3,47 @@ package org.scalasteward.core.io
 import better.files.File
 import cats.data.StateT
 import cats.effect.IO
+import cats.syntax.all._
 import fs2.Stream
 import org.http4s.Uri
-import org.scalasteward.core.mock.{applyPure, MockEff, MockState}
+import org.scalasteward.core.io.FileAlgTest.ioFileAlg
+import org.scalasteward.core.mock.{MockEff, MockState}
 
 class MockFileAlg extends FileAlg[MockEff] {
   override def deleteForce(file: File): MockEff[Unit] =
-    StateT.modify(_.exec(List("rm", "-rf", file.pathAsString)).rm(file))
+    StateT.modifyF[IO, MockState](_.exec(List("rm", "-rf", file.pathAsString)).rmFile(file))
 
   override def ensureExists(dir: File): MockEff[File] =
-    applyPure(s => (s.exec(List("mkdir", "-p", dir.pathAsString)), dir))
+    StateT.modify[IO, MockState](_.exec(List("mkdir", "-p", dir.pathAsString))) >>
+      StateT.liftF(ioFileAlg.ensureExists(dir))
 
   override def home: MockEff[File] =
-    StateT.pure(File.root / "tmp" / "steward")
+    StateT.pure(File.temp / "steward")
 
   override def isDirectory(file: File): MockEff[Boolean] =
-    StateT.pure(false)
+    StateT.modify[IO, MockState](_.exec(List("test", "-d", file.pathAsString))) >>
+      StateT.liftF(ioFileAlg.isDirectory(file))
 
   override def isRegularFile(file: File): MockEff[Boolean] =
-    for {
-      _ <- StateT.modify[IO, MockState](_.exec(List("test", "-f", file.pathAsString)))
-      s <- StateT.get[IO, MockState]
-      exists = s.files.contains(file)
-    } yield exists
+    StateT.modify[IO, MockState](_.exec(List("test", "-f", file.pathAsString))) >>
+      StateT.liftF(ioFileAlg.isRegularFile(file))
 
   override def removeTemporarily[A](file: File)(fa: MockEff[A]): MockEff[A] =
     for {
       _ <- StateT.modify[IO, MockState](_.exec(List("rm", file.pathAsString)))
-      a <- fa
+      s1 <- StateT.get[IO, MockState]
+      (s2, a) <- StateT.liftF(ioFileAlg.removeTemporarily(file)(fa.run(s1)))
+      _ <- StateT.set[IO, MockState](s2)
       _ <- StateT.modify[IO, MockState](_.exec(List("restore", file.pathAsString)))
     } yield a
 
   override def readFile(file: File): MockEff[Option[String]] =
-    applyPure(s => (s.exec(List("read", file.pathAsString)), s.files.get(file)))
+    StateT.modify[IO, MockState](_.exec(List("read", file.pathAsString))) >>
+      StateT.liftF(ioFileAlg.readFile(file))
 
   override def readResource(resource: String): MockEff[String] =
-    for {
-      _ <- StateT.modify[IO, MockState](_.exec(List("read", s"classpath:$resource")))
-      content <- StateT.liftF(FileAlgTest.ioFileAlg.readResource(resource))
-    } yield content
+    StateT.modify[IO, MockState](_.exec(List("read", s"classpath:$resource"))) >>
+      StateT.liftF(ioFileAlg.readResource(resource))
 
   override def readUri(uri: Uri): MockEff[String] =
     for {
@@ -53,14 +55,15 @@ class MockFileAlg extends FileAlg[MockEff] {
       })
     } yield content
 
-  override def walk(dir: File): Stream[MockEff, File] = {
-    val dirAsString = dir.pathAsString
-    val state: MockEff[List[File]] = StateT.inspect {
-      _.files.keys.filter(_.pathAsString.startsWith(dirAsString)).toList
-    }
-    Stream.eval(state).flatMap(Stream.emits[MockEff, File])
-  }
+  override def walk(dir: File): Stream[MockEff, File] =
+    Stream.evals(
+      StateT.liftF[IO, MockState, List[File]](
+        ioFileAlg.walk(dir).compile.toList.map(_.sortBy(_.pathAsString))
+      )
+    )
 
   override def writeFile(file: File, content: String): MockEff[Unit] =
-    StateT.modify(_.exec(List("write", file.pathAsString)).add(file, content))
+    StateT.modifyF[IO, MockState](
+      _.exec(List("write", file.pathAsString)).addFiles(file -> content)
+    )
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.mock.{MockEff, MockState}
 class JsonKeyValueStoreTest extends FunSuite {
   test("put, get") {
     val p = for {
-      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test", "0")
+      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test-1", "0")
       _ <- kvStore.put("k1", "v1")
       v1 <- kvStore.get("k1")
       _ <- kvStore.put("k2", "v2")
@@ -19,9 +19,9 @@ class JsonKeyValueStoreTest extends FunSuite {
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
     assertEquals(value, (Some("v1"), None))
 
-    val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
-    val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
-    val k3File = config.workspace / "store" / "test" / "v0" / "k3" / "test.json"
+    val k1File = config.workspace / "store" / "test-1" / "v0" / "k1" / "test-1.json"
+    val k2File = config.workspace / "store" / "test-1" / "v0" / "k2" / "test-1.json"
+    val k3File = config.workspace / "store" / "test-1" / "v0" / "k3" / "test-1.json"
     val expected = MockState.empty.copy(
       trace = Vector(
         Cmd("write", k1File.toString),
@@ -39,7 +39,7 @@ class JsonKeyValueStoreTest extends FunSuite {
 
   test("modifyF, get, set") {
     val p = for {
-      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test", "0")
+      kvStore <- JsonKeyValueStore.create[MockEff, String, String]("test-2", "0")
       _ <- kvStore.modifyF("k1")(_ => Option("v0").pure[MockEff])
       v1 <- kvStore.get("k1")
       _ <- kvStore.set("k1", None)
@@ -47,7 +47,7 @@ class JsonKeyValueStoreTest extends FunSuite {
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
     assertEquals(value, Some("v0"))
 
-    val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
+    val k1File = config.workspace / "store" / "test-2" / "v0" / "k1" / "test-2.json"
     val expected = MockState.empty.copy(
       trace = Vector(
         Cmd("read", k1File.toString),
@@ -62,7 +62,7 @@ class JsonKeyValueStoreTest extends FunSuite {
   test("cached") {
     val p = for {
       kvStore <- JsonKeyValueStore
-        .create[MockEff, String, String]("test", "0")
+        .create[MockEff, String, String]("test-3", "0")
         .flatMap(CachingKeyValueStore.wrap(_))
       _ <- kvStore.put("k1", "v1")
       v1 <- kvStore.get("k1")
@@ -71,8 +71,8 @@ class JsonKeyValueStoreTest extends FunSuite {
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
     assertEquals(value, (Some("v1"), None))
 
-    val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
-    val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
+    val k1File = config.workspace / "store" / "test-3" / "v0" / "k1" / "test-3.json"
+    val k2File = config.workspace / "store" / "test-3" / "v0" / "k2" / "test-3.json"
     val expected = MockState.empty.copy(
       trace = Vector(Cmd("write", k1File.toString), Cmd("read", k2File.toString)),
       files = Map(k1File -> """"v1"""")

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -32,7 +32,7 @@ class RepoConfigAlgTest extends FunSuite {
          |commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
          |buildRoots = [ ".", "subfolder/subfolder" ]
          |""".stripMargin
-    val initialState = MockState.empty.add(configFile, content)
+    val initialState = MockState.empty.addFiles(configFile -> content).unsafeRunSync()
     val config = repoConfigAlg
       .readRepoConfig(repo)
       .flatMap(repoConfigAlg.mergeWithDefault)
@@ -158,7 +158,8 @@ class RepoConfigAlgTest extends FunSuite {
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
-    val initialState = MockState.empty.add(configFile, """updates.ignore = [ "foo """)
+    val initialState =
+      MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
     val (state, config) = repoConfigAlg.readRepoConfig(repo).run(initialState).unsafeRunSync()
 
     assertEquals(config, None)

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
@@ -48,7 +48,7 @@ class MigrationsLoaderTest extends FunSuite {
   }
 
   test("loadAll: with extra file, without defaults") {
-    val initialState = mockState.addUri(migrationsUri, migrationsContent)
+    val initialState = mockState.addUris(migrationsUri -> migrationsContent)
     val migrations = migrationsLoader
       .loadAll(ScalafixCfg(List(migrationsUri), disableDefaults = true))
       .runA(initialState)
@@ -57,7 +57,7 @@ class MigrationsLoaderTest extends FunSuite {
   }
 
   test("loadAll: with extra file, with defaults") {
-    val initialState = mockState.addUri(migrationsUri, migrationsContent)
+    val initialState = mockState.addUris(migrationsUri -> migrationsContent)
     val migrations = migrationsLoader
       .loadAll(ScalafixCfg(List(migrationsUri), disableDefaults = false))
       .runA(initialState)
@@ -67,7 +67,7 @@ class MigrationsLoaderTest extends FunSuite {
   }
 
   test("loadAll: malformed extra file") {
-    val initialState = mockState.addUri(migrationsUri, """{"key": "i'm not a valid Migration}""")
+    val initialState = mockState.addUris(migrationsUri -> """{"key": "i'm not a valid Migration}""")
     val migrations = migrationsLoader
       .loadAll(ScalafixCfg(List(migrationsUri), disableDefaults = false))
       .runA(initialState)
@@ -78,8 +78,8 @@ class MigrationsLoaderTest extends FunSuite {
 }
 
 object MigrationsLoaderTest {
-  val mockState: MockState = MockState.empty.addUri(
-    MigrationsLoader.defaultScalafixMigrationsUrl,
-    ioFileAlg.readResource("scalafix-migrations.conf").unsafeRunSync()
+  val mockState: MockState = MockState.empty.addUris(
+    MigrationsLoader.defaultScalafixMigrationsUrl ->
+      ioFileAlg.readResource("scalafix-migrations.conf").unsafeRunSync()
   )
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -14,13 +14,12 @@ class ScalafmtAlgTest extends FunSuite {
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.owner / repo.repo
     val scalafmtConf = repoDir / ".scalafmt.conf"
-    val initialState = MockState.empty.add(
-      scalafmtConf,
-      """maxColumn = 100
-        |version=2.0.0-RC8
-        |align.openParenCallSite = false
-        |""".stripMargin
-    )
+    val initialState = MockState.empty
+      .addFiles(scalafmtConf -> """maxColumn = 100
+                                  |version=2.0.0-RC8
+                                  |align.openParenCallSite = false
+                                  |""".stripMargin)
+      .unsafeRunSync()
     val (state, maybeVersion) =
       scalafmtAlg.getScalafmtVersion(buildRoot).run(initialState).unsafeRunSync()
     val expectedState = MockState.empty.copy(
@@ -43,13 +42,12 @@ class ScalafmtAlgTest extends FunSuite {
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.owner / repo.repo
     val scalafmtConf = repoDir / ".scalafmt.conf"
-    val initialState = MockState.empty.add(
-      scalafmtConf,
-      """maxColumn = 100
-        |version="2.0.0-RC8"
-        |align.openParenCallSite = false
-        |""".stripMargin
-    )
+    val initialState = MockState.empty
+      .addFiles(scalafmtConf -> """maxColumn = 100
+                                  |version="2.0.0-RC8"
+                                  |align.openParenCallSite = false
+                                  |""".stripMargin)
+      .unsafeRunSync()
     val (_, maybeVersion) =
       scalafmtAlg.getScalafmtVersion(buildRoot).run(initialState).unsafeRunSync()
     assertEquals(maybeVersion, Some(Version("2.0.0-RC8")))

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -56,8 +56,7 @@ class PruningAlgTest extends FunSuite {
           |    "entryCreatedAt" : 1581969227183
           |  }
           |}""".stripMargin
-    val initial = MockState.empty
-      .add(pullRequestsFile, pullRequestsContent)
+    val initial = MockState.empty.addFiles(pullRequestsFile -> pullRequestsContent).unsafeRunSync()
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(
@@ -159,8 +158,8 @@ class PruningAlgTest extends FunSuite {
           |}
           |""".stripMargin
     val initial = MockState.empty
-      .add(pullRequestsFile, pullRequestsContent)
-      .add(versionsFile, versionsContent)
+      .addFiles(pullRequestsFile -> pullRequestsContent, versionsFile -> versionsContent)
+      .unsafeRunSync()
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(
@@ -262,8 +261,8 @@ class PruningAlgTest extends FunSuite {
           |}
           |""".stripMargin
     val initial = MockState.empty
-      .add(pullRequestsFile, pullRequestsContent)
-      .add(versionsFile, versionsContent)
+      .addFiles(pullRequestsFile -> pullRequestsContent, versionsFile -> versionsContent)
+      .unsafeRunSync()
     val data = RepoData(repo, repoCache, repoCache.maybeRepoConfig.getOrElse(RepoConfig.empty))
     val state = pruningAlg.needsAttention(data).runS(initial).unsafeRunSync()
     val expected = initial.copy(


### PR DESCRIPTION
This changes `MockFileAlg` such that it not only modifies the `MockState` but also files in the filesystem via the default `FileAlg` implementation. The main motivation for this change is to make using actual Git commands in tests possible. Another advantage is that we increase the coverage of the default `FileAlg`. A disadvantage is that tests can now be influenced by existing or deleted files. So we need to be more careful now that tests do not write files in the same location.