### PR TITLE
Use a common root directory for file operations in tests

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -4,8 +4,8 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Resolver, Scope, Version}
-import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
+import org.scalasteward.core.mock.MockContext.{config, mockRoot}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.scalafmt
@@ -27,7 +27,7 @@ class BuildToolDispatcherTest extends FunSuite {
     val expectedState = initial.copy(trace =
       Vector(
         Cmd("read", s"$repoDir/.scala-steward.conf"),
-        Cmd("read", s"/tmp/default.scala-steward.conf"),
+        Cmd("read", s"$mockRoot/default.scala-steward.conf"),
         Cmd("test", "-f", s"$repoDir/pom.xml"),
         Cmd("test", "-f", s"$repoDir/build.sc"),
         Cmd("test", "-f", s"$repoDir/build.sbt"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.mock.MockContext.context.sbtAlg
-import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.{config, mockRoot}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.scalafix.Migration
@@ -22,11 +22,11 @@ class SbtAlgTest extends FunSuite {
       trace = Vector(
         Log("Add global sbt plugins"),
         Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
-        Cmd("write", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala"),
-        Cmd("write", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala"),
+        Cmd("write", s"$mockRoot/.sbt/0.13/plugins/StewardPlugin.scala"),
+        Cmd("write", s"$mockRoot/.sbt/1.0/plugins/StewardPlugin.scala"),
         Cmd("fa"),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala"),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala")
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/1.0/plugins/StewardPlugin.scala"),
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/0.13/plugins/StewardPlugin.scala")
       )
     )
     assertEquals(obtained, expected)
@@ -75,8 +75,8 @@ class SbtAlgTest extends FunSuite {
     val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       trace = Vector(
-        Cmd("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
-        Cmd("write", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
+        Cmd("write", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
+        Cmd("write", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         Cmd(
           repoDir.toString,
           "firejail",
@@ -90,8 +90,8 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.supershell=false",
           s";$scalafixEnable;$scalafixAll github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt")
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt")
       )
     )
     assertEquals(state, expected)
@@ -112,8 +112,8 @@ class SbtAlgTest extends FunSuite {
     val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       trace = Vector(
-        Cmd("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
-        Cmd("write", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
+        Cmd("write", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
+        Cmd("write", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         Cmd("write", s"$repoDir/scala-steward-scalafix-options.sbt"),
         Cmd(
           repoDir.toString,
@@ -129,8 +129,8 @@ class SbtAlgTest extends FunSuite {
           s";$scalafixEnable;$scalafixAll github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"
         ),
         Cmd("rm", "-rf", s"$repoDir/scala-steward-scalafix-options.sbt"),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
-        Cmd("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt")
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
+        Cmd("rm", "-rf", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt")
       )
     )
     assertEquals(state, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -1,6 +1,5 @@
 package org.scalasteward.core.edit
 
-import better.files.File
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
@@ -238,7 +237,7 @@ class EditAlgTest extends FunSuite {
   }
 
   private def runApplyUpdate(update: Update, files: Map[String, String]): Map[String, String] = {
-    val repoDir = File.temp / "ws/owner/repo"
+    val repoDir = config.workspace / "owner/repo"
     val filesInRepoDir = files.map { case (file, content) => repoDir / file -> content }
     MockState.empty
       .addFiles(filesInRepoDir.toSeq: _*)

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.git.FileGitAlgTest.{master, Supplement}
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.{config, mockRoot}
 import org.scalasteward.core.util.Nel
 
 class FileGitAlgTest extends FunSuite {
@@ -18,7 +18,7 @@ class FileGitAlgTest extends FunSuite {
   implicit private val ioGitAlg: GenGitAlg[IO, File] =
     new FileGitAlg[IO](config.gitCfg).contramapRepoF(IO.pure)
   private val supplement = new Supplement[IO]
-  private val rootDir = File.temp / "scala-steward" / "git-tests"
+  private val rootDir = mockRoot / "git-tests"
 
   test("branchAuthors") {
     val repo = rootDir / "branchAuthors"

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import fs2.Stream
 import org.http4s.Uri
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockContext, MockEff, MockState}
 
 class MockFileAlg extends FileAlg[MockEff] {
   override def deleteForce(file: File): MockEff[Unit] =
@@ -18,7 +18,7 @@ class MockFileAlg extends FileAlg[MockEff] {
       StateT.liftF(ioFileAlg.ensureExists(dir))
 
   override def home: MockEff[File] =
-    StateT.pure(File.temp / "steward")
+    StateT.pure(MockContext.mockRoot)
 
   override def isDirectory(file: File): MockEff[Boolean] =
     StateT.modify[IO, MockState](_.exec(List("test", "-d", file.pathAsString))) >>

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -7,7 +7,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.application.Config.{ProcessCfg, SandboxCfg}
 import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
-import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.mock.MockContext.{config, mockRoot}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
@@ -35,12 +35,12 @@ class ProcessAlgTest extends FunSuite {
     val cfg = ProcessCfg(Nil, Duration.Zero, SandboxCfg(Nil, Nil, enableSandbox = false), 8192)
     val state = MockProcessAlg
       .create(cfg)
-      .execSandboxed(Nel.of("echo", "hello"), File.temp)
+      .execSandboxed(Nel.of("echo", "hello"), mockRoot)
       .runS(MockState.empty)
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
-      trace = Vector(Cmd(File.temp.toString, "echo", "hello"))
+      trace = Vector(Cmd(mockRoot.toString, "echo", "hello"))
     )
 
     assertEquals(state, expected)
@@ -50,13 +50,13 @@ class ProcessAlgTest extends FunSuite {
     val cfg = ProcessCfg(Nil, Duration.Zero, SandboxCfg(Nil, Nil, enableSandbox = true), 8192)
     val state = MockProcessAlg
       .create(cfg)
-      .execSandboxed(Nel.of("echo", "hello"), File.temp)
+      .execSandboxed(Nel.of("echo", "hello"), mockRoot)
       .runS(MockState.empty)
       .unsafeRunSync()
 
     val expected = MockState.empty.copy(
       trace = Vector(
-        Cmd(File.temp.toString, "firejail", "--quiet", s"--whitelist=${File.temp}", "echo", "hello")
+        Cmd(mockRoot.toString, "firejail", "--quiet", s"--whitelist=$mockRoot", "echo", "hello")
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -16,16 +16,17 @@ import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
 object MockContext {
+  val mockRoot: File = File.temp / "scala-steward"
   val args: Cli.Args = Cli.Args(
-    workspace = File.temp / "ws",
-    reposFile = File.temp / "repos.md",
-    defaultRepoConf = Some(File.temp / "default.scala-steward.conf"),
+    workspace = mockRoot / "workspace",
+    reposFile = mockRoot / "repos.md",
+    defaultRepoConf = Some(mockRoot / "default.scala-steward.conf"),
     gitAuthorName = "Bot Doe",
     gitAuthorEmail = "bot@example.org",
     vcsType = VCSType.GitHub,
     vcsApiHost = Uri(),
     vcsLogin = "bot-doe",
-    gitAskPass = File.temp / "askpass.sh",
+    gitAskPass = mockRoot / "askpass.sh",
     enableSandbox = Some(true),
     envVar = List(EnvVar("VAR1", "val1"), EnvVar("VAR2", "val2")),
     cacheTtl = 1.hour

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,13 +1,12 @@
 package org.scalasteward.core.repoconfig
 
-import better.files.File
 import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.context.repoConfigAlg
-import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
+import org.scalasteward.core.mock.{MockContext, MockState}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
@@ -15,7 +14,7 @@ import scala.concurrent.duration._
 class RepoConfigAlgTest extends FunSuite {
   test("config with all fields set") {
     val repo = Repo("fthomas", "scala-steward")
-    val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
+    val configFile = MockContext.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
     val content =
       """|updates.allow  = [ { groupId = "eu.timepit"} ]
          |updates.pin  = [
@@ -157,7 +156,7 @@ class RepoConfigAlgTest extends FunSuite {
 
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
-    val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
+    val configFile = MockContext.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
     val initialState =
       MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
     val (state, config) = repoConfigAlg.readRepoConfig(repo).run(initialState).unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationsLoaderTest.scala
@@ -6,12 +6,13 @@ import org.scalasteward.core.application.Config.ScalafixCfg
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.mock.MockContext.context.migrationsLoader
+import org.scalasteward.core.mock.MockContext.mockRoot
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.scalafix.MigrationsLoaderTest.mockState
 import org.scalasteward.core.util.Nel
 
 class MigrationsLoaderTest extends FunSuite {
-  val migrationsUri: Uri = Uri.unsafeFromString("/tmp/scala-steward/extra-migrations.conf")
+  val migrationsUri: Uri = Uri.unsafeFromString(s"$mockRoot/extra-migrations.conf")
   val migrationsContent: String =
     """|migrations = [
        |  {


### PR DESCRIPTION
And do not reference `/tmp` directly.