### PR TITLE
Migrate log4cats artifacts

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -24,6 +24,30 @@ changes = [
     initialVersion = 1.0.0
   },
   {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-core
+    initialVersion = 1.2.0
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-noop
+    initialVersion = 1.2.0
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-slf4j
+    initialVersion = 1.2.0
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-testing
+    initialVersion = 1.2.0
+  },
+  {
     groupIdBefore = net.ceedubs
     groupIdAfter = com.iheart
     artifactIdAfter = ficus

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -50,6 +50,12 @@ migrations = [
     rewriteRules: ["github:zio/zio/CurriedAssert?sha=v1.0.0-RC18"]
   },
   {
+    groupId: "io.chrisdavenport",
+    artifactIds: ["log4cats-.*"],
+    newVersion: "1.2.0",
+    rewriteRules: ["https://gist.githubusercontent.com/fthomas/ea14d58e1b445d8038a5bc22acf751e8/raw/0ee15caf71aedc26516ecf2f0c4567b5a7682d3e/log4cats-1.2.0.scala"]
+  },
+  {
     groupId: "org.http4s",
     artifactIds: ["http4s-.*"],
     newVersion: "0.21.5",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -53,7 +53,7 @@ migrations = [
     groupId: "io.chrisdavenport",
     artifactIds: ["log4cats-.*"],
     newVersion: "1.2.0",
-    rewriteRules: ["https://gist.githubusercontent.com/fthomas/ea14d58e1b445d8038a5bc22acf751e8/raw/0ee15caf71aedc26516ecf2f0c4567b5a7682d3e/log4cats-1.2.0.scala"]
+    rewriteRules: ["https://gist.githubusercontent.com/fthomas/ea14d58e1b445d8038a5bc22acf751e8/raw/e1180c91dab0b36d8f9ec37d413ef9507bee67ff/log4cats-1.2.0.scala"]
   },
   {
     groupId: "org.http4s",


### PR DESCRIPTION
I was just made aware that log4cats is now published under `org.typelevel`.  This will rewrite the organization of log4cats-core, log4cats-noop, log4cats-slf4j, and log4cats-testing. The package names for these were also changed from `io.chrisdavenport.log4cats` to `org.typelevel.log4cats`, so if we merge this all update PRs will fail because of that source incompatibility. In theory this could be salvaged with a Scalafix migration that rewrites the imports and is used at the same time, but I'm not sure if it is worth the hassle.

/cc @ChristopherDavenport, @rossabaker 