### PR TITLE
Added support for GitLab draft MRs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -42,7 +42,14 @@ final private[gitlab] case class MergeRequestPayload(
 
 private[gitlab] object MergeRequestPayload {
   def apply(id: String, projectId: Long, data: NewPullRequestData): MergeRequestPayload =
-    MergeRequestPayload(id, data.title, data.body, projectId, data.head, data.base)
+    MergeRequestPayload(
+      id,
+      List(if (data.draft) "Draft: " else "", data.title).mkString,
+      data.body,
+      projectId,
+      data.head,
+      data.base
+    )
 }
 
 final private[gitlab] case class MergeRequestOut(

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/MergeRequestPayloadTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/MergeRequestPayloadTest.scala
@@ -1,0 +1,48 @@
+package org.scalasteward.core.vcs.gitlab
+
+import io.circe.syntax._
+import io.circe.literal._
+import munit.FunSuite
+import org.scalasteward.core.git.Branch
+import org.scalasteward.core.vcs.data.NewPullRequestData
+import org.scalasteward.core.vcs.gitlab.GitLabJsonCodec._
+
+class MergeRequestPayloadTest extends FunSuite {
+  private val master = Branch("master")
+  private val data = NewPullRequestData(
+    "Test MR title",
+    "Test MR body",
+    "source",
+    master
+  )
+  private val id = "123"
+  private val projectId = 321L
+
+  test("asJson") {
+    val obtained = MergeRequestPayload(id, projectId, data).asJson
+    val expected =
+      json"""{
+               "id" : "123",
+               "title" : "Test MR title",
+               "description" : "Test MR body",
+               "target_project_id" : 321,
+               "source_branch" : "source",
+               "target_branch" : "master"
+             }"""
+    assertEquals(obtained, expected)
+  }
+
+  test("asJson for draft MR") {
+    val obtained = MergeRequestPayload(id, projectId, data.copy(draft = true)).asJson
+    val expected =
+      json"""{
+               "id" : "123",
+               "title" : "Draft: Test MR title",
+               "description" : "Test MR body",
+               "target_project_id" : 321,
+               "source_branch" : "source",
+               "target_branch" : "master"
+             }"""
+    assertEquals(obtained, expected)
+  }
+}


### PR DESCRIPTION
GitLab support for draft MRs introduced in #1961 (see [`NewPullRequestData`](https://github.com/scala-steward-org/scala-steward/pull/1961/files#diff-9f88dbf5ecab0e5057fa1fff36ae22860f197aa6cfb0d1b0d62a8bb74a6d2321R43))