### PR TITLE
Tweak URL for the Cats Effect 2.4.0 Scalafix migration

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -121,7 +121,7 @@ migrations = [
     groupId: "org.typelevel",
     artifactIds: ["cats-effect", "cats-effect-laws"],
     newVersion: "2.4.0",
-    rewriteRules: ["github:typelevel/cats-effect/v2_4_0?sha=v2.4.0"],
+    rewriteRules: ["github:typelevel/cats-effect/v2_4_0?sha=series/2.x"],
     doc: "https://github.com/typelevel/cats-effect/blob/v2.4.0/scalafix/README.md"
   },
   {


### PR DESCRIPTION
I normally prefer immutable references but in this case I want to make
sure that the Scalafix can be run in case the `v2.4.0` tag has not been
pushed after the release happened.

See also #1982.