### PR TITLE
Ignore build roots that contain '..'

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,7 +31,9 @@ final case class RepoConfig(
     buildRoots: Option[List[BuildRootConfig]] = None
 ) {
   def buildRootsOrDefault: List[BuildRootConfig] =
-    buildRoots.getOrElse(List(BuildRootConfig.repoRoot))
+    buildRoots
+      .map(_.filterNot(_.relativePath.contains("..")))
+      .getOrElse(List(BuildRootConfig.repoRoot))
 
   def updatePullRequestsOrDefault: PullRequestUpdateStrategy =
     updatePullRequests.getOrElse(PullRequestUpdateStrategy.default)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -200,6 +200,12 @@ class RepoConfigAlgTest extends FunSuite {
     assertEquals(config, Right(expected))
   }
 
+  test("build root with '..'") {
+    val content = """buildRoots = [ "../../../etc" ]"""
+    val config = RepoConfigAlg.parseRepoConfig(content).map(_.buildRootsOrDefault)
+    assertEquals(config, Right(Nil))
+  }
+
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = MockContext.config.workspace / "fthomas/scala-steward/.scala-steward.conf"


### PR DESCRIPTION
This should prevent exiting Scala Steward's workspace using build roots
that contain `..`.