### PR TITLE
Do not make BuildToolDispatcher a subclass of BuildToolAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -142,8 +142,7 @@ object Context {
       implicit val mavenAlg: MavenAlg[F] = MavenAlg.create[F](config)
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F](config)
       implicit val millAlg: MillAlg[F] = MillAlg.create[F]
-      implicit val buildToolDispatcher: BuildToolDispatcher[F] =
-        BuildToolDispatcher.create[F](config)
+      implicit val buildToolDispatcher: BuildToolDispatcher[F] = new BuildToolDispatcher[F](config)
       implicit val refreshErrorAlg: RefreshErrorAlg[F] = new RefreshErrorAlg[F](refreshErrorStore)
       implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F](config)
       implicit val editAlg: EditAlg[F] = new EditAlg[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
@@ -18,11 +18,12 @@ package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
+import org.scalasteward.core.vcs.data.BuildRoot
 
-trait BuildToolAlg[F[_], R] {
-  def containsBuild(r: R): F[Boolean]
+trait BuildToolAlg[F[_]] {
+  def containsBuild(buildRoot: BuildRoot): F[Boolean]
 
-  def getDependencies(r: R): F[List[Scope.Dependencies]]
+  def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]]
 
-  def runMigration(r: R, migration: ScalafixMigration): F[Unit]
+  def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit]
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -27,7 +27,7 @@ import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
 
-trait MavenAlg[F[_]] extends BuildToolAlg[F, BuildRoot]
+trait MavenAlg[F[_]] extends BuildToolAlg[F]
 
 object MavenAlg {
   def create[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -27,7 +27,7 @@ import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
 
-trait MillAlg[F[_]] extends BuildToolAlg[F, BuildRoot]
+trait MillAlg[F[_]] extends BuildToolAlg[F]
 
 object MillAlg {
   private val content =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -32,7 +32,7 @@ import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
 
-trait SbtAlg[F[_]] extends BuildToolAlg[F, BuildRoot] {
+trait SbtAlg[F[_]] extends BuildToolAlg[F] {
   def addGlobalPluginTemporarily[A](plugin: FileData)(fa: F[A]): F[A]
 
   def addGlobalPlugins[A](fa: F[A]): F[A]


### PR DESCRIPTION
This inheritance was an unnecessary complication since we don't pass
the dispatcher to code that expects a `BuildToolAlg`. This change allows
us to remove `BuildToolDispatcher#containsBuild` which was never used.