### PR TITLE
Parse RepoConfig only once

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -20,20 +20,19 @@ import better.files.File
 import cats.effect.{BracketThrow, ExitCode}
 import cats.syntax.all._
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.scalasteward.core.buildtool.sbt.SbtAlg
-import org.scalasteward.core.data.RepoData
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
 import org.scalasteward.core.repocache.RepoCacheAlg
-import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.update.PruningAlg
 import org.scalasteward.core.util
 import org.scalasteward.core.util.DateTimeAlg
 import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.vcs.github.{GitHubApp, GitHubAppApiAlg, GitHubAuthAlg}
+import org.typelevel.log4cats.Logger
+
 import scala.concurrent.duration._
 
 final class StewardAlg[F[_]](config: Config)(implicit
@@ -46,7 +45,6 @@ final class StewardAlg[F[_]](config: Config)(implicit
     nurtureAlg: NurtureAlg[F],
     pruningAlg: PruningAlg[F],
     repoCacheAlg: RepoCacheAlg[F],
-    repoConfigAlg: RepoConfigAlg[F],
     sbtAlg: SbtAlg[F],
     selfCheckAlg: SelfCheckAlg[F],
     streamCompiler: Stream.Compiler[F, F],
@@ -90,9 +88,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
       logger.attemptLogLabel(util.string.lineLeftRight(label), Some(label)) {
         F.guarantee {
           for {
-            (cache, fork) <- repoCacheAlg.checkCache(repo)
-            config <- repoConfigAlg.mergeWithDefault(cache.maybeRepoConfig)
-            data = RepoData(repo, cache, config)
+            (data, fork) <- repoCacheAlg.checkCache(repo)
             (attentionNeeded, updates) <- pruningAlg.needsAttention(data)
             _ <- if (attentionNeeded) nurtureAlg.nurture(data, fork, updates) else F.unit
           } yield ()

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -18,14 +18,14 @@ package org.scalasteward.core.repocache
 
 import cats.syntax.all._
 import cats.{MonadThrow, Parallel}
-import org.typelevel.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildToolDispatcher
-import org.scalasteward.core.data.{Dependency, DependencyInfo}
+import org.scalasteward.core.data.{Dependency, DependencyInfo, RepoData}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
+import org.typelevel.log4cats.Logger
 
 final class RepoCacheAlg[F[_]](config: Config)(implicit
     buildToolDispatcher: BuildToolDispatcher[F],
@@ -39,7 +39,7 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
     vcsRepoAlg: VCSRepoAlg[F],
     F: MonadThrow[F]
 ) {
-  def checkCache(repo: Repo): F[(RepoCache, RepoOut)] =
+  def checkCache(repo: Repo): F[(RepoData, RepoOut)] =
     logger.info(s"Check cache of ${repo.show}") >>
       refreshErrorAlg.skipIfFailedRecently(repo) {
         for {
@@ -48,32 +48,38 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
             repoCacheRepository.findCache(repo)
           ).parTupled
           latestSha1 = branchOut.commit.sha
-          cache <- maybeCache
+          data <- maybeCache
             .filter(_.sha1 === latestSha1)
-            .fold(cloneAndRefreshCache(repo, repoOut))(F.pure)
-        } yield (cache, repoOut)
+            .fold(cloneAndRefreshCache(repo, repoOut))(supplementCache(repo, _))
+        } yield (data, repoOut)
       }
 
-  private def cloneAndRefreshCache(repo: Repo, repoOut: RepoOut): F[RepoCache] =
+  private def supplementCache(repo: Repo, cache: RepoCache): F[RepoData] =
+    repoConfigAlg.mergeWithDefault(cache.maybeRepoConfig).map { config =>
+      RepoData(repo, cache, config)
+    }
+
+  private def cloneAndRefreshCache(repo: Repo, repoOut: RepoOut): F[RepoData] =
     vcsRepoAlg.cloneAndSync(repo, repoOut) >> refreshCache(repo)
 
-  private def refreshCache(repo: Repo): F[RepoCache] =
+  private def refreshCache(repo: Repo): F[RepoData] =
     for {
       _ <- logger.info(s"Refresh cache of ${repo.show}")
-      cache <- refreshErrorAlg.persistError(repo)(computeCache(repo))
-      _ <- repoCacheRepository.updateCache(repo, cache)
-    } yield cache
+      data <- refreshErrorAlg.persistError(repo)(computeCache(repo))
+      _ <- repoCacheRepository.updateCache(repo, data.cache)
+    } yield data
 
-  private def computeCache(repo: Repo): F[RepoCache] =
+  private def computeCache(repo: Repo): F[RepoData] =
     for {
       branch <- gitAlg.currentBranch(repo)
       latestSha1 <- gitAlg.latestSha1(repo, branch)
-      dependencies <- buildToolDispatcher.getDependencies(repo)
+      maybeConfig <- repoConfigAlg.readRepoConfig(repo)
+      config <- repoConfigAlg.mergeWithDefault(maybeConfig)
+      dependencies <- buildToolDispatcher.getDependencies(repo, config)
       dependencyInfos <-
-        dependencies
-          .traverse(_.traverse(_.traverse(gatherDependencyInfo(repo, _))))
-      maybeRepoConfig <- repoConfigAlg.readRepoConfig(repo)
-    } yield RepoCache(latestSha1, dependencyInfos, maybeRepoConfig)
+        dependencies.traverse(_.traverse(_.traverse(gatherDependencyInfo(repo, _))))
+      cache = RepoCache(latestSha1, dependencyInfos, maybeConfig)
+    } yield RepoData(repo, cache, config)
 
   private def gatherDependencyInfo(repo: Repo, dependency: Dependency): F[DependencyInfo] =
     gitAlg.findFilesContaining(repo, dependency.version).map(DependencyInfo(dependency, _))

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -4,16 +4,18 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Resolver, Scope, Version}
+import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
-import org.scalasteward.core.mock.MockContext.{config, mockRoot}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.vcs.data.Repo
 
 class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("build-tool-dispatcher", "test-1")
+    val repoConfig = RepoConfig.empty
     val repoDir = config.workspace / repo.show
     val initial = MockState.empty
       .addFiles(
@@ -22,12 +24,10 @@ class BuildToolDispatcherTest extends FunSuite {
       )
       .unsafeRunSync()
     val (state, deps) =
-      buildToolDispatcher.getDependencies(repo).run(initial).unsafeRunSync()
+      buildToolDispatcher.getDependencies(repo, repoConfig).run(initial).unsafeRunSync()
 
     val expectedState = initial.copy(trace =
       Vector(
-        Cmd("read", s"$repoDir/.scala-steward.conf"),
-        Cmd("read", s"$mockRoot/default.scala-steward.conf"),
         Cmd("test", "-f", s"$repoDir/pom.xml"),
         Cmd("test", "-f", s"$repoDir/build.sc"),
         Cmd("test", "-f", s"$repoDir/build.sbt"),


### PR DESCRIPTION
Instead of reading and parsing a repo's config twice in `RepoCacheAlg`
and `BuildToolDispatcher` we now only parse it once in `RepoCacheAlg`
and then pass that value to `BuildToolDispatcher`.