### PR TITLE
Implement Version.Component.parse with cats-parse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val core = myCrossProject("core")
       Dependencies.caseApp,
       Dependencies.catsCore,
       Dependencies.catsEffect,
+      Dependencies.catsParse,
       Dependencies.circeConfig,
       Dependencies.circeGeneric,
       Dependencies.circeGenericExtras,

--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionBenchmark.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.benchmark
 
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
-import org.scalasteward.core.data.Version
+import org.scalasteward.core.data.Version.Component
 
 import java.util.concurrent.TimeUnit
 
@@ -25,9 +25,9 @@ import java.util.concurrent.TimeUnit
 class VersionBenchmark {
   @Benchmark
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  def constructor: Any = {
-    Version("1.1.2-1")
-    Version("8.0.192-R14")
-    Version("1.2.0+9-4a769501")
+  def parseBench: Any = {
+    Component.parse("1.1.2-1")
+    Component.parse("8.0.192-R14")
+    Component.parse("1.2.0+9-4a769501")
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % "2.3.3"
   val catsCore = "org.typelevel" %% "cats-core" % "2.4.2"
   val catsLaws = "org.typelevel" %% "cats-laws" % catsCore.revision
+  val catsParse = "org.typelevel" %% "cats-parse" % "0.3.1"
   val circeConfig = "io.circe" %% "circe-config" % "0.8.0"
   val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   val circeGenericExtras = "io.circe" %% "circe-generic-extras" % "0.13.0"


### PR DESCRIPTION
This implements `Version.Component.parse` with cats-parse which gives a nice performance improvement:
```
master:
[info] Benchmark                    Mode  Cnt   Score   Error  Units
[info] VersionBenchmark.parseBench  avgt    3  10.233 ± 0.329  us/op

topic/cats-parse:
[info] Benchmark                    Mode  Cnt  Score   Error  Units
[info] VersionBenchmark.parseBench  avgt    3  6.979 ± 0.692  us/op
```

This change is of course totally irrelevant for the overall performance of Scala Steward. Playing with and getting a feel for cats-parse was the main motivation here.