### PR TITLE
Improve performance of Version.startsWithDate

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionBenchmark.scala
@@ -29,5 +29,6 @@ class VersionBenchmark {
     Component.parse("1.1.2-1")
     Component.parse("8.0.192-R14")
     Component.parse("1.2.0+9-4a769501")
+    Component.parse("1.0.0-20201119-091040")
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -113,10 +113,10 @@ object Version {
   }
 
   private def startsWithDate(s: String): Boolean =
-    """(\d{4})(\d{2})(\d{2})""".r.findPrefixMatchOf(s).exists { m =>
-      val year = m.group(1).toInt
-      val month = m.group(2).toInt
-      val day = m.group(3).toInt
+    s.length >= 8 && s.take(8).forall(_.isDigit) && {
+      val year = s.substring(0, 4).toInt
+      val month = s.substring(4, 6).toInt
+      val day = s.substring(6, 8).toInt
       (year >= 1900 && year <= 2100) &&
       (month >= 1 && month <= 12) &&
       (day >= 1 && day <= 31)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -113,7 +113,7 @@ object Version {
   }
 
   private def startsWithDate(s: String): Boolean =
-    s.length >= 8 && s.take(8).forall(_.isDigit) && {
+    s.length >= 8 && s.substring(0, 8).forall(_.isDigit) && {
       val year = s.substring(0, 4).toInt
       val month = s.substring(4, 6).toInt
       val day = s.substring(6, 8).toInt


### PR DESCRIPTION
```
master:
[info] Benchmark                    Mode  Cnt   Score   Error  Units
[info] VersionBenchmark.parseBench  avgt    3  11.632 ± 0.250  us/op

topic/improve-startsWithDate
[info] Benchmark                    Mode  Cnt  Score   Error  Units
[info] VersionBenchmark.parseBench  avgt    3  9.044 ± 0.913  us/op
```