### PR TITLE
Fix warnings about unused moduleRootPkg key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -301,7 +301,7 @@ installPlugin := {
   IO.copyFile(source, target)
 }
 
-lazy val moduleRootPkg = settingKey[String]("")
+lazy val moduleRootPkg = settingKey[String]("").withRank(KeyRanks.Invisible)
 moduleRootPkg := rootPkg
 
 // Run Scala Steward from sbt for development and testing.


### PR DESCRIPTION
This fixes these warnings:
```
[warn] there are 4 keys that are not used by any other settings/tasks:
[warn]
[warn] * benchmark / moduleRootPkg
[warn]   +- /home/runner/work/scala-steward/scala-steward/build.sbt:202
[warn] * mill-plugin / moduleRootPkg
[warn]   +- /home/runner/work/scala-steward/scala-steward/build.sbt:202
[warn] * root / moduleRootPkg
[warn]   +- /home/runner/work/scala-steward/scala-steward/build.sbt:305
[warn] * sbt-plugin / moduleRootPkg
[warn]   +- /home/runner/work/scala-steward/scala-steward/build.sbt:202
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```