### PR TITLE
Implement MockEff as Kleisli with Ref[IO, MockState]

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -24,7 +24,7 @@ class BuildToolDispatcherTest extends FunSuite {
       )
       .unsafeRunSync()
     val (state, deps) =
-      buildToolDispatcher.getDependencies(repo, repoConfig).run(initial).unsafeRunSync()
+      buildToolDispatcher.getDependencies(repo, repoConfig).runSA(initial).unsafeRunSync()
 
     val expectedState = initial.copy(trace =
       Vector(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.buildtool.sbt
 
-import cats.data.StateT
+import cats.data.Kleisli
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
@@ -15,7 +15,7 @@ import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 class SbtAlgTest extends FunSuite {
   test("addGlobalPlugins") {
     val obtained = sbtAlg
-      .addGlobalPlugins(StateT.modify(_.exec(List("fa"))))
+      .addGlobalPlugins(Kleisli(_.update(_.exec(List("fa")))))
       .runS(MockState.empty)
       .unsafeRunSync()
     val expected = MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -14,7 +14,7 @@ class CoursierAlgTest extends FunSuite {
       Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"https://github.com/typelevel/cats-effect"))
@@ -28,7 +28,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"https://github.com/playframework/play-ws"))
@@ -42,7 +42,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"http://msgpack.org/"))
@@ -56,7 +56,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"http://code.google.com/p/flying-saucer/"))
@@ -70,7 +70,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"https://bytebuddy.net"))
@@ -84,7 +84,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, None)
@@ -100,7 +100,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactUrl(dep.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"https://github.com/xerial/sbt-sonatype"))
@@ -115,7 +115,7 @@ class CoursierAlgTest extends FunSuite {
       Some(ScalaVersion("2.12"))
     )
     val (state, result) =
-      coursierAlg.getArtifactUrl(dep.withSbtPluginReleases).run(MockState.empty).unsafeRunSync()
+      coursierAlg.getArtifactUrl(dep.withSbtPluginReleases).runSA(MockState.empty).unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(result, Some(uri"https://github.com/sbt/sbt-release"))
   }
@@ -127,7 +127,7 @@ class CoursierAlgTest extends FunSuite {
     )
     val (state, result) = coursierAlg
       .getArtifactIdUrlMapping(dependencies.withMavenCentral)
-      .run(MockState.empty)
+      .runSA(MockState.empty)
       .unsafeRunSync()
     assertEquals(state, MockState.empty)
     assertEquals(

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -58,7 +58,7 @@ class FileAlgTest extends FunSuite {
     val (state, edited) = (for {
       home <- fileAlg.home
       edited <- fileAlg.editFile(home / "does-not-exists.txt", Some.apply)
-    } yield edited).run(MockState.empty).unsafeRunSync()
+    } yield edited).runSA(MockState.empty).unsafeRunSync()
 
     val expected =
       MockState.empty.copy(trace = Vector(Cmd("read", s"$mockRoot/does-not-exists.txt")))
@@ -72,7 +72,7 @@ class FileAlgTest extends FunSuite {
       _ <- fileAlg.writeFile(file, "123")
       edit = (s: String) => Some(s.replace("2", "4"))
       edited <- fileAlg.editFile(file, edit)
-    } yield edited).run(MockState.empty).unsafeRunSync()
+    } yield edited).runSA(MockState.empty).unsafeRunSync()
 
     val expected = MockState.empty.copy(
       trace = Vector(

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
@@ -1,16 +1,19 @@
 package org.scalasteward.core.io
 
+import cats.data.Kleisli
 import org.scalasteward.core.application.Config.ProcessCfg
-import org.scalasteward.core.mock.{applyPure, MockEff}
+import org.scalasteward.core.mock.MockEff
 
 object MockProcessAlg {
   def create(config: ProcessCfg): ProcessAlg[MockEff] =
     ProcessAlg.fromExecImpl(config) { args =>
-      applyPure { s =>
-        val cmd = args.workingDirectory.map(_.toString).toList ++ args.command.toList
-        val s1 = s.exec(cmd, args.extraEnv: _*)
-        val a = s.commandOutputs.getOrElse(args.command.toList, List.empty)
-        (s1, a)
+      Kleisli {
+        _.modify { s =>
+          val cmd = args.workingDirectory.map(_.toString).toList ++ args.command.toList
+          val s1 = s.exec(cmd, args.extraEnv: _*)
+          val a = s.commandOutputs.getOrElse(args.command.toList, List.empty)
+          (s1, a)
+        }
       }
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -1,16 +1,16 @@
 package org.scalasteward.core.io
 
 import better.files.File
-import cats.data.StateT
+import cats.data.Kleisli
 import org.scalasteward.core.mock.{MockContext, MockEff}
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
   override def cleanWorkspace: MockEff[Unit] =
-    StateT.pure(())
+    Kleisli.pure(())
 
   override def rootDir: MockEff[File] =
-    StateT.pure(MockContext.config.workspace)
+    Kleisli.pure(MockContext.config.workspace)
 
   override def repoDir(repo: Repo): MockEff[File] =
     rootDir.map(_ / repo.owner / repo.repo)

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockLogger.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockLogger.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.mock
 
-import cats.data.StateT
+import cats.data.Kleisli
 import org.typelevel.log4cats.Logger
 
 class MockLogger extends Logger[MockEff] {
@@ -35,5 +35,5 @@ class MockLogger extends Logger[MockEff] {
     impl(None, message)
 
   def impl(maybeThrowable: Option[Throwable], message: String): MockEff[Unit] =
-    StateT.modify(_.log(maybeThrowable, message))
+    Kleisli(_.update(_.log(maybeThrowable, message)))
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -2,6 +2,7 @@ package org.scalasteward.core.mock
 
 import better.files.File
 import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
@@ -30,6 +31,9 @@ final case class MockState(
 
   def log(maybeThrowable: Option[Throwable], msg: String): MockState =
     copy(trace = trace :+ Log((maybeThrowable, msg)))
+
+  def toRef: IO[Ref[IO, MockState]] =
+    Ref[IO].of(this)
 }
 
 object MockState {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -1,13 +1,25 @@
 package org.scalasteward.core
 
-import cats.Applicative
-import cats.data.StateT
+import cats.Monad
+import cats.data.Kleisli
 import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 
 package object mock {
-  type MockEff[A] = StateT[IO, MockState, A]
+  type MockEff[A] = Kleisli[IO, Ref[IO, MockState], A]
 
-  def applyPure[F[_]: Applicative, S, A](f: S => (S, A)): StateT[F, S, A] =
-    StateT.apply(s => f(s).pure[F])
+  implicit class MockEffOps[A](private val fa: MockEff[A]) extends AnyVal {
+    def runA(state: MockState): IO[A] =
+      state.toRef.flatMap(fa.run)
+
+    def runS(state: MockState): IO[MockState] =
+      state.toRef.flatMap(ref => fa.run(ref) >> ref.get)
+
+    def runSA(state: MockState): IO[(MockState, A)] =
+      state.toRef.flatMap(ref => fa.run(ref).flatMap(a => ref.get.map(s => (s, a))))
+  }
+
+  def getFlatMapSet[F[_], A, B](f: A => F[A])(ref: Ref[F, A])(implicit F: Monad[F]): F[Unit] =
+    ref.get.flatMap(f).flatMap(ref.set)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core
 
-import cats.Monad
+import cats.FlatMap
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.effect.concurrent.Ref
@@ -20,6 +20,6 @@ package object mock {
       state.toRef.flatMap(ref => fa.run(ref).flatMap(a => ref.get.map(s => (s, a))))
   }
 
-  def getFlatMapSet[F[_], A, B](f: A => F[A])(ref: Ref[F, A])(implicit F: Monad[F]): F[Unit] =
+  def getFlatMapSet[F[_], A, B](f: A => F[A])(ref: Ref[F, A])(implicit F: FlatMap[F]): F[Unit] =
     ref.get.flatMap(f).flatMap(ref.set)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -38,7 +38,7 @@ class PullRequestRepositoryTest extends FunSuite {
       result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0")
       createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
     } yield (result, createdAt)
-    val (state, (result, createdAt)) = p.run(MockState.empty).unsafeRunSync()
+    val (state, (result, createdAt)) = p.runSA(MockState.empty).unsafeRunSync()
 
     val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
     assertEquals(result, Some((url, sha1, PullRequestState.Open)))
@@ -72,7 +72,7 @@ class PullRequestRepositoryTest extends FunSuite {
       _ <- pullRequestRepository.changeState(repo, url, PullRequestState.Closed)
       closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
     } yield (emptyResult, result, closedResult)
-    val (state, (emptyResult, result, closedResult)) = p.run(MockState.empty).unsafeRunSync()
+    val (state, (emptyResult, result, closedResult)) = p.runSA(MockState.empty).unsafeRunSync()
     val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(closedResult, List.empty)
@@ -104,7 +104,7 @@ class PullRequestRepositoryTest extends FunSuite {
       )
       result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
     } yield (emptyResult, result)
-    val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
+    val (state, (emptyResult, result)) = p.runSA(MockState.empty).unsafeRunSync()
     val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)
@@ -135,7 +135,7 @@ class PullRequestRepositoryTest extends FunSuite {
       )
       result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, newUpdate)
     } yield (emptyResult, result)
-    val (state, (emptyResult, result)) = p.run(MockState.empty).unsafeRunSync()
+    val (state, (emptyResult, result)) = p.runSA(MockState.empty).unsafeRunSync()
     val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -16,7 +16,7 @@ class JsonKeyValueStoreTest extends FunSuite {
       _ <- kvStore.put("k2", "v2")
       v3 <- kvStore.get("k3")
     } yield (v1, v3)
-    val (state, value) = p.run(MockState.empty).unsafeRunSync()
+    val (state, value) = p.runSA(MockState.empty).unsafeRunSync()
     assertEquals(value, (Some("v1"), None))
 
     val k1File = config.workspace / "store" / "test-1" / "v0" / "k1" / "test-1.json"
@@ -44,7 +44,7 @@ class JsonKeyValueStoreTest extends FunSuite {
       v1 <- kvStore.get("k1")
       _ <- kvStore.set("k1", None)
     } yield v1
-    val (state, value) = p.run(MockState.empty).unsafeRunSync()
+    val (state, value) = p.runSA(MockState.empty).unsafeRunSync()
     assertEquals(value, Some("v0"))
 
     val k1File = config.workspace / "store" / "test-2" / "v0" / "k1" / "test-2.json"
@@ -68,7 +68,7 @@ class JsonKeyValueStoreTest extends FunSuite {
       v1 <- kvStore.get("k1")
       v2 <- kvStore.get("k2")
     } yield (v1, v2)
-    val (state, value) = p.run(MockState.empty).unsafeRunSync()
+    val (state, value) = p.runSA(MockState.empty).unsafeRunSync()
     assertEquals(value, (Some("v1"), None))
 
     val k1File = config.workspace / "store" / "test-3" / "v0" / "k1" / "test-3.json"

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -9,6 +9,7 @@ import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockContext, MockState}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
+
 import scala.concurrent.duration._
 
 class RepoConfigAlgTest extends FunSuite {
@@ -211,7 +212,7 @@ class RepoConfigAlgTest extends FunSuite {
     val configFile = MockContext.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
     val initialState =
       MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
-    val (state, config) = repoConfigAlg.readRepoConfig(repo).run(initialState).unsafeRunSync()
+    val (state, config) = repoConfigAlg.readRepoConfig(repo).runSA(initialState).unsafeRunSync()
 
     assertEquals(config, None)
     val log = state.trace.collectFirst { case Log((_, msg)) => msg }.getOrElse("")

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -21,7 +21,7 @@ class ScalafmtAlgTest extends FunSuite {
                                   |""".stripMargin)
       .unsafeRunSync()
     val (state, maybeVersion) =
-      scalafmtAlg.getScalafmtVersion(buildRoot).run(initialState).unsafeRunSync()
+      scalafmtAlg.getScalafmtVersion(buildRoot).runSA(initialState).unsafeRunSync()
     val expectedState = initialState.copy(
       trace = Vector(Cmd("read", s"$repoDir/.scalafmt.conf"))
     )
@@ -42,7 +42,7 @@ class ScalafmtAlgTest extends FunSuite {
                                   |""".stripMargin)
       .unsafeRunSync()
     val (_, maybeVersion) =
-      scalafmtAlg.getScalafmtVersion(buildRoot).run(initialState).unsafeRunSync()
+      scalafmtAlg.getScalafmtVersion(buildRoot).runSA(initialState).unsafeRunSync()
     assertEquals(maybeVersion, Some(Version("2.0.0-RC8")))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -64,7 +64,7 @@ class FilterAlgTest extends FunSuite {
 
     val initialState = MockState.empty
     val (state, filtered) =
-      filterAlg.localFilterMany(config, List(update1, update2)).run(initialState).unsafeRunSync()
+      filterAlg.localFilterMany(config, List(update1, update2)).runSA(initialState).unsafeRunSync()
 
     assertEquals(filtered, List(update1))
     val expected = initialState.copy(


### PR DESCRIPTION
This implements `MockEff` as
```scala
type MockEff[A] = Kleisli[IO, Ref[IO, MockState], A]
```
instead of
```scala
type MockEff[A] = StateT[IO, MockState, A]
```

The motivation for this change is the upgrade to Cats Effect 3 where
`Context.step1` will most likely require a `Concurrent[F]` and
`Async[MockEff]` (and all type classes below) can be derived automatically
if `MockEff` is based on `Kleisli`. This constraint cannot be satisfied
with the `StateT` based `MockEff` for which only `Sync[MockEff]` can be
derived automatically.