### PR TITLE
Change order of predicates for finding hooks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -39,10 +39,10 @@ final class HookExecutor[F[_]](implicit
   def execPostUpdateHooks(data: RepoData, update: Update): F[List[Commit]] =
     HookExecutor.postUpdateHooks
       .filter { hook =>
-        hook.enabledByCache(data.cache) &&
-        hook.enabledByConfig(data.config) &&
         update.groupId === hook.groupId &&
-        update.artifactIds.exists(_.name === hook.artifactId.name)
+        update.artifactIds.exists(_.name === hook.artifactId.name) &&
+        hook.enabledByCache(data.cache) &&
+        hook.enabledByConfig(data.config)
       }
       .distinctBy(_.command)
       .flatTraverse(execPostUpdateHook(data.repo, update, _))


### PR DESCRIPTION
Use simple predicates first and expensive predicates later.