### PR TITLE
Bypass Git's pre-push hooks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -110,7 +110,7 @@ final class FileGitAlg[F[_]](config: GitCfg)(implicit
     } yield Option.when(before =!= after)(Commit())
 
   override def push(repo: File, branch: Branch): F[Unit] =
-    git("push", "--force", "--set-upstream", "origin", branch.name)(repo).void
+    git("push", "--force", "--no-verify", "--set-upstream", "origin", branch.name)(repo).void
 
   override def removeClone(repo: File): F[Unit] =
     fileAlg.deleteForce(repo)

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -45,7 +45,17 @@ class VCSRepoAlgTest extends FunSuite {
         Cmd(envVars, repoDir, "git", "fetch", "--force", "--tags", "upstream", "master"),
         Cmd(envVars, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
         Cmd(envVars, repoDir, "git", "merge", "upstream/master"),
-        Cmd(envVars, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master"),
+        Cmd(
+          envVars,
+          repoDir,
+          "git",
+          "push",
+          "--force",
+          "--no-verify",
+          "--set-upstream",
+          "origin",
+          "master"
+        ),
         Cmd(envVars, repoDir, "git", "submodule", "update", "--init", "--recursive")
       )
     )


### PR DESCRIPTION
Pre-push hooks can prevent Scala Steward from pushing its update branches. Here is an example from the logs:
```
...
2021-04-07 21:09:11,026 INFO  Trying heuristic 'original'
2021-04-07 21:09:11,382 INFO  Push 2 commit(s)
2021-04-07 21:09:19,117 ERROR Steward stryker-mutator/stryker4s failed
java.io.IOException: 'git push --force --set-upstream origin update/cats-effect-3.0.1' exited with code 1
Running pre-push formatting hook... (you can skip this with --no-verify, but don't)
Looking for unformatted files...
...
```