### PR TITLE
Add Scalafix migration for http4s 0.22.0

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -64,6 +64,12 @@ migrations = [
   {
     groupId: "org.http4s",
     artifactIds: ["http4s-.*"],
+    newVersion: "0.22.0",
+    rewriteRules: ["github:http4s/http4s/v0_22?sha=v0.22.0"]
+  },
+  {
+    groupId: "org.http4s",
+    artifactIds: ["http4s-.*"],
     newVersion: "0.21.5",
     rewriteRules: ["dependency:v0_21@org.http4s:http4s-scalafix:0.21.5"],
     doc: "https://github.com/http4s/http4s/releases/tag/v0.21.5"


### PR DESCRIPTION
http4s got a new Scalafix for the upgrade to 0.22 in https://github.com/http4s/http4s/pull/4743, so let's add it here too.

/cc @rossabaker @vasilmkd