### PR TITLE
Add a migration rule for scalafix 0.9.28

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -143,6 +143,12 @@ migrations = [
     rewriteRules: ["github:typelevel/cats-effect/v3_0_0?sha=series/3.x"],
     scalacOptions: ["-P:semanticdb:synthetics:on"]
   },
+    {
+    groupId: "ch.epfl.scala",
+    artifactIds: ["scalafix-testkit"],
+    newVersion: "0.9.28",
+    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28"]
+  },
   {
     groupId: "org.typelevel",
     artifactIds: ["cats-parse"],

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -147,7 +147,7 @@ migrations = [
     groupId: "ch.epfl.scala",
     artifactIds: ["scalafix-testkit"],
     newVersion: "0.9.28",
-    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28?sha=dba15e3"]
+    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28"]
   },
   {
     groupId: "org.typelevel",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -147,7 +147,7 @@ migrations = [
     groupId: "ch.epfl.scala",
     artifactIds: ["scalafix-testkit"],
     newVersion: "0.9.28",
-    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28"]
+    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28?sha=dba15e3"]
   },
   {
     groupId: "org.typelevel",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -147,7 +147,7 @@ migrations = [
     groupId: "ch.epfl.scala",
     artifactIds: ["scalafix-testkit"],
     newVersion: "0.9.28",
-    rewriteRules: ["github:scalacenter/scalafix.g8/v0_9_28"]
+    rewriteRules: ["https://raw.githubusercontent.com/scalacenter/scalafix.g8/main/migration-rules/v0.9.28/rules/src/main/scala/fix/v0_9_28.scala"]
   },
   {
     groupId: "org.typelevel",


### PR DESCRIPTION
Hello, we would like to add an automatic rule for the migration, but I don't know how to test to make sure it will work/resolve correctly. Thanks for your feedbacks 