### PR TITLE
Fix link to auto-merge GitHub Action

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,7 +67,7 @@ number adheres to [Semantic Versioning](https://semver.org/)) as demonstrated
 Other examples of Mergify rules for Scala Steward can be found via
 [GitHub's code search](https://github.com/search?p=6&q=%22author%3Dscala-steward%22+filename%3A.mergify.yml&type=Code).
 
-An alternative is the [merge PR github action](https://github.com/marketplace/actions/merge-depenendecy-update-prs)
+An alternative is the [merge PR github action](https://github.com/marketplace/actions/merge-dependency-update-prs)
 which you can include in a GitHub workflow to automatically merge Scala Steward's 
 pull requests.
 


### PR DESCRIPTION
I recently republished the action to fix a typo in the name (and marketplace URL).