### PR TITLE
scalafix-testkit is mostly used through sbt-scalafix

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -145,7 +145,7 @@ migrations = [
   },
     {
     groupId: "ch.epfl.scala",
-    artifactIds: ["scalafix-testkit"],
+    artifactIds: ["scalafix-testkit", "sbt-scalafix"],
     newVersion: "0.9.28",
     rewriteRules: ["https://raw.githubusercontent.com/scalacenter/scalafix.g8/main/migration-rules/v0.9.28/rules/src/main/scala/fix/v0_9_28.scala"]
   },


### PR DESCRIPTION
I am not quite sure how the resolution works, but since most of the repos will be bumping scalafix-testkit transitively through sbt-scalafix, I guess we need to make it explicit?

The releases are being pushed to maven central now, so I guess if I am right, this rather be merged fast.