### PR TITLE
Support reading and updating .mill-version file

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -16,10 +16,11 @@
 
 package org.scalasteward.core.buildtool.mill
 
+import better.files.File
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.BuildToolAlg
-import org.scalasteward.core.data.Scope
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver, Scope}
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -64,9 +65,26 @@ object MillAlg {
           parsed <- F.fromEither(
             parser.parseModules(extracted.dropWhile(!_.startsWith("{")).mkString("\n"))
           )
-        } yield parsed.map(module => Scope(module.dependencies, module.repositories))
+          dependencies = parsed.map(module => Scope(module.dependencies, module.repositories))
+          millBuildVersion <- getMillVersion(buildRootDir)
+          millBuildDeps = millBuildVersion.toSeq.map(version =>
+            Scope(List(millMainArtifact(version)), List(millMainResolver))
+          )
+        } yield dependencies ++ millBuildDeps
 
       override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
         F.unit
+
+      def getMillVersion(buildRootDir: File): F[Option[String]] =
+        for {
+          millVersionFileContent <- fileAlg.readFile(buildRootDir / ".mill-version")
+          version = millVersionFileContent.flatMap(parser.parseMillVersion)
+        } yield version
+
     }
+
+  private[this] val millMainResolver: Resolver = Resolver.mavenCentral
+
+  private def millMainArtifact(version: String): Dependency =
+    Dependency(GroupId("com.lihaoyi"), ArtifactId("mill-main"), version)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -20,7 +20,7 @@ import better.files.File
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.BuildToolAlg
-import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver, Scope}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver, Scope, Update}
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -84,7 +84,13 @@ object MillAlg {
     }
 
   private[this] val millMainResolver: Resolver = Resolver.mavenCentral
+  private[this] val millMainGroupId = GroupId("com.lihaoyi")
+  private[this] val millMainArtifactId = ArtifactId("mill-main")
 
   private def millMainArtifact(version: String): Dependency =
-    Dependency(GroupId("com.lihaoyi"), ArtifactId("mill-main"), version)
+    Dependency(millMainGroupId, millMainArtifactId, version)
+
+  def isMillMainUpdate(update: Update.Single): Boolean =
+    update.groupId === millMainGroupId && update.artifactId.name === millMainArtifactId.name
+
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -85,7 +85,7 @@ object MillAlg {
 
   private[this] val millMainResolver: Resolver = Resolver.mavenCentral
   private[this] val millMainGroupId = GroupId("com.lihaoyi")
-  private[this] val millMainArtifactId = ArtifactId("mill-main")
+  private[this] val millMainArtifactId = ArtifactId("mill-main", "mill-main_2.13")
 
   private def millMainArtifact(version: String): Dependency =
     Dependency(millMainGroupId, millMainArtifactId, version)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
@@ -40,6 +40,9 @@ object parser {
           .leftMap(CirceParseError("Failed to decode Modules", _): ParseError)
     } yield json.modules
 
+  def parseMillVersion(s: String): Option[String] =
+    Option(s.trim()).filter(_.nonEmpty)
+
 }
 
 case class Modules(modules: List[MillModule])

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -18,10 +18,12 @@ package org.scalasteward.core.edit
 
 import cats.Foldable
 import cats.syntax.all._
+// import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.scalafmt.isScalafmtUpdate
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
+
 import scala.util.matching.Regex
 
 /** `UpdateHeuristic` is a wrapper for a function that takes an `Update` and
@@ -211,6 +213,8 @@ object UpdateHeuristic {
     replaceVersion = {
       case update: Update.Single if isScalafmtUpdate(update) =>
         defaultReplaceVersion(_ => List("version"))(update)
+//      case update: Update.Single if MillAlg.isMillMainUpdate(update) =>
+//        // TODO: fill in the missing pieces
       case _ =>
         _ => None
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -19,7 +19,6 @@ package org.scalasteward.core.edit
 import cats.Foldable
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.mill.MillAlg
-// import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.scalafmt.isScalafmtUpdate
 import org.scalasteward.core.util

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.edit
 
 import cats.Foldable
 import cats.syntax.all._
+import org.scalasteward.core.buildtool.mill.MillAlg
 // import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.scalafmt.isScalafmtUpdate
@@ -213,8 +214,8 @@ object UpdateHeuristic {
     replaceVersion = {
       case update: Update.Single if isScalafmtUpdate(update) =>
         defaultReplaceVersion(_ => List("version"))(update)
-//      case update: Update.Single if MillAlg.isMillMainUpdate(update) =>
-//        // TODO: fill in the missing pieces
+      case update: Update.Single if MillAlg.isMillMainUpdate(update) =>
+        content => if(content === update.currentVersion) Some(update.nextVersion) else None
       case _ =>
         _ => None
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -214,7 +214,7 @@ object UpdateHeuristic {
       case update: Update.Single if isScalafmtUpdate(update) =>
         defaultReplaceVersion(_ => List("version"))(update)
       case update: Update.Single if MillAlg.isMillMainUpdate(update) =>
-        content => if(content === update.currentVersion) Some(update.nextVersion) else None
+        content => if (content === update.currentVersion) Some(update.nextVersion) else None
       case _ =>
         _ => None
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -74,7 +74,7 @@ final case class UpdatesConfig(
 
 object UpdatesConfig {
   val defaultFileExtensions: Set[String] =
-    Set(".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml")
+    Set(".mill-version", ".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml")
 
   implicit val updatesConfigEq: Eq[UpdatesConfig] =
     Eq.fromUniversalEquals

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -34,7 +34,8 @@ class MillAlgTest extends FunSuite {
       trace = Vector(
         Cmd("write", predef),
         Cmd(repoDir.toString :: millCmd),
-        Cmd("rm", "-rf", predef)
+        Cmd("rm", "-rf", predef),
+        Cmd("read", s"$repoDir/.mill-version")
       )
     )
     assertEquals(state, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
@@ -1,0 +1,24 @@
+package org.scalasteward.core.buildtool.mill
+
+import munit.FunSuite
+
+class MillVersionParserTest extends FunSuite {
+  val data = Seq(
+    "" -> None,
+    "0.6.0" -> Some("0.6.0"),
+    "0.9.6-16-a5da34" -> Some("0.9.6-16-a5da34"),
+    """0.6.0
+      |""".stripMargin -> Some("0.6.0"),
+    "\n\r0.6.0\n\r".stripMargin -> Some("0.6.0"),
+    " 0.6.0 " -> Some("0.6.0")
+  )
+
+  for {
+    (versionFileContent, expected) <- data
+  } yield test(
+    s"parse version from .mill-version file with content '${versionFileContent.replace("\n", "\n")}'"
+  ) {
+    val parsed = parser.parseMillVersion(versionFileContent)
+    assertEquals(parsed, expected)
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
@@ -9,14 +9,14 @@ class MillVersionParserTest extends FunSuite {
     "0.9.6-16-a5da34" -> Some("0.9.6-16-a5da34"),
     """0.6.0
       |""".stripMargin -> Some("0.6.0"),
-    "\n\r0.6.0\n\r".stripMargin -> Some("0.6.0"),
+    "\r\n0.6.0\r\n".stripMargin -> Some("0.6.0"),
     " 0.6.0 " -> Some("0.6.0")
   )
 
   for {
     (versionFileContent, expected) <- data
   } yield test(
-    s"parse version from .mill-version file with content '${versionFileContent.replace("\n", "\n")}'"
+    s"parse version from .mill-version file with content '${versionFileContent}'"
   ) {
     val parsed = parser.parseMillVersion(versionFileContent)
     assertEquals(parsed, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
@@ -16,7 +16,7 @@ class MillVersionParserTest extends FunSuite {
   for {
     (versionFileContent, expected) <- data
   } yield test(
-    s"parse version from .mill-version file with content '${versionFileContent}'"
+    s"parse version from .mill-version file with content '$versionFileContent'"
   ) {
     val parsed = parser.parseMillVersion(versionFileContent)
     assertEquals(parsed, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -258,18 +258,10 @@ class EditAlgTest extends FunSuite {
       newerVersions = Nel.of("0.9.9")
     )
     val original = Map(
-      ".mill-version" -> """0.9.5""",
-      "build.sc" ->
-        """Deps {
-          |  val millMain = ivy"com.lihaoyi::mill-main:0.9.5" // scala-steward:off
-          |}""".stripMargin
+      ".mill-version" -> """0.9.5"""
     )
     val expected = Map(
-      ".mill-version" -> """0.9.9""",
-      "build.sc" ->
-        """Deps {
-          |  val millMain = ivy"com.lihaoyi::mill-main:0.9.5" // scala-steward:off
-          |}""".stripMargin
+      ".mill-version" -> """0.9.9"""
     )
     assertEquals(runApplyUpdate(Repo("edit-alg", "test-10"), update, original), expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -252,6 +252,28 @@ class EditAlgTest extends FunSuite {
     assertEquals(runApplyUpdate(Repo("edit-alg", "test-9"), update, original), expected)
   }
 
+  test("mill version file update") {
+    val update = Update.Single(
+      crossDependency = "com.lihaoyi" % "mill-main" % "0.9.5",
+      newerVersions = Nel.of("0.9.9")
+    )
+    val original = Map(
+      ".mill-version" -> """0.9.5""",
+      "build.sc" ->
+        """Deps {
+          |  val millMain = ivy"com.lihaoyi::mill-main:0.9.5" // scala-steward:off
+          |}""".stripMargin
+    )
+    val expected = Map(
+      ".mill-version" -> """0.9.9""",
+      "build.sc" ->
+        """Deps {
+          |  val millMain = ivy"com.lihaoyi::mill-main:0.9.5" // scala-steward:off
+          |}""".stripMargin
+    )
+    assertEquals(runApplyUpdate(Repo("edit-alg", "test-10"), update, original), expected)
+  }
+
   private def runApplyUpdate(
       repo: Repo,
       update: Update,


### PR DESCRIPTION
This PR adds support to read and update `.mill-version` files.

----
Initial but outdate comment:

_This is a draft, as the feature isn't complete yet_

@fthomas Thanks for the detailed steps in https://github.com/scala-steward-org/scala-steward/issues/1504#issuecomment-832950344. I managed to implement step 1 and 2, but fail at step 3. I think I'm not familiar enough with the used APIs. I could imagine it's just a finger exercise for you, in which case I'd be glad if you could help me out with a snippet. Please don't take it as a demand, but probably it speeds things up, at least on my side. ;-) Thank you!

I tried to add tests for step 1 and 2, but have no idea how to test step 3.

