### PR TITLE
Switched default docker base image from openjdk8 to adoptopenjdk11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,8 @@ lazy val metadataSettings = Def.settings(
 )
 
 lazy val dockerSettings = Def.settings(
-  dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE")).getOrElse("openjdk:8-jdk-alpine"),
+  dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE"))
+    .getOrElse("adoptopenjdk/openjdk11:alpine"),
   dockerCommands ++= {
     val getSbtVersion = sbtVersion.value
     val sbtTgz = s"sbt-$getSbtVersion.tgz"


### PR DESCRIPTION
fixes #2156 

Unfortunately there exists no openjdk11-alpine image from the openjdk organisation (https://github.com/docker-library/openjdk/pull/235#issuecomment-424599754 https://github.com/docker-library/openjdk/issues/313).

Therefore I decided to switch to the alpine variant of adoptopenjdk. Another approach would be to switch to something like openjdk/11-jdk-slim. My reasoning behind doing it this way was to keep the operation system constant (and good experience with adoptopenjdk). If you prefer the other way around: I am happy to change the PR.