### PR TITLE
Add sbt-davenverse to the plugins that depend on sbt-github-actions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -69,6 +69,7 @@ object HookExecutor {
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak")),
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-sonatype")),
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-bintray")),
+    (GroupId("io.chrisdavenport"), ArtifactId("sbt-davenverse")),
     (GroupId("org.http4s"), ArtifactId("sbt-http4s-org"))
   )
 


### PR DESCRIPTION
This will run `sbt githubWorkflowGenerate` if necessary in projects that use sbt-davenverse.

/cc @ChristopherDavenport @JesusMtnez