### PR TITLE
Allow choosing a custom default branch

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -37,4 +37,5 @@ All command line arguments for the `scala-steward` application.
   --github-app-key-file  FILE                        Github application key file
   --github-app-id  ID                                Github application id
   --refresh-backoff-period DURATION                  Period of time a failed build won't be triggered again, default: "7 days"
+  --default-branch BRANCH                            A fixed branch name to use as default instead of the repository's default branch
 ```

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -59,7 +59,8 @@ object Cli {
       githubAppId: Option[Long] = None,
       urlCheckerTestUrl: Option[Uri] = None,
       defaultMavenRepo: Option[String] = None,
-      refreshBackoffPeriod: FiniteDuration = 7.days
+      refreshBackoffPeriod: FiniteDuration = 7.days,
+      defaultBranch: Option[String] = None
   )
 
   final case class EnvVar(name: String, value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -33,6 +33,7 @@ import org.scalasteward.core.vcs.VCSType
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.vcs.github.GitHubApp
 import scala.concurrent.duration.FiniteDuration
+import org.scalasteward.core.git.Branch
 
 /** Configuration for scala-steward.
   *
@@ -77,7 +78,8 @@ final case class Config(
     githubApp: Option[GitHubApp],
     urlCheckerTestUrl: Uri,
     defaultResolver: Resolver,
-    refreshBackoffPeriod: FiniteDuration
+    refreshBackoffPeriod: FiniteDuration,
+    defaultBranch: Option[Branch]
 ) {
   def vcsUser[F[_]](implicit
       processAlg: ProcessAlg[F],
@@ -167,6 +169,7 @@ object Config {
       defaultResolver = args.defaultMavenRepo
         .map(url => Resolver.MavenRepository("default", url, None))
         .getOrElse(Resolver.mavenCentral),
-      refreshBackoffPeriod = args.refreshBackoffPeriod
+      refreshBackoffPeriod = args.refreshBackoffPeriod,
+      defaultBranch = args.defaultBranch.map(Branch(_))
     )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -43,7 +43,11 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
     logger.info(s"Check cache of ${repo.show}") >>
       refreshErrorAlg.skipIfFailedRecently(repo) {
         (
-          vcsApiAlg.createForkOrGetRepoWithDefaultBranch(repo, config.doNotFork, config.defaultBranch),
+          vcsApiAlg.createForkOrGetRepoWithDefaultBranch(
+            repo,
+            config.doNotFork,
+            config.defaultBranch
+          ),
           repoCacheRepository.findCache(repo)
         ).parTupled.flatMap { case ((repoOut, branchOut), maybeCache) =>
           val latestSha1 = branchOut.commit.sha

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -43,7 +43,7 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
     logger.info(s"Check cache of ${repo.show}") >>
       refreshErrorAlg.skipIfFailedRecently(repo) {
         (
-          vcsApiAlg.createForkOrGetRepoWithDefaultBranch(repo, config.doNotFork),
+          vcsApiAlg.createForkOrGetRepoWithDefaultBranch(repo, config.doNotFork, config.defaultBranch),
           repoCacheRepository.findCache(repo)
         ).parTupled.flatMap { case ((repoOut, branchOut), maybeCache) =>
           val latestSha1 = branchOut.commit.sha

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -42,13 +42,18 @@ trait VCSApiAlg[F[_]] {
   final def createForkOrGetRepo(repo: Repo, doNotFork: Boolean): F[RepoOut] =
     if (doNotFork) getRepo(repo) else createFork(repo)
 
-  final def createForkOrGetRepoWithDefaultBranch(repo: Repo, doNotFork: Boolean)(implicit
+  final def createForkOrGetRepoWithDefaultBranch(
+      repo: Repo,
+      doNotFork: Boolean,
+      defaultBranch: Option[Branch]
+  )(implicit
       F: MonadThrow[F]
   ): F[(RepoOut, BranchOut)] =
     for {
       forkOrRepo <- createForkOrGetRepo(repo, doNotFork)
-      defaultBranch <- getDefaultBranchOfParentOrRepo(forkOrRepo, doNotFork)
-    } yield (forkOrRepo, defaultBranch)
+      forkOrRepoWithDefaultBranch = applyDefaultBranch(forkOrRepo, defaultBranch)
+      defaultBranch <- getDefaultBranchOfParentOrRepo(forkOrRepoWithDefaultBranch, doNotFork)
+    } yield (forkOrRepoWithDefaultBranch, defaultBranch)
 
   final def applyDefaultBranch(repoOut: RepoOut, defaultBranch: Option[Branch]): RepoOut =
     defaultBranch.fold(repoOut) { branch =>

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -50,6 +50,14 @@ trait VCSApiAlg[F[_]] {
       defaultBranch <- getDefaultBranchOfParentOrRepo(forkOrRepo, doNotFork)
     } yield (forkOrRepo, defaultBranch)
 
+  final def applyDefaultBranch(repoOut: RepoOut, defaultBranch: Option[Branch]): RepoOut =
+    defaultBranch.fold(repoOut) { branch =>
+      repoOut.copy(
+        default_branch = branch,
+        parent = repoOut.parent.map(_.copy(default_branch = branch))
+      )
+    }
+
   final def getDefaultBranchOfParentOrRepo(repoOut: RepoOut, doNotFork: Boolean)(implicit
       F: MonadThrow[F]
   ): F[BranchOut] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -40,7 +40,9 @@ final class VCSRepoAlg[F[_]](config: Config)(implicit
   private def clone(repo: Repo, repoOut: RepoOut): F[Unit] =
     logger.info(s"Clone ${repoOut.repo.show}") >>
       gitAlg.clone(repo, withLogin(repoOut.clone_url)) >>
-      gitAlg.setAuthor(repo, config.gitCfg.gitAuthor)
+      gitAlg.setAuthor(repo, config.gitCfg.gitAuthor) >> config.defaultBranch.fold(F.unit)(
+        gitAlg.checkoutBranch(repo, _)
+      )
 
   private def syncFork(repo: Repo, repoOut: RepoOut): F[Unit] =
     repoOut.parentOrRaise[F].flatMap { parent =>

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -29,7 +29,8 @@ class CliTest extends FunSuite {
         List("--artifact-migrations", "/opt/scala-steward/extra-artifact-migrations.conf"),
         List("--github-app-id", "12345678"),
         List("--github-app-key-file", "example_app_key"),
-        List("--refresh-backoff-period", "1 day")
+        List("--refresh-backoff-period", "1 day"),
+        List("--default-branch", "1.x")
       ).flatten
     )
     val expected = Success(
@@ -50,7 +51,8 @@ class CliTest extends FunSuite {
         artifactMigrations = Some(File("/opt/scala-steward/extra-artifact-migrations.conf")),
         githubAppId = Some(12345678),
         githubAppKeyFile = Some(File("example_app_key")),
-        refreshBackoffPeriod = 1.day
+        refreshBackoffPeriod = 1.day,
+        defaultBranch = Some("1.x")
       )
     )
     assertEquals(obtained, expected)


### PR DESCRIPTION
# What has been done in this PR?

A new `--default-branch` argument has been added to the Scala Steward cli. When this argument is present, its value will be used as the default branch when updating repositories instead of the repository's default branch.

# Why this change?

This change enables users who run their own instances of Scala Steward to customize the branch in which updates are performed. This will enable multiple use-cases, for example:

- Updating multiple branches in a repository.
- Merging updates into a "develop" branch regularly that will be merged into the real default branch every so often.

This change will be specially useful for users of the [Scala Steward GitHub Action](https://github.com/scala-steward-org/scala-steward-action) after scala-steward-org/scala-steward-action#268 is merged.

Example:

```yml
on:
  schedule:
    - cron: '0 0 * * 0'
name: Launch Scala Steward on `main`, `1.x` and `2.x`
jobs:
  scala-steward:
    runs-on: ubuntu-latest
    name: Launch Scala Steward
    strategy:
      matrix:
        branch: ['main', '1.x', '2.x']
    steps:
      - name: Launch Scala Steward
        uses: scala-steward-org/scala-steward-action@v2
        with:
          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
          branch: ${{ matrix.branch }}
```