### PR TITLE
Migrate to newer artifact version

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -3,7 +3,7 @@ changes = [
     groupIdBefore = com.cavorite
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-avro
-    initialVersion = 3.2.0
+    initialVersion = 3.3.0
   },
   {
     groupIdBefore = com.github.julien-truffaut


### PR DESCRIPTION
Trigger migration with new version of `sbt-avro` in `com.github.sbt` organisation
See #2216