### PR TITLE
Support multi-line artifact and version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -89,7 +89,7 @@ object UpdateHeuristic {
       searchTermsToAlternation(getSearchTerms(update).map(removeCommonSuffix)).map { searchTerms =>
         val prefix = getPrefixRegex(update).getOrElse("")
         val currentVersion = Regex.quote(update.currentVersion)
-        s"(?i)(.*)($prefix$searchTerms.*?)$currentVersion(.?)".r
+        s"(?is)(.*?)($prefix$searchTerms.*?)$currentVersion(.?)".r
       }
 
     def replaceVersionF(update: Update): String => Option[String] =
@@ -136,7 +136,7 @@ object UpdateHeuristic {
     util.string.removeSuffix(str, Update.commonSuffixes)
 
   private def isCommonWord(s: String): Boolean =
-    s === "scala"
+    s === "scala" || s === "sbt"
 
   val moduleId: UpdateHeuristic = UpdateHeuristic(
     name = "moduleId",

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -164,7 +164,7 @@ class UpdateHeuristicTest extends FunSuite {
     assertEquals(
       Group("com.sky" % Nel.of("akka-streams", "akka-streams-kafka") % "1.2.0", Nel.one("1.3.0"))
         .replaceVersionIn(original),
-      Some(expected) -> UpdateHeuristic.completeGroupId.name
+      Some(expected) -> UpdateHeuristic.original.name
     )
   }
 
@@ -583,11 +583,11 @@ class UpdateHeuristicTest extends FunSuite {
     )
   }
 
-  test("fail on versions with line break") {
+  test("success on versions with line break") {
     val original = """val scalajsJqueryVersion =
                      |  "0.9.3"""".stripMargin
     assertEquals(
-      Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+      Single("be.doeraene" % "scalajs-jquery" % "0.9.4", Nel.of("0.9.4"))
         .replaceVersionIn(original)
         ._1,
       None
@@ -681,6 +681,28 @@ class UpdateHeuristicTest extends FunSuite {
                      |""".stripMargin
     val update = Single("org.typelevel" % "cats-core" % "2.4.1", Nel.of("2.4.2"))
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
+  }
+
+  test("issue 2099: pom.xml multiline") {
+    val original =
+      """  <dependency>
+        |    <groupId>commons-io</groupId>
+        |    <artifactId>commons-io</artifactId>
+        |    <version>2.6</version>
+        |  </dependency>
+        |""".stripMargin
+    val expected =
+      """  <dependency>
+        |    <groupId>commons-io</groupId>
+        |    <artifactId>commons-io</artifactId>
+        |    <version>2.8.0</version>
+        |  </dependency>
+        |""".stripMargin
+    assertEquals(
+      Single("commons-io" % "commons-io" % "2.6", Nel.of("2.8.0"))
+        .replaceVersionIn(original),
+      Some(expected) -> UpdateHeuristic.strict.name
+    )
   }
 }
 


### PR DESCRIPTION
Closes #2099

Multi-line artifact and its version now will be updated.
This could be helpful specially for Maven users, because dependencies in Maven are often declared like below:

```xml
<dependency>
    <groupId>commons-io</groupId>
    <artifactId>commons-io</artifactId>
    <version>2.6</version>
</dependency>
```