### PR TITLE
Introduce EditAttempt enum

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAttempt.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAttempt.scala
@@ -21,12 +21,24 @@ import org.scalasteward.core.edit.hooks.PostUpdateHook
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.git.Commit
 
-sealed trait EditCommit extends Product with Serializable {
-  def commit: Commit
+sealed trait EditAttempt extends Product with Serializable {
+  def maybeCommit: Option[Commit]
 }
 
-object EditCommit {
-  final case class UpdateCommit(update: Update, commit: Commit) extends EditCommit
-  final case class ScalafixCommit(migration: ScalafixMigration, commit: Commit) extends EditCommit
-  final case class HookCommit(hook: PostUpdateHook, commit: Commit) extends EditCommit
+object EditAttempt {
+  final case class UpdateEdit(update: Update, commit: Commit) extends EditAttempt {
+    override def maybeCommit: Some[Commit] = Some(commit)
+  }
+
+  final case class ScalafixEdit(
+      migration: ScalafixMigration,
+      result: Either[Throwable, Unit],
+      maybeCommit: Option[Commit]
+  ) extends EditAttempt
+
+  final case class HookEdit(
+      hook: PostUpdateHook,
+      result: Either[Throwable, Unit],
+      maybeCommit: Option[Commit]
+  ) extends EditAttempt
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditCommit.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditCommit.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2021 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.edit
+
+import org.scalasteward.core.data.Update
+import org.scalasteward.core.edit.hooks.PostUpdateHook
+import org.scalasteward.core.edit.scalafix.ScalafixMigration
+import org.scalasteward.core.git.Commit
+
+sealed trait EditCommit extends Product with Serializable {
+  def commit: Commit
+}
+
+object EditCommit {
+  final case class UpdateCommit(update: Update, commit: Commit) extends EditCommit
+  final case class ScalafixCommit(migration: ScalafixMigration, commit: Commit) extends EditCommit
+  final case class HookCommit(hook: PostUpdateHook, commit: Commit) extends EditCommit
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -20,8 +20,8 @@ import cats.MonadThrow
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.sbt.{sbtArtifactId, sbtGroupId}
 import org.scalasteward.core.data._
-import org.scalasteward.core.edit.EditCommit
-import org.scalasteward.core.edit.EditCommit.HookCommit
+import org.scalasteward.core.edit.EditAttempt
+import org.scalasteward.core.edit.EditAttempt.HookEdit
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.repocache.RepoCache
@@ -38,7 +38,7 @@ final class HookExecutor[F[_]](implicit
     workspaceAlg: WorkspaceAlg[F],
     F: MonadThrow[F]
 ) {
-  def execPostUpdateHooks(data: RepoData, update: Update): F[List[EditCommit]] =
+  def execPostUpdateHooks(data: RepoData, update: Update): F[List[EditAttempt]] =
     HookExecutor.postUpdateHooks
       .filter { hook =>
         update.groupId === hook.groupId &&
@@ -47,21 +47,17 @@ final class HookExecutor[F[_]](implicit
         hook.enabledByConfig(data.config)
       }
       .distinctBy(_.command)
-      .traverseFilter(execPostUpdateHook(data.repo, update, _))
+      .traverse(execPostUpdateHook(data.repo, update, _))
 
-  private def execPostUpdateHook(
-      repo: Repo,
-      update: Update,
-      hook: PostUpdateHook
-  ): F[Option[EditCommit]] =
+  private def execPostUpdateHook(repo: Repo, update: Update, hook: PostUpdateHook): F[EditAttempt] =
     for {
       _ <- logger.info(s"Executing post-update hook for ${hook.groupId}:${hook.artifactId.name}")
       repoDir <- workspaceAlg.repoDir(repo)
-      _ <- logger.attemptLogWarn_("Post-update hook failed") {
+      result <- logger.attemptLogWarn("Post-update hook failed") {
         processAlg.execMaybeSandboxed(hook.useSandbox)(hook.command, repoDir)
       }
       maybeCommit <- gitAlg.commitAllIfDirty(repo, hook.commitMessage(update))
-    } yield maybeCommit.map(commit => HookCommit(hook, commit))
+    } yield HookEdit(hook, result.void, maybeCommit)
 }
 
 object HookExecutor {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -25,7 +25,6 @@ import org.scalasteward.core.application.Config
 import org.scalasteward.core.coursier.CoursierAlg
 import org.scalasteward.core.data.ProcessResult.{Created, Ignored, Updated}
 import org.scalasteward.core.data._
-import org.scalasteward.core.edit.EditAttempt.ScalafixEdit
 import org.scalasteward.core.edit.{EditAlg, EditAttempt}
 import org.scalasteward.core.git.{Branch, Commit, GitAlg}
 import org.scalasteward.core.repoconfig.PullRequestUpdateStrategy
@@ -178,14 +177,13 @@ final class NurtureAlg[F[_]](config: Config)(implicit
           .traverse(vcsExtraAlg.getReleaseRelatedUrls(_, data.update))
       filesWithOldVersion <- gitAlg.findFilesContaining(data.repo, data.update.currentVersion)
       branchName = vcs.createBranch(config.vcsType, data.fork, data.update)
-      migrations = edits.collect { case ScalafixEdit(migration, _, _) => migration }
       requestData = NewPullRequestData.from(
         data,
         branchName,
         existingArtifactUrlsMap,
         releaseRelatedUrls.getOrElse(List.empty),
-        migrations,
-        filesWithOldVersion
+        filesWithOldVersion,
+        edits
       )
       pr <- vcsApiAlg.createPullRequest(data.repo, requestData)
       _ <- pullRequestRepository.createOrUpdate(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -180,10 +180,10 @@ final class NurtureAlg[F[_]](config: Config)(implicit
       requestData = NewPullRequestData.from(
         data,
         branchName,
+        edits,
         existingArtifactUrlsMap,
         releaseRelatedUrls.getOrElse(List.empty),
-        filesWithOldVersion,
-        edits
+        filesWithOldVersion
       )
       pr <- vcsApiAlg.createPullRequest(data.repo, requestData)
       _ <- pullRequestRepository.createOrUpdate(

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -50,10 +50,10 @@ object NewPullRequestData {
 
   def bodyFor(
       update: Update,
+      edits: List[EditAttempt],
       artifactIdToUrl: Map[String, Uri],
       releaseRelatedUrls: List[ReleaseRelatedUrl],
-      filesWithOldVersion: List[String],
-      edits: List[EditAttempt]
+      filesWithOldVersion: List[String]
   ): String = {
     val artifacts = artifactsWithOptionalUrl(update, artifactIdToUrl)
     val migrations = edits.collect { case ScalafixEdit(migration, _, _) => migration }
@@ -198,14 +198,14 @@ object NewPullRequestData {
   def from(
       data: UpdateData,
       branchName: String,
+      edits: List[EditAttempt] = List.empty,
       artifactIdToUrl: Map[String, Uri] = Map.empty,
       releaseRelatedUrls: List[ReleaseRelatedUrl] = List.empty,
-      filesWithOldVersion: List[String] = List.empty,
-      edits: List[EditAttempt] = List.empty
+      filesWithOldVersion: List[String] = List.empty
   ): NewPullRequestData =
     NewPullRequestData(
       title = git.commitMsgFor(data.update, data.repoConfig.commits),
-      body = bodyFor(data.update, artifactIdToUrl, releaseRelatedUrls, filesWithOldVersion, edits),
+      body = bodyFor(data.update, edits, artifactIdToUrl, releaseRelatedUrls, filesWithOldVersion),
       head = branchName,
       base = data.baseBranch
     )


### PR DESCRIPTION
This introduces the `EditAttempt` enum for the different types of edits Scala Steward can do in a PR: version bumps, Scalafix changes, and post-update hooks changes. The purpose of this change is that we can in the future use the list of `EditAttempts` returned by `EditAlg` to create more faithful PR bodies that better reflect what Scala Steward did: for example only mention Scalafix migrations if they result in changes, indicate if a Scalafix migration failed, or add labels for post-update hooks., etc.