### PR TITLE
Add artifact migration for sbt-native-packager

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -132,6 +132,12 @@ changes = [
     initialVersion = 0.65.3
   },
   {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-native-packager
+    initialVersion = 1.9.0
+  },
+  {
     groupIdBefore = com.jsuereth
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-pgp


### PR DESCRIPTION
See https://github.com/sbt/sbt-native-packager/pull/1419

Old artifacts: https://scala.jfrog.io/ui/native/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0
New artifacts: https://repo1.maven.org/maven2/com/github/sbt/sbt-native-packager_2.12_1.0/

/cc @muuki88