### PR TITLE
Add "ea" to the list of pre-release identifiers

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -138,9 +138,10 @@ object Version {
       def isPreReleaseIdent: Boolean = order < 0
       def order: Int =
         value.toUpperCase match {
-          case "SNAP" | "SNAPSHOT" | "NIGHTLY" => -5
-          case "ALPHA" | "PREVIEW"             => -4
-          case "BETA" | "B"                    => -3
+          case "SNAP" | "SNAPSHOT" | "NIGHTLY" => -6
+          case "ALPHA" | "PREVIEW"             => -5
+          case "BETA" | "B"                    => -4
+          case "EA" /* early access */         => -3
           case "M" | "MILESTONE" | "AM"        => -2
           case "RC"                            => -1
           case _                               => 0

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -211,7 +211,8 @@ class VersionTest extends DisciplineSuite {
         List("1.0.0-20201208-143052-2c1b1172"),
         Some("1.0.0-20201208-143052-2c1b1172")
       ),
-      ("0.27.0-RC1", List("0.27.0-bin-20200826-2e58a66-NIGHTLY"), None)
+      ("0.27.0-RC1", List("0.27.0-bin-20200826-2e58a66-NIGHTLY"), None),
+      ("17.0.0.1", List("18-ea+4"), None)
     )
 
     val rnd = new Random()


### PR DESCRIPTION
See https://github.com/scala-steward-org/scala-steward/issues/1560#issuecomment-938638701.