### PR TITLE
Log errors in CoursierAlg#getVersions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -92,7 +92,7 @@ object CoursierAlg {
             val module = toCoursierModule(dependency)
             repository.versions(module, cacheNoTtl.fetch).run.flatMap {
               case Left(message) =>
-                logger.trace(message) >> F.raiseError(new Throwable(message))
+                logger.debug(message) >> F.raiseError(new Throwable(message))
               case Right((versions, _)) => F.pure(versions.available.map(Version.apply).sorted)
             }
         }


### PR DESCRIPTION
This refers to #2276. As mentioned in #2202, it's only logged on TRACE level