### PR TITLE
Change name of our logger

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -78,7 +78,7 @@ object Context {
     for {
       _ <- Resource.unit[F]
       config = Config.from(args)
-      logger <- Resource.eval(Slf4jLogger.fromName[F](Context.getClass.getSimpleName))
+      logger <- Resource.eval(Slf4jLogger.fromName[F]("org.scalasteward.core"))
       client <- OkHttpBuilder.withDefaultClient[F].flatMap(_.resource)
       fileAlg = FileAlg.create[F](logger, F)
       processAlg = ProcessAlg.create[F](config.processCfg)(logger, F)


### PR DESCRIPTION
This changes the name of our logger so that it matches the name in
`logback.xml`. Without this change, setting the `LOG_LEVEL` system
property has no effect on the log level of our logger.