### PR TITLE
Use vcsLogin instead of AuthenticatedUser

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -42,14 +42,14 @@ final class VCSSelection[F[_]](config: Config, user: AuthenticatedUser)(implicit
       config.vcsApiHost,
       config.doNotFork,
       config.gitLabCfg,
-      user,
+      config.vcsLogin,
       _ => gitlab.authentication.addCredentials(user)
     )
 
   private def bitbucketApiAlg: BitbucketApiAlg[F] =
     new BitbucketApiAlg(
       config.vcsApiHost,
-      user,
+      config.vcsLogin,
       _ => bitbucket.authentication.addCredentials(user),
       config.doNotFork
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -6,7 +6,6 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.{Cli, Config}
 import org.scalasteward.core.git.FileGitAlg
 import org.scalasteward.core.vcs.VCSType
-import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.concurrent.duration._
 
 object MockConfig {
@@ -29,5 +28,4 @@ object MockConfig {
   val envVars = List(s"GIT_ASKPASS=${config.gitCfg.gitAskPass}", "VAR1=val1", "VAR2=val2")
   def gitCmd(repoDir: File): List[String] =
     envVars ++ (repoDir.toString :: FileGitAlg.gitCmd.toList)
-  val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -160,12 +160,8 @@ class BitbucketApiAlgTest extends FunSuite {
 
   implicit val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
   implicit val httpJsonClient: HttpJsonClient[IO] = new HttpJsonClient[IO]
-  private val bitbucketApiAlg = new BitbucketApiAlg[IO](
-    config.vcsApiHost,
-    AuthenticatedUser("scala-steward", ""),
-    _ => IO.pure,
-    false
-  )
+  private val bitbucketApiAlg =
+    new BitbucketApiAlg[IO](config.vcsApiHost, "scala-steward", _ => IO.pure, false)
 
   private val prUrl = uri"https://bitbucket.org/fthomas/base.g8/pullrequests/2"
   private val repo = Repo("fthomas", "base.g8")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -17,7 +17,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg
 import org.scalasteward.core.data.{RepoData, Update, UpdateData}
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.mock.MockConfig.{config, user}
+import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.{HttpJsonClient, Nel}
 import org.scalasteward.core.vcs.data._
@@ -34,7 +34,7 @@ class GitLabApiAlgTest extends FunSuite {
       case GET -> Root / "projects" / "foo/bar" =>
         Ok(getRepo)
 
-      case POST -> Root / "projects" / "scala-steward/bar" / "merge_requests" =>
+      case POST -> Root / "projects" / s"${config.vcsLogin}/bar" / "merge_requests" =>
         Ok(getMr)
 
       case POST -> Root / "projects" / "foo/bar" / "merge_requests" =>
@@ -84,7 +84,7 @@ class GitLabApiAlgTest extends FunSuite {
       config.vcsApiHost,
       doNotFork = false,
       GitLabCfg(mergeWhenPipelineSucceeds = false),
-      user,
+      config.vcsLogin,
       _ => IO.pure
     )
 
@@ -118,7 +118,7 @@ class GitLabApiAlgTest extends FunSuite {
         config.vcsApiHost,
         doNotFork = true,
         GitLabCfg(mergeWhenPipelineSucceeds = false),
-        user,
+        config.vcsLogin,
         _ => IO.pure
       )
     val prOut =
@@ -157,7 +157,7 @@ class GitLabApiAlgTest extends FunSuite {
         config.vcsApiHost,
         doNotFork = true,
         GitLabCfg(mergeWhenPipelineSucceeds = true),
-        user,
+        config.vcsLogin,
         _ => IO.pure
       )
 
@@ -192,7 +192,7 @@ class GitLabApiAlgTest extends FunSuite {
         config.vcsApiHost,
         doNotFork = true,
         GitLabCfg(mergeWhenPipelineSucceeds = true),
-        user,
+        config.vcsLogin,
         _ => IO.pure
       )(errorJsonClient, implicitly, implicitly)
 


### PR DESCRIPTION
This replaces `user: AuthenticatedUser` with `vcsLogin` in places where
the password is not required. `user.login` is the same as `vcsLogin`.