### PR TITLE
Add Repo.toPath

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -24,6 +24,8 @@ final case class Repo(
     repo: String
 ) {
   def show: String = s"$owner/$repo"
+
+  def toPath: String = s"$owner/$repo"
 }
 
 object Repo {
@@ -31,5 +33,5 @@ object Repo {
     Eq.fromUniversalEquals
 
   implicit val repoKeyEncoder: KeyEncoder[Repo] =
-    KeyEncoder.instance(repo => repo.owner + "/" + repo.repo)
+    KeyEncoder.instance(_.toPath)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -31,7 +31,7 @@ package object vcs {
   def listingBranch(vcsType: VCSType, fork: Repo, update: Update): String =
     vcsType match {
       case GitHub =>
-        s"${fork.show}:${git.branchFor(update).name}"
+        s"${fork.toPath}:${git.branchFor(update).name}"
 
       case GitLab | Bitbucket | BitbucketServer =>
         git.branchFor(update).name

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -18,7 +18,7 @@ class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("build-tool-dispatcher", "test-1")
     val repoConfig = RepoConfig.empty
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val initial = MockState.empty
       .addFiles(
         repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -11,7 +11,7 @@ class MavenAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("namespace", "repo-name")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = MockConfig.config.workspace / repo.show
+    val repoDir = MockConfig.config.workspace / repo.toPath
 
     val state = mavenAlg.getDependencies(buildRoot).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -13,7 +13,7 @@ class MillAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("lihaoyi", "fastparse")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val predef = s"$repoDir/scala-steward.sc"
     val millCmd = List(
       "firejail",

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -36,7 +36,7 @@ class SbtAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("typelevel", "cats")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.2.6")
     val initial = MockState.empty.copy(files = files)
     val state = sbtAlg.getDependencies(buildRoot).runS(initial).unsafeRunSync()
@@ -64,7 +64,7 @@ class SbtAlgTest extends FunSuite {
   test("runMigrations") {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val migration = ScalafixMigration(
       GroupId("co.fs2"),
       Nel.of("fs2-core"),
@@ -101,7 +101,7 @@ class SbtAlgTest extends FunSuite {
   test("runMigrations: migration with scalacOptions") {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val migration = ScalafixMigration(
       GroupId("org.typelevel"),
       Nel.of("cats-core"),

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -22,7 +22,7 @@ class EditAlgTest extends FunSuite {
   test("applyUpdate") {
     val repo = Repo("edit-alg", "test-1")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val update = Update.Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
     val file1 = repoDir / "build.sbt"
     val file2 = repoDir / "project/Dependencies.scala"
@@ -58,7 +58,7 @@ class EditAlgTest extends FunSuite {
   test("applyUpdate with scalafmt update") {
     val repo = Repo("edit-alg", "test-2")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val update = Update.Single("org.scalameta" % "scalafmt-core" % "2.0.0", Nel.of("2.1.0"))
     val scalafmtConf = repoDir / scalafmtConfName
     val scalafmtConfContent = """maxColumn = 100
@@ -116,7 +116,7 @@ class EditAlgTest extends FunSuite {
   test("apply update to ammonite file") {
     val repo = Repo("edit-alg", "test-3")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val update = Update.Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
     val file1 = repoDir / "script.sc"
     val file2 = repoDir / "build.sbt"
@@ -274,7 +274,7 @@ class EditAlgTest extends FunSuite {
       files: Map[String, String]
   ): Map[String, String] = {
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.show
+    val repoDir = config.workspace / repo.toPath
     val filesInRepoDir = files.map { case (file, content) => repoDir / file -> content }
     MockState.empty
       .addFiles(filesInRepoDir.toSeq: _*)

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -41,7 +41,8 @@ class PullRequestRepositoryTest extends FunSuite {
     } yield (result, createdAt)
     val (state, (result, createdAt)) = p.runSA(MockState.empty).unsafeRunSync()
 
-    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     assertEquals(result, Some((url, sha1, PullRequestState.Open)))
     assert(createdAt.isDefined)
 
@@ -74,7 +75,8 @@ class PullRequestRepositoryTest extends FunSuite {
       closedResult <- pullRequestRepository.getObsoleteOpenPullRequests(repo, nextUpdate)
     } yield (emptyResult, result, closedResult)
     val (state, (emptyResult, result, closedResult)) = p.runSA(MockState.empty).unsafeRunSync()
-    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(closedResult, List.empty)
     assertEquals(result, List((number, url, TestData.Updates.PortableScala)))
@@ -106,7 +108,8 @@ class PullRequestRepositoryTest extends FunSuite {
       result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, update)
     } yield (emptyResult, result)
     val (state, (emptyResult, result)) = p.runSA(MockState.empty).unsafeRunSync()
-    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)
 
@@ -137,7 +140,8 @@ class PullRequestRepositoryTest extends FunSuite {
       result <- pullRequestRepository.getObsoleteOpenPullRequests(repo, newUpdate)
     } yield (emptyResult, result)
     val (state, (emptyResult, result)) = p.runSA(MockState.empty).unsafeRunSync()
-    val store = config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     assertEquals(emptyResult, List.empty)
     assertEquals(result, List.empty)
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -117,10 +117,10 @@ class PruningAlgTest extends FunSuite {
           |}""".stripMargin
     )
     val pullRequestsFile =
-      config.workspace / s"store/pull_requests/v2/github/${repo.show}/pull_requests.json"
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     val pullRequestsContent =
       s"""|{
-          |  "https://github.com/${repo.show}/pull/27" : {
+          |  "https://github.com/${repo.toPath}/pull/27" : {
           |    "baseSha1" : "12def27a837ba6dc9e17406cbbe342fba3527c14",
           |    "update" : {
           |      "Single" : {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -11,7 +11,7 @@ import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 
 class VCSRepoAlgTest extends CatsEffectSuite {
   private val repo = Repo("fthomas", "datapackage")
-  private val repoDir = config.workspace / repo.show
+  private val repoDir = config.workspace / repo.toPath
   private val parentRepoOut = RepoOut(
     "datapackage",
     UserOut("fthomas"),


### PR DESCRIPTION
This adds `Repo.toPath` which has currently the same implementation as
`Repo.show`. `show` is used as representation in log messages while
`toPath` is used as path components.

This allows us in #2281 to use `owner/repo:branch` for `show` and
`owner/repo/branch` for `toPath`.