### PR TITLE
Update http4s/v0_22 Scalafix migration

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -65,7 +65,7 @@ migrations = [
     groupId: "org.http4s",
     artifactIds: ["http4s-.*"],
     newVersion: "0.22.0",
-    rewriteRules: ["github:http4s/http4s/v0_22?sha=v0.22.0"]
+    rewriteRules: ["github:http4s/http4s/v0_22?sha=series/0.22"]
   },
   {
     groupId: "org.http4s",


### PR DESCRIPTION
Because this migration is still under active development: https://github.com/http4s/http4s/pull/5387.