### PR TITLE
Allow slashes in owners in the repos.md file (again)

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -34,7 +34,7 @@ final case class Repo(
 
 object Repo {
   def parse(s: String): Option[Repo] = {
-    val regex = """-\s+([^/:]+)/([^/:]+)(:.+)?""".r
+    val regex = """-\s+([^:]+)/([^/:]+)(:.+)?""".r
     s match {
       case regex(owner, repo, branch) =>
         Some(Repo(owner.trim, repo.trim, Option(branch).map(b => Branch(b.tail.trim))))

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoTest.scala
@@ -5,10 +5,8 @@ import org.scalasteward.core.git.Branch
 
 class RepoTest extends FunSuite {
   test("parse") {
-    assertEquals(
-      Repo.parse("- typelevel/cats-effect"),
-      Some(Repo("typelevel", "cats-effect", None))
-    )
+    assertEquals(Repo.parse("- typelevel/cats-effect"), Some(Repo("typelevel", "cats-effect")))
+    assertEquals(Repo.parse("- group1/group2/project1"), Some(Repo("group1/group2", "project1")))
     assertEquals(
       Repo.parse("- typelevel/cats-effect:3.x"),
       Some(Repo("typelevel", "cats-effect", Some(Branch("3.x"))))


### PR DESCRIPTION
This again allows the owner field to contain slashes.
We had this since #742 but it was (inadvertently) reverted in #2297.