### PR TITLE
Prefer HTTP URLs in CoursierAlg.getArtifactUrl

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -140,5 +140,5 @@ object CoursierAlg {
     }
 
   private def getScmUrlOrHomePage(info: Info): Option[Uri] =
-    (info.scm.flatMap(_.url).toList :+ info.homePage).flatMap(uri.browsableUriFromString).headOption
+    uri.findBrowsableUrl(info.scm.flatMap(_.url).toList :+ info.homePage)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
@@ -20,7 +20,7 @@ import cats.syntax.all._
 import io.circe.{Decoder, KeyDecoder, KeyEncoder}
 import monocle.Optional
 import org.http4s.Uri
-import org.http4s.Uri.{Authority, UserInfo}
+import org.http4s.Uri.{Authority, Scheme, UserInfo}
 
 object uri {
   implicit val uriDecoder: Decoder[Uri] =
@@ -41,7 +41,11 @@ object uri {
   val withUserInfo: Optional[Uri, UserInfo] =
     authorityWithUserInfo.compose(withAuthority)
 
-  def browsableUriFromString(s: String): Option[Uri] =
-    if (s.isEmpty || s.startsWith("git@") || s.startsWith("git:")) None
-    else Uri.fromString(s).toOption.filter(_.scheme.isDefined)
+  private val httpSchemes: Set[Scheme] =
+    Set(Scheme.https, Scheme.http)
+
+  def findBrowsableUrl(xs: List[String]): Option[Uri] = {
+    val urls = xs.flatMap(Uri.fromString(_).toList).filter(_.scheme.isDefined)
+    urls.find(_.scheme.exists(httpSchemes)).orElse(urls.headOption)
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,7 +1,6 @@
 package org.scalasteward.core.coursier
 
-import cats.effect.unsafe.implicits.global
-import munit.FunSuite
+import munit.CatsEffectSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
@@ -9,86 +8,49 @@ import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext.context.coursierAlg
 import org.scalasteward.core.mock.MockState
 
-class CoursierAlgTest extends FunSuite {
+class CoursierAlgTest extends CatsEffectSuite {
   test("getArtifactUrl: library") {
-    val dep =
-      Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"https://github.com/typelevel/cats-effect"))
+    val artifactId = ArtifactId("cats-effect", "cats-effect_2.12")
+    val dep = Dependency(GroupId("org.typelevel"), artifactId, "1.0.0")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://github.com/typelevel/cats-effect"))
+    }
   }
 
   test("getArtifactUrl: defaults to homepage") {
-    val dep = Dependency(
-      GroupId("com.typesafe.play"),
-      ArtifactId("play-ws-standalone-json", "play-ws-standalone-json_2.12"),
-      "2.1.0-M7"
-    )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"https://github.com/playframework/play-ws"))
+    val artifactId = ArtifactId("play-ws-standalone-json", "play-ws-standalone-json_2.12")
+    val dep = Dependency(GroupId("com.typesafe.play"), artifactId, "2.1.0-M7")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://github.com/playframework/play-ws"))
+    }
   }
 
   test("getArtifactUrl: URL with no or invalid scheme 1") {
-    val dep = Dependency(
-      GroupId("org.msgpack"),
-      ArtifactId("msgpack-core"),
-      "0.8.20"
-    )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"http://msgpack.org/"))
+    val dep = Dependency(GroupId("org.msgpack"), ArtifactId("msgpack-core"), "0.8.20")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"http://msgpack.org/"))
+    }
   }
 
   test("getArtifactUrl: URL with no or invalid scheme 2") {
-    val dep = Dependency(
-      GroupId("org.xhtmlrenderer"),
-      ArtifactId("flying-saucer-parent"),
-      "9.0.1"
-    )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"http://code.google.com/p/flying-saucer/"))
+    val dep = Dependency(GroupId("org.xhtmlrenderer"), ArtifactId("flying-saucer-parent"), "9.0.1")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"http://code.google.com/p/flying-saucer/"))
+    }
   }
 
   test("getArtifactUrl: from parent") {
-    val dep = Dependency(
-      GroupId("net.bytebuddy"),
-      ArtifactId("byte-buddy"),
-      "1.10.5"
-    )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"https://bytebuddy.net"))
+    val dep = Dependency(GroupId("net.bytebuddy"), ArtifactId("byte-buddy"), "1.10.5")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://bytebuddy.net"))
+    }
   }
 
   test("getArtifactUrl: minimal pom") {
-    val dep = Dependency(
-      GroupId("altrmi"),
-      ArtifactId("altrmi-common"),
-      "0.9.6"
-    )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, None)
+    val dep = Dependency(GroupId("altrmi"), ArtifactId("altrmi-common"), "0.9.6")
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, None)
+    }
   }
 
   test("getArtifactUrl: sbt plugin on Maven Central") {
@@ -99,12 +61,9 @@ class CoursierAlgTest extends FunSuite {
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
     )
-    val (state, result) = coursierAlg
-      .getArtifactUrl(dep.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"https://github.com/xerial/sbt-sonatype"))
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://github.com/xerial/sbt-sonatype"))
+    }
   }
 
   test("getArtifactUrl: sbt plugin on sbt-plugin-releases") {
@@ -115,10 +74,18 @@ class CoursierAlgTest extends FunSuite {
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
     )
-    val (state, result) =
-      coursierAlg.getArtifactUrl(dep.withSbtPluginReleases).runSA(MockState.empty).unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(result, Some(uri"https://github.com/sbt/sbt-release"))
+    coursierAlg.getArtifactUrl(dep.withSbtPluginReleases).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://github.com/sbt/sbt-release"))
+    }
+  }
+
+  test("getArtifactUrl: invalid scm URL but valid homepage") {
+    val groupId = GroupId("com.github.japgolly.scalajs-react")
+    val dep = Dependency(groupId, ArtifactId("core", "core_sjs1_2.13"), "2.0.0-RC5")
+
+    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
+      assertEquals(obtained, Some(uri"https://github.com/japgolly/scalajs-react"))
+    }
   }
 
   test("getArtifactIdUrlMapping") {
@@ -126,17 +93,13 @@ class CoursierAlgTest extends FunSuite {
       Dependency(GroupId("org.typelevel"), ArtifactId("cats-core", "cats-core_2.12"), "1.6.0"),
       Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     )
-    val (state, result) = coursierAlg
-      .getArtifactIdUrlMapping(dependencies.withMavenCentral)
-      .runSA(MockState.empty)
-      .unsafeRunSync()
-    assertEquals(state, MockState.empty)
-    assertEquals(
-      result,
-      Map(
-        "cats-core" -> uri"https://github.com/typelevel/cats",
-        "cats-effect" -> uri"https://github.com/typelevel/cats-effect"
-      )
-    )
+    coursierAlg.getArtifactIdUrlMapping(dependencies.withMavenCentral).runA(MockState.empty).map {
+      obtained =>
+        val expected = Map(
+          "cats-core" -> uri"https://github.com/typelevel/cats",
+          "cats-effect" -> uri"https://github.com/typelevel/cats-effect"
+        )
+        assertEquals(obtained, expected)
+    }
   }
 }


### PR DESCRIPTION
This improves `CoursierAlg.getArtifactUrl` such that URLs with HTTP schemes are preferred over URLs with other schemes.

This change is motivated by [scalajs-react's POM](https://repo1.maven.org/maven2/com/github/japgolly/scalajs-react/core_sjs1_2.13/2.0.0-RC5/core_sjs1_2.13-2.0.0-RC5.pom) which contains the following URLs:
```xml
<url>https://github.com/japgolly/scalajs-react</url>
...
<scm>
  ...
  <url>github.com:japgolly/scalajs-react.git</url>
</scm>
```
Before this change, `scm.url` was preferred over `url`. But since `scm.url` does not use a HTTP scheme, `url` is now preferred.

The `github.com:` URL is unusable for finding release notes and other release related URLs that are normally used in PR bodies. That is the reason why recent scalajs-react updates (like https://github.com/rpiaggio/crystal/pull/269) did not contain any links.