### PR TITLE
Run scalafmt with `--quiet`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -95,7 +95,7 @@ object HookExecutor {
     PostUpdateHook(
       groupId = scalafmtGroupId,
       artifactId = scalafmtArtifactId,
-      command = Nel.of(scalafmtBinary, opts.nonInteractive),
+      command = Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet),
       useSandbox = false,
       commitMessage = update => CommitMsg(s"Reformat with scalafmt ${update.nextVersion}"),
       enabledByCache = _ => true,

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -25,8 +25,7 @@ import org.scalasteward.core.edit.EditAttempt.HookEdit
 import org.scalasteward.core.git.{CommitMsg, GitAlg}
 import org.scalasteward.core.io.{ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.repocache.RepoCache
-import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
-import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}
+import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.logger._
 import org.scalasteward.core.vcs.data.Repo
@@ -95,7 +94,7 @@ object HookExecutor {
     PostUpdateHook(
       groupId = scalafmtGroupId,
       artifactId = scalafmtArtifactId,
-      command = Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet),
+      command = ScalafmtAlg.postUpdateHookCommand,
       useSandbox = false,
       commitMessage = update => CommitMsg(s"Reformat with scalafmt ${update.nextVersion}"),
       enabledByCache = _ => true,

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -70,6 +70,9 @@ object ScalafmtAlg {
     val version = "--version"
   }
 
+  val postUpdateHookCommand: Nel[String] =
+    Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet)
+
   private[scalafmt] def parseScalafmtConf(s: String): Either[ParsingFailure, Option[Version]] =
     io.circe.config.parser.parse(s).map {
       _.asObject.flatMap(_.apply("version")).flatMap(_.asString).map(Version.apply)

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -52,7 +52,7 @@ final class ScalafmtAlg[F[_]](config: Config)(implicit
       .value
 
   def reformatChanged(repo: Repo): F[Unit] = {
-    val cmd = Nel.of(scalafmtBinary, opts.nonInteractive) ++ opts.modeChanged
+    val cmd = Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet) ++ opts.modeChanged
     workspaceAlg.repoDir(repo).flatMap(processAlg.exec(cmd, _)).void
   }
 
@@ -66,6 +66,7 @@ object ScalafmtAlg {
   object opts {
     val modeChanged = List("--mode", "changed")
     val nonInteractive = "--non-interactive"
+    val quiet = "--quiet"
     val version = "--version"
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -100,11 +100,15 @@ class EditAlgTest extends FunSuite {
         Cmd("read", scalafmtConf.pathAsString),
         Cmd("write", scalafmtConf.pathAsString),
         Cmd(
-          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString :: scalafmtBinary :: opts.nonInteractive :: opts.modeChanged
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
+            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: opts.modeChanged
         ),
         Cmd(gitStatus(repoDir)),
         Log("Executing post-update hook for org.scalameta:scalafmt-core"),
-        Cmd("VAR1=val1", "VAR2=val2", repoDir.toString, scalafmtBinary, opts.nonInteractive),
+        Cmd(
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
+            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: Nil
+        ),
         Cmd(gitStatus(repoDir))
       ),
       files = Map(

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -41,7 +41,10 @@ class HookExecutorTest extends CatsEffectSuite {
     val expected = initial.copy(
       trace = Vector(
         Log("Executing post-update hook for org.scalameta:scalafmt-core"),
-        Cmd("VAR1=val1", "VAR2=val2", repoDir.toString, scalafmtBinary, opts.nonInteractive),
+        Cmd(
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
+            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: Nil
+        ),
         Cmd(
           gitCmd(repoDir),
           "status",


### PR DESCRIPTION
Run scalafmt with `--quiet` option so that exceptions from scalafmt do
not contain useless progress output like this:
```
Reformatting...
Reformatting... (0.12 %, 1 / 836)

Reformatting... (0.72 %, 6 / 836)

Reformatting... (1.56 %, 13 / 836)

Reformatting... (2.39 %, 20 / 836)

Reformatting... (4.31 %, 36 / 836)

Reformatting... (7.18 %, 60 / 836)

...
```