### PR TITLE
Wait until currently used dependencies are sufficiently old before updating them

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -32,6 +32,7 @@ import org.scalasteward.core.edit.hooks.HookExecutor
 import org.scalasteward.core.edit.scalafix.{ScalafixMigrationsFinder, ScalafixMigrationsLoader}
 import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.mavencentral.MavenCentralApiAlg
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository}
 import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
 import org.scalasteward.core.repocache._
@@ -124,6 +125,7 @@ object Context {
       implicit val gitHubAuthAlg: GitHubAuthAlg[F] = GitHubAuthAlg.create[F]
       implicit val hookExecutor: HookExecutor[F] = new HookExecutor[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
+      implicit val mavenCentralApiAlg: MavenCentralApiAlg[F] = new MavenCentralApiAlg[F]()
       implicit val repoCacheRepository: RepoCacheRepository[F] =
         new RepoCacheRepository[F](repoCacheStore)
       implicit val vcsApiAlg: VCSApiAlg[F] = new VCSSelection[F](config, vcsUser).vcsApiAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/data/DependencyInfo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/DependencyInfo.scala
@@ -19,9 +19,12 @@ package org.scalasteward.core.data
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 
+import java.time.Instant
+
 final case class DependencyInfo(
     dependency: Dependency,
-    filesContainingVersion: List[String]
+    filesContainingVersion: List[String],
+    releaseTimestamp: Option[Instant] = None
 )
 
 object DependencyInfo {

--- a/modules/core/src/main/scala/org/scalasteward/core/mavencentral/MavenCentralApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/mavencentral/MavenCentralApiAlg.scala
@@ -1,0 +1,21 @@
+package org.scalasteward.core.mavencentral
+
+import cats.Applicative
+import cats.syntax.functor._
+import org.http4s.implicits.http4sLiteralsSyntax
+import org.scalasteward.core.data.Dependency
+import org.scalasteward.core.util.HttpJsonClient
+
+/** See the section labelled 'REST API' in [[https://search.maven.org/classic/#api]]
+  */
+class MavenCentralApiAlg[F[_]: Applicative](implicit
+  client: HttpJsonClient[F]
+) {
+
+  def searchForDocumentOn(dependency: Dependency): F[Option[Document]] = client.get[SearchOut](
+    uri"https://search.maven.org/solrsearch/select".withQueryParam(
+      "q",
+      s"g:${dependency.groupId.value}+AND+a:${dependency.artifactId.name}+AND+v:${dependency.version}"),
+    req => Applicative[F].point(req)
+  ).map(_.response.docs.find(_.dependency == dependency))
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/mavencentral/SearchOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/mavencentral/SearchOut.scala
@@ -1,0 +1,39 @@
+package org.scalasteward.core.mavencentral
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
+
+import java.time.Instant
+
+case class SearchOut(response: SearchResponse)
+object SearchOut {
+  implicit val decoder: Decoder[SearchOut] = deriveDecoder
+}
+
+case class SearchResponse(docs: Seq[Document])
+object SearchResponse {
+  implicit val decoder: Decoder[SearchResponse] = deriveDecoder
+}
+
+//"g": "software.amazon.awssdk",
+//  "a": "s3",
+//  "v": "2.17.71",
+case class Document(
+  g: String,
+  a: String,
+  v: String,
+  timestamp: Instant
+) {
+  val groupId = GroupId(g)
+  val artifactId = ArtifactId(a)
+  val dependency = Dependency(groupId, artifactId, v)
+}
+
+object Document {
+  implicit val instantDecoder: Decoder[Instant] = Decoder.decodeLong.map(Instant.ofEpochMilli)
+
+  implicit val decoder: Decoder[Document] = deriveDecoder
+}
+
+

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -26,11 +26,13 @@ import io.circe.{Codec, Decoder}
 import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.update.FilterAlg.{
   FilterResult,
+  RejectionReason,
   IgnoredByConfig,
   NotAllowedByConfig,
   VersionPinnedByConfig
 }
 import org.scalasteward.core.util.{combineOptions, Nel}
+import org.scalasteward.core.repoconfig.UpdatePattern.MatchResult
 
 final case class UpdatesConfig(
     pin: List[UpdatePattern] = List.empty,
@@ -43,32 +45,21 @@ final case class UpdatesConfig(
     fileExtensions.fold(UpdatesConfig.defaultFileExtensions)(_.toSet)
 
   def keep(update: Update.Single): FilterResult =
-    isAllowed(update).flatMap(isPinned).flatMap(isIgnored)
+    check(allow, NotAllowedByConfig)(update)
+      .flatMap(check(pin, VersionPinnedByConfig, noEffectWhen = _.byArtifactId.isEmpty))
+      .flatMap(check(ignore, IgnoredByConfig, include = false))
 
-  private def isAllowed(update: Update.Single): FilterResult = {
-    val m = UpdatePattern.findMatch(allow, update, include = true)
-    if (m.filteredVersions.nonEmpty)
-      Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
-    else if (allow.isEmpty)
-      Right(update)
-    else Left(NotAllowedByConfig(update))
-  }
-
-  private def isPinned(update: Update.Single): FilterResult = {
-    val m = UpdatePattern.findMatch(pin, update, include = true)
-    if (m.filteredVersions.nonEmpty)
-      Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
-    else if (m.byArtifactId.isEmpty)
-      Right(update)
-    else Left(VersionPinnedByConfig(update))
-  }
-
-  private def isIgnored(update: Update.Single): FilterResult = {
-    val m = UpdatePattern.findMatch(ignore, update, include = false)
-    if (m.filteredVersions.nonEmpty)
-      Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
-    else
-      Left(IgnoredByConfig(update))
+  private def check(
+    patterns: List[UpdatePattern],
+    reportedReasonWhenAllRejectedFrom: Update.Single => RejectionReason,
+    include: Boolean = true,
+    noEffectWhen: MatchResult => Boolean = _ => false,
+  )(update: Update.Single): FilterResult = if (patterns.isEmpty) Right(update) else {
+    val m = UpdatePattern.findMatch(patterns, update, include)
+    Nel.fromList(m.filteredVersions)
+      .map(filteredVersions => update.copy(newerVersions = filteredVersions))
+      .orElse(Option.when(noEffectWhen(m))(update))
+      .toRight(reportedReasonWhenAllRejectedFrom(update))
   }
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -23,15 +23,9 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.refined._
 import io.circe.{Codec, Decoder}
-import org.scalasteward.core.data.{GroupId, Update}
-import org.scalasteward.core.update.FilterAlg.{
-  FilterResult,
-  RejectionReason,
-  IgnoredByConfig,
-  NotAllowedByConfig,
-  VersionPinnedByConfig
-}
-import org.scalasteward.core.util.{combineOptions, Nel}
+import org.scalasteward.core.data.{Dependency, GroupId, Update}
+import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig, RejectionReason, VersionPinnedByConfig}
+import org.scalasteward.core.util.{Nel, combineOptions}
 import org.scalasteward.core.repoconfig.UpdatePattern.MatchResult
 
 final case class UpdatesConfig(
@@ -41,6 +35,11 @@ final case class UpdatesConfig(
     limit: Option[NonNegInt] = None,
     fileExtensions: Option[List[String]] = None
 ) {
+  private val allUpdatePatterns = pin ++ allow ++ ignore
+
+  def wouldLikeToKnowAgeOf(dependency: Dependency): Boolean =
+    allUpdatePatterns.exists(_.groupAndArtifactWouldMatch(dependency))
+
   def fileExtensionsOrDefault: Set[String] =
     fileExtensions.fold(UpdatesConfig.defaultFileExtensions)(_.toSet)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubAppApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubAppApiAlg.scala
@@ -68,7 +68,7 @@ class GitHubAppApiAlg[F[_]: Applicative](
             req.putHeaders(
               Header.Raw(ci"Authorization", s"token $token"),
               acceptHeader
-            )
+            ) // how does this get the next lot of Repositories?!?
           )
       )
       .map(values =>

--- a/modules/core/src/test/scala/org/scalasteward/core/mavencentral/MavenCentralApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mavencentral/MavenCentralApiAlgTest.scala
@@ -1,0 +1,96 @@
+package org.scalasteward.core.mavencentral
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.circe.literal._
+import munit.FunSuite
+import org.http4s.HttpRoutes
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
+import org.scalasteward.core.util.HttpJsonClient
+
+import java.time.Instant
+
+
+class MavenCentralApiAlgTest extends FunSuite {
+  val routes: HttpRoutes[IO] =
+    HttpRoutes.of[IO] {
+      // https://search.maven.org/solrsearch/select?q=g:%22software.amazon.awssdk%22%20AND%20a:%22s3%22%20AND%20v:%222.17.71%22&rows=20&wt=json
+      case GET -> Root / "solrsearch" / "select" =>
+        Ok(
+          json""" {
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "g:\"software.amazon.awssdk\" AND a:\"s3\" AND v:\"2.17.71\"",
+      "core": "",
+      "indent": "off",
+      "fl": "id,g,a,v,p,ec,timestamp,tags",
+      "start": "",
+      "sort": "score desc,timestamp desc,g asc,a asc,v desc",
+      "rows": "20",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "docs": [
+      {
+        "id": "software.amazon.awssdk:s3:2.17.71",
+        "g": "software.amazon.awssdk",
+        "a": "s3",
+        "v": "2.17.71",
+        "p": "jar",
+        "timestamp": 1635540791000,
+        "ec": [
+          "-javadoc.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "tags": [
+          "classes",
+          "module",
+          "with",
+          "client",
+          "communicating",
+          "simple",
+          "used",
+          "amazon",
+          "that",
+          "service",
+          "java",
+          "holds",
+          "storage"
+        ]
+      }
+    ]
+  }
+} """
+        )
+
+      case req =>
+        println(req.toString())
+        NotFound()
+    }
+
+  implicit val httpJsonClient: HttpJsonClient[IO] = {
+    implicit val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
+    new HttpJsonClient[IO]
+  }
+
+  val mavenCentralApiAlg = new MavenCentralApiAlg[IO]() // (_ => IO.pure)
+
+  test("searchForDependency") {
+    val dependency = Dependency(GroupId("software.amazon.awssdk"), ArtifactId("s3"), "2.17.71")
+
+    val docOpt = mavenCentralApiAlg.searchForDocumentOn(dependency).unsafeRunSync()
+    assertEquals(docOpt.map(_.timestamp),Some(Instant.parse("2021-10-29T20:53:11Z")))
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -24,7 +24,10 @@ class RepoConfigAlgTest extends FunSuite {
          |                 { groupId = "eu.timepit", artifactId = "refined.3", version = { suffix="jre" } },
          |                 { groupId = "eu.timepit", artifactId = "refined.4", version = { prefix="0.8.", suffix="jre" } }
          |               ]
-         |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
+         |updates.ignore = [
+         |                   { groupId = "org.acme", version = "1.0" },
+         |                   { groupId = "software.amazon.awssdk", artifactId = "dynamodb", untilCurrentArtifactIsAged = "14d" },
+         |                 ]
          |updates.limit = 4
          |updates.fileExtensions = [ ".txt" ]
          |pullRequests.frequency = "@weekly"


### PR DESCRIPTION
This aims to fix #1581 - _"receiving daily PRs for dependencies that get released nightly (like any of the [AWS SDK modules](https://search.maven.org/artifact/software.amazon.awssdk/s3)) can be a bit much, especially for expensive, long-running CI builds."_ - ie not everybody wants to merge a new PR daily for one of these...! :

![image](https://user-images.githubusercontent.com/52038/139739691-d9473943-54e6-431a-bcf7-6adf8f0e9378.png)

This PR will allow users to configure Scala Steward so that it _won't_ open PRs to update dependencies that are younger than the specified threshold - eg, if the artifact I'm _using_ is only a few days old, I don't want to get a PR to update it just yet!