### PR TITLE
Set default `--refresh-backoff-period` to zero

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -37,5 +37,5 @@ All command line arguments for the `scala-steward` application.
   --gitlab-merge-when-pipeline-succeeds  BOOLEAN     Wether to merge a gitlab merge request when the pipeline succeeds
   --github-app-key-file  FILE                        Github application key file
   --github-app-id  ID                                Github application id
-  --refresh-backoff-period DURATION                  Period of time a failed build won't be triggered again, default: "7 days"
+  --refresh-backoff-period DURATION                  Period of time a failed build won't be triggered again, default: "0 days"
 ```

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -59,7 +59,7 @@ object Cli {
       githubAppId: Option[Long] = None,
       urlCheckerTestUrl: Option[Uri] = None,
       defaultMavenRepo: Option[String] = None,
-      refreshBackoffPeriod: FiniteDuration = 7.days
+      refreshBackoffPeriod: FiniteDuration = 0.days
   )
 
   final case class EnvVar(name: String, value: String)


### PR DESCRIPTION
This sets the default `--refresh-backoff-period` to 0 days which means
that Scala Steward will not skip repos where running the build failed
previously. It effectively disables the `RefreshErrorAlg`. I
think this is a better default for most Scala Steward users since most
have control over the repositories that Scala Steward tracks and can fix
any issues with failing repos. Skipping repos is mostly interesting for
public instances where the Scala Steward operator cannot fix all issues.