### PR TITLE
Allow running Scalafix migrations after version bump

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -9,6 +9,8 @@ migrations = [
     groupId: "co.fs2",
     artifactIds: ["fs2-.*"],
     newVersion: "3.0.7",
+    // Note that the replace rule can generate broken code in some cases.
+    // See https://github.com/scalacenter/scalafix/issues/1168 for details.
     rewriteRules: [
       "replace:fs2.text.utf8Decode/fs2.text.utf8.decode",
       "replace:fs2.text.utf8DecodeC/fs2.text.utf8.decodeC",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -6,6 +6,18 @@ migrations = [
     rewriteRules: ["github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"]
   },
   {
+    groupId: "co.fs2",
+    artifactIds: ["fs2-.*"],
+    newVersion: "3.0.7",
+    rewriteRules: [
+      "replace:fs2.text.utf8Decode/fs2.text.utf8.decode",
+      "replace:fs2.text.utf8DecodeC/fs2.text.utf8.decodeC",
+      "replace:fs2.text.utf8Encode/fs2.text.utf8.encode",
+      "replace:fs2.text.utf8EncodeC/fs2.text.utf8.encodeC"
+    ],
+    executionOrder: "post-update"
+  },
+  {
     groupId: "com.github.fd4s",
     artifactIds: ["fs2-kafka"],
     newVersion: "1.3.1",

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
@@ -16,11 +16,12 @@
 
 package org.scalasteward.core.edit.scalafix
 
+import cats.Eq
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import org.scalasteward.core.data.{GroupId, Version}
-import org.scalasteward.core.edit.scalafix.ScalafixMigration.Target
+import org.scalasteward.core.edit.scalafix.ScalafixMigration.{ExecutionOrder, Target}
 import org.scalasteward.core.git.{Author, CommitMsg}
 import org.scalasteward.core.util.Nel
 
@@ -32,7 +33,8 @@ final case class ScalafixMigration(
     doc: Option[String] = None,
     scalacOptions: Option[Nel[String]] = None,
     authors: Option[Nel[Author]] = None,
-    target: Option[Target] = None
+    target: Option[Target] = None,
+    executionOrder: Option[ExecutionOrder] = None
 ) {
   def commitMessage(result: Either[Throwable, Unit]): CommitMsg = {
     val verb = if (result.isRight) "Applied" else "Failed"
@@ -41,12 +43,31 @@ final case class ScalafixMigration(
     CommitMsg(title, body.toList, authors.foldMap(_.toList))
   }
 
+  def executionOrderOrDefault: ExecutionOrder =
+    executionOrder.getOrElse(ExecutionOrder.PreUpdate)
+
   def targetOrDefault: Target =
     target.getOrElse(Target.Sources)
 }
 
 object ScalafixMigration {
-  sealed trait Target
+  sealed trait ExecutionOrder extends Product with Serializable
+  object ExecutionOrder {
+    case object PreUpdate extends ExecutionOrder
+    case object PostUpdate extends ExecutionOrder
+
+    implicit val executionOrderEq: Eq[ExecutionOrder] =
+      Eq.fromUniversalEquals
+
+    implicit val executionOrderDecoder: Decoder[ExecutionOrder] =
+      Decoder[String].emap {
+        case "pre-update"  => Right(PreUpdate)
+        case "post-update" => Right(PostUpdate)
+        case s => Left(s"Unexpected string '$s'. Expected 'pre-update' or 'post-update'.")
+      }
+  }
+
+  sealed trait Target extends Product with Serializable
   object Target {
     case object Sources extends Target
     case object Build extends Target
@@ -55,7 +76,7 @@ object ScalafixMigration {
       Decoder[String].emap {
         case "sources" => Right(Sources)
         case "build"   => Right(Build)
-        case unknown   => Left(s"Unexpected string '$unknown'. Expected 'sources' or 'build'.")
+        case s         => Left(s"Unexpected string '$s'. Expected 'sources' or 'build'.")
       }
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
@@ -23,7 +23,7 @@ import io.circe.generic.semiauto._
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.{ExecutionOrder, Target}
 import org.scalasteward.core.git.{Author, CommitMsg}
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.util.{unexpectedString, Nel}
 
 final case class ScalafixMigration(
     groupId: GroupId,
@@ -63,7 +63,7 @@ object ScalafixMigration {
       Decoder[String].emap {
         case "pre-update"  => Right(PreUpdate)
         case "post-update" => Right(PostUpdate)
-        case s => Left(s"Unexpected string '$s'. Expected 'pre-update' or 'post-update'.")
+        case s             => unexpectedString(s, List("pre-update", "post-update"))
       }
   }
 
@@ -76,7 +76,7 @@ object ScalafixMigration {
       Decoder[String].emap {
         case "sources" => Right(Sources)
         case "build"   => Right(Build)
-        case s         => Left(s"Unexpected string '$s'. Expected 'sources' or 'build'.")
+        case s         => unexpectedString(s, List("sources", "build"))
       }
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -87,4 +87,7 @@ package object util {
       _.mapAccumulate(init) { case (i, a) => (N.plus(i, weight(a)), a) }
         .takeThrough { case (total, _) => N.lt(total, limit) }
         .map { case (_, a) => a }
+
+  def unexpectedString(s: String, expected: List[String]): Left[String, Nothing] =
+    Left(s"Unexpected string '$s'. Expected one of: ${expected.mkString(", ")}.")
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSType.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.vcs
 import cats.Eq
 import cats.syntax.all._
 import org.http4s.syntax.literals._
+import org.scalasteward.core.util.unexpectedString
 import org.scalasteward.core.vcs.VCSType._
 
 sealed trait VCSType {
@@ -57,8 +58,7 @@ object VCSType {
   def parse(s: String): Either[String, VCSType] =
     all.find(_.asString === s) match {
       case Some(value) => Right(value)
-      case None =>
-        Left(s"Unexpected string '$s'. Expected one of: ${all.map(_.asString).mkString(", ")}.")
+      case None        => unexpectedString(s, all.map(_.asString))
     }
 
   def fromPublicWebHost(host: String): Option[VCSType] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/json.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.vcs.bitbucket
 import io.circe.Decoder
 import org.http4s.Uri
 import org.scalasteward.core.git.{Branch, Sha1}
+import org.scalasteward.core.util.unexpectedString
 import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.vcs.data._
 
@@ -34,7 +35,7 @@ private[bitbucket] object json {
     Decoder[String].emap {
       case "OPEN"                               => Right(PullRequestState.Open)
       case "MERGED" | "SUPERSEDED" | "DECLINED" => Right(PullRequestState.Closed)
-      case unknown                              => Left(s"Unexpected string '$unknown'")
+      case s => unexpectedString(s, List("OPEN", "MERGED", "SUPERSEDED", "DECLINED"))
     }
 
   implicit val pullRequestOutDecoder: Decoder[PullRequestOut] = Decoder.instance { c =>

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.vcs.data
 
 import cats.Eq
 import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.util.unexpectedString
 import org.scalasteward.core.vcs.data.PullRequestState.{Closed, Open}
 
 sealed trait PullRequestState {
@@ -40,7 +41,7 @@ object PullRequestState {
       _.toLowerCase match {
         case "open" | "opened"                => Right(Open)
         case "closed" | "merged" | "declined" => Right(Closed)
-        case unknown                          => Left(s"Unexpected string '$unknown'")
+        case s => unexpectedString(s, List("open", "opened", "closed", "merged", "declined"))
       }
     }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
@@ -2,6 +2,7 @@ package org.scalasteward.core.edit.scalafix
 
 import io.circe.config.parser
 import munit.FunSuite
+import org.scalasteward.core.edit.scalafix.ScalafixMigration.{ExecutionOrder, Target}
 import org.scalasteward.core.util.Nel
 
 class ScalafixMigrationTest extends FunSuite {
@@ -24,5 +25,13 @@ class ScalafixMigrationTest extends FunSuite {
       "Co-authored-by: Jane Doe <jane@example.com>"
     )
     assertEquals(obtained, Right(expected))
+  }
+
+  test("decode unknown executionOrder") {
+    assert(io.circe.parser.decode[ExecutionOrder]("foo").isLeft)
+  }
+
+  test("decode unknown target") {
+    assert(io.circe.parser.decode[Target]("foo").isLeft)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
@@ -28,10 +28,10 @@ class ScalafixMigrationTest extends FunSuite {
   }
 
   test("decode unknown executionOrder") {
-    assert(io.circe.parser.decode[ExecutionOrder]("foo").isLeft)
+    assert(io.circe.parser.decode[ExecutionOrder](""""foo"""").isLeft)
   }
 
   test("decode unknown target") {
-    assert(io.circe.parser.decode[Target]("foo").isLeft)
+    assert(io.circe.parser.decode[Target](""""foo"""").isLeft)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
@@ -10,17 +10,20 @@ class ScalafixMigrationsFinderTest extends FunSuite {
   test("findMigrations") {
     val update = Update.Single("org.typelevel" % "cats-core" % "2.1.0", Nel.of("2.2.0"))
     val migrations = scalafixMigrationsFinder.findMigrations(update)
-    val expected = List(
-      ScalafixMigration(
-        GroupId("org.typelevel"),
-        Nel.of("cats-core"),
-        Version("2.2.0"),
-        Nel.of("github:typelevel/cats/Cats_v2_2_0?sha=v2.2.0"),
-        Some(
-          "https://github.com/typelevel/cats/blob/v2.2.0/scalafix/README.md#migration-to-cats-v220"
-        ),
-        Some(Nel.of("-P:semanticdb:synthetics:on"))
-      )
+    val expected = (
+      List(
+        ScalafixMigration(
+          GroupId("org.typelevel"),
+          Nel.of("cats-core"),
+          Version("2.2.0"),
+          Nel.of("github:typelevel/cats/Cats_v2_2_0?sha=v2.2.0"),
+          Some(
+            "https://github.com/typelevel/cats/blob/v2.2.0/scalafix/README.md#migration-to-cats-v220"
+          ),
+          Some(Nel.of("-P:semanticdb:synthetics:on"))
+        )
+      ),
+      List()
     )
     assertEquals(migrations, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
@@ -5,6 +5,7 @@ import munit.FunSuite
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.ScalafixCfg
 import org.scalasteward.core.data.{GroupId, Version}
+import org.scalasteward.core.edit.scalafix.ScalafixMigration.ExecutionOrder.PreUpdate
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.Target.Sources
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.mock.MockConfig.mockRoot
@@ -23,7 +24,8 @@ class ScalafixMigrationsLoaderTest extends FunSuite {
        |    rewriteRules: ["awesome rewrite rule"],
        |    doc: "https://scalacenter.github.io/scalafix/",
        |    authors: ["Jane Doe <jane@example.com>"],
-       |    target: "sources"
+       |    target: "sources",
+       |    executionOrder: "pre-update"
        |  }
        |]""".stripMargin
   val migration: ScalafixMigration = ScalafixMigration(
@@ -33,7 +35,8 @@ class ScalafixMigrationsLoaderTest extends FunSuite {
     Nel.of("awesome rewrite rule"),
     Some("https://scalacenter.github.io/scalafix/"),
     authors = Some(Nel.of(Author("Jane Doe", "jane@example.com"))),
-    target = Some(Sources)
+    target = Some(Sources),
+    executionOrder = Some(PreUpdate)
   )
 
   test("loadAll: without extra file, without defaults") {


### PR DESCRIPTION
This allows to run Scalafix migrations after the version bump. To run a
migration after the version bump, the `executionOrder` field has to be
set to `"post-update"`. The effective default value for this field is
`"pre-update"`.

Post-update migrations are useful if they consist of multiple rules
that only produce compiling code if the version is bumped before. One
example is the FS2 migration added here that consists of multiple
`replace:` rules. The symbols it renames are still present after the
bump to > 3.0.7. So it is OK to apply them successively after the
version bump but it would lead to compile errors if they were applied
before the bump because each rule could produce code that does not
compile with the old version. Running subsequent rules would then fail
with compile errors.

Here is an example PR where two rules where applied and that would have
failed without being `post-update`: https://github.com/scala-steward-org/test-repo-2/pull/71