### PR TITLE
Set `User-Agent` header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val core = myCrossProject("core")
       scalaVersion,
       scalaBinaryVersion,
       sbtVersion,
+      BuildInfoKey("gitHubUrl" -> gitHubUrl),
       BuildInfoKey("mainBranch" -> mainBranch),
       BuildInfoKey.map(git.gitHeadCommit) { case (k, v) => k -> v.getOrElse(mainBranch) },
       BuildInfoKey.map(`sbt-plugin`.jvm / moduleRootPkg) { case (_, v) =>


### PR DESCRIPTION
Sets the `User-Agent` header for all request by our http4s client. For @scala-steward it looks like this:
```
User-Agent: Scala-Steward/0.12.0-40-63828607 (operated by scala-steward; https://github.com/scala-steward-org/scala-steward)
```

Closes #2326.