### PR TITLE
Add Scastie about Version#selectNext to the FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,6 +16,8 @@ and 3.0.0.
 * If your version is 1.0.2 or 1.1.0, Scala Steward would create a PR updating it to 1.2.0
 * If your version is 1.2.0 or 2.0.0, Scala Steward would create a PR updating it to 3.0.0
 
+(This can be verified with [this Scastie](https://scastie.scala-lang.org/6cTFqY3dTmGbZIIEgM6lyQ).)
+
 Of course, once you merge a Scala Steward PR, you've updated your version,
 which can result in Scala Steward sending another PR making the next update.
 

--- a/modules/docs/mdoc/faq.md
+++ b/modules/docs/mdoc/faq.md
@@ -16,6 +16,8 @@ and 3.0.0.
 * If your version is 1.0.2 or 1.1.0, Scala Steward would create a PR updating it to 1.2.0
 * If your version is 1.2.0 or 2.0.0, Scala Steward would create a PR updating it to 3.0.0
 
+(This can be verified with [this Scastie](https://scastie.scala-lang.org/6cTFqY3dTmGbZIIEgM6lyQ).)
+
 Of course, once you merge a Scala Steward PR, you've updated your version,
 which can result in Scala Steward sending another PR making the next update.
 


### PR DESCRIPTION
Adds a link to https://scastie.scala-lang.org/6cTFqY3dTmGbZIIEgM6lyQ to the FAQ.

This is useful for checking if Scala Steward will propose an update from version x to version y.