### PR TITLE
Use Resource for temporarily creating and removing files

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -95,7 +95,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
       for {
         _ <- selfCheckAlg.checkAll
         _ <- workspaceAlg.cleanWorkspace
-        exitCode <- sbtAlg.addGlobalPlugins {
+        exitCode <- sbtAlg.addGlobalPlugins.surround {
           (config.githubApp.map(getGitHubAppRepos).getOrElse(Stream.empty) ++
             readRepos(config.reposFile))
             .evalMap(steward)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -58,7 +58,7 @@ object MillAlg {
         for {
           buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
           predef = buildRootDir / "scala-steward.sc"
-          extracted <- fileAlg.createTemporarily(predef, content) {
+          extracted <- fileAlg.createTemporarily(predef, content).surround {
             val command = Nel("mill", List("-i", "-p", predef.toString, "show", extractDeps))
             processAlg.execSandboxed(command, buildRootDir)
           }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -55,8 +55,8 @@ object SbtAlg {
     new SbtAlg[F] {
       override def addGlobalPluginTemporarily(plugin: FileData): Resource[F, Unit] =
         Resource.eval(sbtDir).flatMap { dir =>
-          List("0.13", "1.0").traverse_ { v =>
-            fileAlg.createTemporarily(dir / v / "plugins" / plugin.name, plugin.content)
+          List("0.13", "1.0").traverse_ { version =>
+            fileAlg.createTemporarily(dir / version / "plugins" / plugin.name, plugin.content)
           }
         }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -15,8 +15,8 @@ import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class SbtAlgTest extends FunSuite {
   test("addGlobalPlugins") {
-    val obtained = sbtAlg
-      .addGlobalPlugins(Kleisli(_.update(_.exec(List("fa")))))
+    val obtained = sbtAlg.addGlobalPlugins
+      .surround(Kleisli(_.update(_.exec(List("fa")))))
       .runS(MockState.empty)
       .unsafeRunSync()
     val expected = MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -20,7 +20,7 @@ class FileAlgTest extends FunSuite {
 
     val p = for {
       before <- ioFileAlg.readFile(file)
-      during <- ioFileAlg.createTemporarily(file, content)(ioFileAlg.readFile(file))
+      during <- ioFileAlg.createTemporarily(file, content).surround(ioFileAlg.readFile(file))
       after <- ioFileAlg.readFile(file)
     } yield (before, during, after)
 
@@ -43,7 +43,7 @@ class FileAlgTest extends FunSuite {
     val p = for {
       _ <- ioFileAlg.writeFile(file, content)
       before <- ioFileAlg.readFile(file)
-      during <- ioFileAlg.removeTemporarily(file)(ioFileAlg.readFile(file))
+      during <- ioFileAlg.removeTemporarily(file).surround(ioFileAlg.readFile(file))
       after <- ioFileAlg.readFile(file)
     } yield (before, during, after)
 
@@ -52,7 +52,7 @@ class FileAlgTest extends FunSuite {
 
   test("removeTemporarily: nonexistent file") {
     val file = mockRoot / "does-not-exists.txt"
-    assertEquals(ioFileAlg.removeTemporarily(file)(IO.pure(42)).unsafeRunSync(), 42)
+    assertEquals(ioFileAlg.removeTemporarily(file).surround(IO.pure(42)).unsafeRunSync(), 42)
   }
 
   test("editFile: nonexistent file") {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -1,13 +1,18 @@
 package org.scalasteward.core
 
-import cats.FlatMap
 import cats.data.Kleisli
 import cats.effect.{Async, IO, Ref}
 import cats.syntax.all._
+import cats.{~>, FlatMap}
 
 package object mock {
-  type MockEff[A] = Kleisli[IO, Ref[IO, MockState], A]
+  type MockCtx = Ref[IO, MockState]
+  type MockEff[A] = Kleisli[IO, MockCtx, A]
   val MockEff: Async[MockEff] = Async[MockEff]
+
+  val ioToMockEff: ~>[IO, MockEff] = new ~>[IO, MockEff] {
+    override def apply[A](fa: IO[A]): MockEff[A] = Kleisli(_ => fa)
+  }
 
   implicit class MockEffOps[A](private val fa: MockEff[A]) extends AnyVal {
     def runA(state: MockState): IO[A] =


### PR DESCRIPTION
Using `Resource` makes it easier to compose those functions compared to
nesting `F[A] => F[A]`.