### PR TITLE
Improve formatting of UnexpectedResponse.getMessage

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -133,5 +133,10 @@ final case class UnexpectedResponse(
 ) extends RuntimeException
     with NoStackTrace {
   override def getMessage: String =
-    s"uri: $uri\nmethod: $method\nstatus: $status\nheaders: $headers\nbody: $body"
+    s"""|uri: $uri
+        |method: $method
+        |status: $status
+        |headers:
+        |${headers.headers.map(h => s"  ${h.show}").mkString("\n")}
+        |body: $body""".stripMargin
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
@@ -1,0 +1,29 @@
+package org.scalasteward.core.util
+
+import munit.FunSuite
+import org.http4s.{Header, Headers, Method, Status, Uri}
+import org.typelevel.ci.CIString
+
+class UnexpectedResponseTest extends FunSuite {
+  test("getMessage") {
+    val unexpected = UnexpectedResponse(
+      Uri.unsafeFromString("https://api.github.com/repos/foo/bar/pulls"),
+      Method.POST,
+      Headers(
+        Header.Raw(CIString("access-control-allow-origin"), "*"),
+        Header.Raw(CIString("content-type"), "application/json; charset=utf-8")
+      ),
+      Status.Forbidden,
+      """{ message: "nope" }"""
+    )
+    val expected =
+      """|uri: https://api.github.com/repos/foo/bar/pulls
+         |method: POST
+         |status: 403 Forbidden
+         |headers:
+         |  access-control-allow-origin: *
+         |  content-type: application/json; charset=utf-8
+         |body: { message: "nope" }""".stripMargin
+    assertEquals(unexpected.getMessage, expected)
+  }
+}


### PR DESCRIPTION
This lists each header of the response on its own line instead of
having them all on one line.