### PR TITLE
Do not use traits for BuildToolAlg implementations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -147,9 +147,9 @@ object Context {
       implicit val versionsCache: VersionsCache[F] =
         new VersionsCache[F](config.cacheTtl, versionsStore)
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
-      implicit val mavenAlg: MavenAlg[F] = MavenAlg.create[F](config)
-      implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F](config)
-      implicit val millAlg: MillAlg[F] = MillAlg.create[F]
+      implicit val mavenAlg: MavenAlg[F] = new MavenAlg[F](config)
+      implicit val sbtAlg: SbtAlg[F] = new SbtAlg[F](config)
+      implicit val millAlg: MillAlg[F] = new MillAlg[F]
       implicit val buildToolDispatcher: BuildToolDispatcher[F] = new BuildToolDispatcher[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
         new RefreshErrorAlg[F](refreshErrorStore, config.refreshBackoffPeriod)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -27,49 +27,44 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
 
-trait MavenAlg[F[_]] extends BuildToolAlg[F]
+final class MavenAlg[F[_]](config: Config)(implicit
+    fileAlg: FileAlg[F],
+    processAlg: ProcessAlg[F],
+    workspaceAlg: WorkspaceAlg[F],
+    F: MonadCancelThrow[F]
+) extends BuildToolAlg[F] {
+  override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
+    workspaceAlg
+      .buildRootDir(buildRoot)
+      .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "pom.xml"))
 
-object MavenAlg {
-  def create[F[_]](config: Config)(implicit
-      fileAlg: FileAlg[F],
-      processAlg: ProcessAlg[F],
-      workspaceAlg: WorkspaceAlg[F],
-      F: MonadCancelThrow[F]
-  ): MavenAlg[F] =
-    new MavenAlg[F] {
-      override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
-        workspaceAlg
-          .buildRootDir(buildRoot)
-          .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "pom.xml"))
+  override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
+    for {
+      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+      dependenciesRaw <- exec(
+        mvnCmd(command.listDependencies),
+        buildRootDir
+      )
+      repositoriesRaw <- exec(
+        mvnCmd(command.listRepositories),
+        buildRootDir
+      )
+      dependencies = parser.parseDependencies(dependenciesRaw).distinct
+      resolvers = parser.parseResolvers(repositoriesRaw).distinct
+    } yield List(Scope(dependencies, resolvers))
 
-      override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
-        for {
-          buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-          dependenciesRaw <- exec(
-            mvnCmd(command.listDependencies),
-            buildRootDir
-          )
-          repositoriesRaw <- exec(
-            mvnCmd(command.listRepositories),
-            buildRootDir
-          )
-          dependencies = parser.parseDependencies(dependenciesRaw).distinct
-          resolvers = parser.parseResolvers(repositoriesRaw).distinct
-        } yield List(Scope(dependencies, resolvers))
+  override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
+    F.unit
 
-      override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-        F.unit
+  private def exec(command: Nel[String], repoDir: File): F[List[String]] =
+    maybeIgnoreOptsFiles(repoDir).surround(processAlg.execSandboxed(command, repoDir))
 
-      def exec(command: Nel[String], repoDir: File): F[List[String]] =
-        maybeIgnoreOptsFiles(repoDir).surround(processAlg.execSandboxed(command, repoDir))
+  private def mvnCmd(commands: String*): Nel[String] =
+    Nel("mvn", "--batch-mode" :: commands.toList)
 
-      def mvnCmd(commands: String*): Nel[String] =
-        Nel("mvn", "--batch-mode" :: commands.toList)
+  private def maybeIgnoreOptsFiles(dir: File): Resource[F, Unit] =
+    if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
 
-      def maybeIgnoreOptsFiles(dir: File): Resource[F, Unit] =
-        if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
-
-      def ignoreOptsFiles(dir: File): Resource[F, Unit] =
-        fileAlg.removeTemporarily(dir / ".jvmopts")
-    }
+  private def ignoreOptsFiles(dir: File): Resource[F, Unit] =
+    fileAlg.removeTemporarily(dir / ".jvmopts")
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -17,7 +17,6 @@
 package org.scalasteward.core.buildtool.sbt
 
 import better.files.File
-import cats.Functor
 import cats.data.OptionT
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
@@ -32,115 +31,104 @@ import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
 import org.typelevel.log4cats.Logger
 
-trait SbtAlg[F[_]] extends BuildToolAlg[F] {
-  def addGlobalPluginTemporarily(plugin: FileData): Resource[F, Unit]
-
-  def addGlobalPlugins: Resource[F, Unit]
-
-  def getSbtVersion(buildRoot: BuildRoot): F[Option[SbtVersion]]
-
-  final def getSbtDependency(buildRoot: BuildRoot)(implicit F: Functor[F]): F[Option[Dependency]] =
+final class SbtAlg[F[_]](config: Config)(implicit
+    fileAlg: FileAlg[F],
+    logger: Logger[F],
+    processAlg: ProcessAlg[F],
+    scalafixCli: ScalafixCli[F],
+    workspaceAlg: WorkspaceAlg[F],
+    F: Concurrent[F]
+) extends BuildToolAlg[F] {
+  private def getSbtDependency(buildRoot: BuildRoot): F[Option[Dependency]] =
     OptionT(getSbtVersion(buildRoot)).subflatMap(sbtDependency).value
-}
 
-object SbtAlg {
-  def create[F[_]](config: Config)(implicit
-      fileAlg: FileAlg[F],
-      logger: Logger[F],
-      processAlg: ProcessAlg[F],
-      scalafixCli: ScalafixCli[F],
-      workspaceAlg: WorkspaceAlg[F],
-      F: Concurrent[F]
-  ): SbtAlg[F] =
-    new SbtAlg[F] {
-      override def addGlobalPluginTemporarily(plugin: FileData): Resource[F, Unit] =
-        Resource.eval(sbtDir).flatMap { dir =>
-          List("0.13", "1.0").traverse_ { version =>
-            fileAlg.createTemporarily(dir / version / "plugins" / plugin.name, plugin.content)
-          }
-        }
-
-      override def addGlobalPlugins: Resource[F, Unit] =
-        Resource.eval(logger.info("Add global sbt plugins")) >>
-          Resource.eval(stewardPlugin).flatMap(addGlobalPluginTemporarily)
-
-      override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
-        workspaceAlg
-          .buildRootDir(buildRoot)
-          .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "build.sbt"))
-
-      override def getSbtVersion(buildRoot: BuildRoot): F[Option[SbtVersion]] =
-        for {
-          buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-          maybeProperties <- fileAlg.readFile(buildRootDir / "project" / "build.properties")
-          version = maybeProperties.flatMap(parser.parseBuildProperties)
-        } yield version
-
-      override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
-        for {
-          buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-          commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
-          lines <- sbt(commands, buildRootDir)
-          dependencies = parser.parseDependencies(lines)
-          additionalDependencies <- getAdditionalDependencies(buildRoot)
-        } yield additionalDependencies ::: dependencies
-
-      override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-        migration.targetOrDefault match {
-          case ScalafixMigration.Target.Sources => runSourcesMigration(buildRoot, migration)
-          case ScalafixMigration.Target.Build   => runBuildMigration(buildRoot, migration)
-        }
-
-      private def runSourcesMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-        addGlobalPluginTemporarily(scalaStewardScalafixSbt).surround {
-          workspaceAlg.buildRootDir(buildRoot).flatMap { buildRootDir =>
-            val withScalacOptions =
-              migration.scalacOptions.fold(Resource.unit[F]) { opts =>
-                val file = scalaStewardScalafixOptions(opts.toList)
-                fileAlg.createTemporarily(buildRootDir / file.name, file.content)
-              }
-            val scalafixCmds = migration.rewriteRules.map(rule => s"$scalafixAll $rule").toList
-            withScalacOptions.surround(sbt(Nel(scalafixEnable, scalafixCmds), buildRootDir).void)
-          }
-        }
-
-      private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-        for {
-          buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-          projectDir = buildRootDir / "project"
-          files0 <- (
-            fileAlg.walk(buildRootDir, 1).filter(_.extension.contains(".sbt")) ++
-              fileAlg.walk(projectDir, 1).filter(_.extension.exists(Set(".sbt", ".scala")))
-          ).compile.toList
-          _ <- Nel.fromList(files0).fold(F.unit) { files1 =>
-            scalafixCli.runMigration(buildRootDir, files1, migration)
-          }
-        } yield ()
-
-      val sbtDir: F[File] =
-        fileAlg.home.map(_ / ".sbt")
-
-      def sbt(sbtCommands: Nel[String], repoDir: File): F[List[String]] =
-        maybeIgnoreOptsFiles(repoDir).surround {
-          val command =
-            Nel.of(
-              "sbt",
-              "-Dsbt.color=false",
-              "-Dsbt.log.noformat=true",
-              "-Dsbt.supershell=false",
-              sbtCommands.mkString_(";", ";", "")
-            )
-          processAlg.execSandboxed(command, repoDir)
-        }
-
-      def maybeIgnoreOptsFiles[A](dir: File): Resource[F, Unit] =
-        if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
-
-      def ignoreOptsFiles(dir: File): Resource[F, Unit] =
-        List(".jvmopts", ".sbtopts").traverse_(file => fileAlg.removeTemporarily(dir / file))
-
-      def getAdditionalDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
-        getSbtDependency(buildRoot)
-          .map(_.map(dep => Scope(List(dep), List(config.defaultResolver))).toList)
+  private def addGlobalPluginTemporarily(plugin: FileData): Resource[F, Unit] =
+    Resource.eval(sbtDir).flatMap { dir =>
+      List("0.13", "1.0").traverse_ { version =>
+        fileAlg.createTemporarily(dir / version / "plugins" / plugin.name, plugin.content)
+      }
     }
+
+  def addGlobalPlugins: Resource[F, Unit] =
+    Resource.eval(logger.info("Add global sbt plugins")) >>
+      Resource.eval(stewardPlugin).flatMap(addGlobalPluginTemporarily)
+
+  override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
+    workspaceAlg
+      .buildRootDir(buildRoot)
+      .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "build.sbt"))
+
+  private def getSbtVersion(buildRoot: BuildRoot): F[Option[SbtVersion]] =
+    for {
+      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+      maybeProperties <- fileAlg.readFile(buildRootDir / "project" / "build.properties")
+      version = maybeProperties.flatMap(parser.parseBuildProperties)
+    } yield version
+
+  override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
+    for {
+      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+      commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
+      lines <- sbt(commands, buildRootDir)
+      dependencies = parser.parseDependencies(lines)
+      additionalDependencies <- getAdditionalDependencies(buildRoot)
+    } yield additionalDependencies ::: dependencies
+
+  override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
+    migration.targetOrDefault match {
+      case ScalafixMigration.Target.Sources => runSourcesMigration(buildRoot, migration)
+      case ScalafixMigration.Target.Build   => runBuildMigration(buildRoot, migration)
+    }
+
+  private def runSourcesMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
+    addGlobalPluginTemporarily(scalaStewardScalafixSbt).surround {
+      workspaceAlg.buildRootDir(buildRoot).flatMap { buildRootDir =>
+        val withScalacOptions =
+          migration.scalacOptions.fold(Resource.unit[F]) { opts =>
+            val file = scalaStewardScalafixOptions(opts.toList)
+            fileAlg.createTemporarily(buildRootDir / file.name, file.content)
+          }
+        val scalafixCmds = migration.rewriteRules.map(rule => s"$scalafixAll $rule").toList
+        withScalacOptions.surround(sbt(Nel(scalafixEnable, scalafixCmds), buildRootDir).void)
+      }
+    }
+
+  private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
+    for {
+      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+      projectDir = buildRootDir / "project"
+      files0 <- (
+        fileAlg.walk(buildRootDir, 1).filter(_.extension.contains(".sbt")) ++
+          fileAlg.walk(projectDir, 1).filter(_.extension.exists(Set(".sbt", ".scala")))
+      ).compile.toList
+      _ <- Nel.fromList(files0).fold(F.unit) { files1 =>
+        scalafixCli.runMigration(buildRootDir, files1, migration)
+      }
+    } yield ()
+
+  private val sbtDir: F[File] =
+    fileAlg.home.map(_ / ".sbt")
+
+  private def sbt(sbtCommands: Nel[String], repoDir: File): F[List[String]] =
+    maybeIgnoreOptsFiles(repoDir).surround {
+      val command =
+        Nel.of(
+          "sbt",
+          "-Dsbt.color=false",
+          "-Dsbt.log.noformat=true",
+          "-Dsbt.supershell=false",
+          sbtCommands.mkString_(";", ";", "")
+        )
+      processAlg.execSandboxed(command, repoDir)
+    }
+
+  private def maybeIgnoreOptsFiles[A](dir: File): Resource[F, Unit] =
+    if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
+
+  private def ignoreOptsFiles(dir: File): Resource[F, Unit] =
+    List(".jvmopts", ".sbtopts").traverse_(file => fileAlg.removeTemporarily(dir / file))
+
+  private def getAdditionalDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
+    getSbtDependency(buildRoot)
+      .map(_.map(dep => Scope(List(dep), List(config.defaultResolver))).toList)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -23,7 +23,6 @@ import org.scalasteward.core.data.Update
 import org.scalasteward.core.scalafmt.isScalafmtUpdate
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
-
 import scala.util.matching.Regex
 
 /** `UpdateHeuristic` is a wrapper for a function that takes an `Update` and


### PR DESCRIPTION
We don't have different implementations of the `BuildToolAlg` subclasses
so having `trait`s for them is a needless complication.