### PR TITLE
Do not select versions with a "smaller" pre-release identifier

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -53,9 +53,9 @@ final case class Version(value: String) {
           // Do not select pre-releases of the same series if this is not a pre-release.
           (v.isPreRelease && !isPreRelease && sameSeries) ||
           // Do not select versions with pre-release identifiers whose order is smaller
-          // than the order of pre-release identifiers in this version. This, for example,
-          // prevents updates from 2.1.4.0-RC17 to 2.1.4.0-RC17+1-307f2f6c-SNAPSHOT.
-          ((minAlphaOrder < 0) && (v.minAlphaOrder < minAlphaOrder)) ||
+          // than the order of possible pre-release identifiers in this version. This,
+          // for example, prevents updates from 2.1.4.0-RC17 to 2.1.4.0-RC17+1-307f2f6c-SNAPSHOT.
+          v.minAlphaOrder < minAlphaOrder ||
           // Do not select versions that are identical up to the hashes.
           v.alnumComponents === alnumComponents ||
           // Do not select a version with hash if this version contains no hash.

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -212,6 +212,7 @@ class VersionTest extends DisciplineSuite {
         Some("1.0.0-20201208-143052-2c1b1172")
       ),
       ("0.27.0-RC1", List("0.27.0-bin-20200826-2e58a66-NIGHTLY"), None),
+      ("2.0.16-200-ge888c6dea", List("2.0.16-200-ge888c6dea-14-c067d59f0-SNAPSHOT"), None),
       ("17.0.0.1", List("18-ea+4"), None)
     )
 


### PR DESCRIPTION
Prevents PRs like https://github.com/VirtusLab/scala-cli/pull/407.