### PR TITLE
Fix `git diff` call

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -38,7 +38,7 @@ final class FileGitAlg[F[_]](config: GitCfg)(implicit
     git("branch", "--list", "--no-color", "--all", branch.name)(repo).map(_.mkString.trim.nonEmpty)
 
   override def branchesDiffer(repo: File, b1: Branch, b2: Branch): F[Boolean] =
-    git("diff", "--name-only", b1.name, b2.name)(repo).map(_.nonEmpty)
+    git("diff", "--name-only", b1.name, b2.name, "--")(repo).map(_.nonEmpty)
 
   override def checkoutBranch(repo: File, branch: Branch): F[Unit] =
     git("checkout", branch.name)(repo).void


### PR DESCRIPTION
`git diff` fails if there is a branch and file with the same name:
```
2021-11-23 14:16:10,530 INFO  Create branch update/bloop-config-1.4.11
2021-11-23 14:16:18,210 ERROR Steward com-lihaoyi/mill failed
git diff --name-only main update/bloop-config-1.4.11' exited with code 128
fatal: ambiguous argument 'main': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
This change therefore adds `--` after the branches in our `git diff` call.