### PR TITLE
Fix `deleteRemoteBranch` call

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -69,7 +69,7 @@ final class VCSRepoAlg[F[_]](config: Config)(implicit
     val local = Branch(updateBranchPrefix)
     val remote = local.withPrefix("origin/")
     gitAlg.branchExists(repo, local).ifM(gitAlg.deleteLocalBranch(repo, local), F.unit) >>
-      gitAlg.branchExists(repo, remote).ifM(gitAlg.deleteRemoteBranch(repo, remote), F.unit)
+      gitAlg.branchExists(repo, remote).ifM(gitAlg.deleteRemoteBranch(repo, local), F.unit)
   }
 
   private def initSubmodules(repo: Repo): F[Unit] =


### PR DESCRIPTION
Changes `git push origin --delete origin/update` to
`git push origin --delete update` because it fails with the
remote prefix:
```
git push origin --delete origin/update' exited with code 1
error: unable to delete 'origin/update': remote ref does not exist
```
Follow-up to #2371.