### PR TITLE
Rework syntax for creating updates in tests

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -1,21 +1,20 @@
 package org.scalasteward.core
 
-import _root_.org.typelevel.log4cats.Logger
-import _root_.org.typelevel.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.types.numeric.NonNegInt
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.data._
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
 import org.scalasteward.core.repoconfig._
+import org.scalasteward.core.util.Change
 import org.scalasteward.core.util.Change.{Changed, Unchanged}
-import org.scalasteward.core.util.{Change, Nel}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration.FiniteDuration
 
 object TestInstances {
@@ -49,7 +48,7 @@ object TestInstances {
         artifactId <- Gen.alphaStr
         currentVersion <- Gen.alphaStr
         newerVersion <- Gen.alphaStr
-      } yield Single(groupId % artifactId % currentVersion, Nel.one(newerVersion))
+      } yield (groupId.g % artifactId.a % currentVersion %> newerVersion).single
     )
 
   private val hashGen: Gen[String] =

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -19,43 +19,101 @@ object TestSyntax {
     }
   }
 
-  implicit class StringOps(val self: String) extends AnyVal {
-    def %(artifactId: ArtifactId): (GroupId, ArtifactId) =
-      (GroupId(self), artifactId)
-
-    def %(artifactIds: Nel[ArtifactId]): (GroupId, Nel[ArtifactId]) =
-      (GroupId(self), artifactIds)
+  implicit class StringOps(private val self: String) extends AnyVal {
+    def g: GroupId = GroupId(self)
+    def a: ArtifactId = ArtifactId(self)
   }
 
-  implicit class GroupIdAndArtifactIdOps(val self: (GroupId, ArtifactId)) extends AnyVal {
-    def %(version: String): Dependency =
-      Dependency(self._1, self._2, version)
+  implicit class StringTupleOps(private val self: (String, String)) extends AnyVal {
+    def a: ArtifactId = ArtifactId(self._1, self._2)
   }
 
-  implicit class GroupIdAndArtifactIdsOps(val self: (GroupId, Nel[ArtifactId])) extends AnyVal {
-    def %(version: String): Nel[Dependency] =
-      self._2.map(artifactId => Dependency(self._1, artifactId, version))
+  implicit class GroupIdOps(private val self: GroupId) {
+    def %(artifactId: ArtifactId): (GroupId, ArtifactId) = (self, artifactId)
+    def %(artifactIds: Nel[ArtifactId]): (GroupId, Nel[ArtifactId]) = (self, artifactIds)
+    def %%(artifactIds: Nel[Nel[ArtifactId]]): (GroupId, Nel[Nel[ArtifactId]]) = (self, artifactIds)
   }
 
-  implicit class DependencyOps(val self: Dependency) extends AnyVal {
-    def %(configurations: String): Dependency =
-      self.copy(configurations = Some(configurations))
+  implicit class GroupIdAndArtifactIdOps(private val self: (GroupId, ArtifactId)) extends AnyVal {
+    def %(version: String): Dependency = Dependency(self._1, self._2, version)
   }
 
-  implicit def stringToArtifactId(string: String): ArtifactId =
-    ArtifactId(string)
+  implicit class GroupIdAndArtifactIdsOps(
+      private val self: (GroupId, Nel[ArtifactId])
+  ) extends AnyVal {
+    def %(version: String): (GroupId, Nel[ArtifactId], String) = (self._1, self._2, version)
+  }
 
-  implicit def stringsToArtifactId(strings: Nel[String]): Nel[ArtifactId] =
-    strings.map(stringToArtifactId)
+  implicit class GroupIdAndManyArtifactIdsOps(
+      private val self: (GroupId, Nel[Nel[ArtifactId]])
+  ) extends AnyVal {
+    def %(version: String): (GroupId, Nel[Nel[ArtifactId]], String) = (self._1, self._2, version)
+  }
 
-  implicit def dependencyToCrossDependency(dependency: Dependency): CrossDependency =
-    CrossDependency(dependency)
+  implicit class DependencyOps(private val self: Dependency) extends AnyVal {
+    def %(configurations: String): Dependency = self.copy(configurations = Some(configurations))
+    def %>(nextVersion: String): (Dependency, String) = (self, nextVersion)
+    def %>(newerVersions: Nel[String]): (Dependency, Nel[String]) = (self, newerVersions)
+    def cross: CrossDependency = CrossDependency(self)
+  }
 
-  implicit def dependenciesToCrossDependency(dependencies: Nel[Dependency]): CrossDependency =
-    CrossDependency(dependencies)
+  implicit class DependenciesOps(private val self: Nel[Dependency]) extends AnyVal {
+    def %>(nextVersion: String): (Nel[Dependency], String) = (self, nextVersion)
+  }
 
-  implicit def dependenciesToCrossDependencies(
-      dependencies: Nel[Dependency]
-  ): Nel[CrossDependency] =
-    dependencies.map(CrossDependency(_))
+  implicit class GroupIdAndArtifactIdsAndVersionOps(
+      private val self: (GroupId, Nel[ArtifactId], String)
+  ) extends AnyVal {
+    def %>(nextVersion: String): (GroupId, Nel[ArtifactId], String, String) =
+      (self._1, self._2, self._3, nextVersion)
+  }
+
+  implicit class GroupIdAndManyArtifactIdsAndVersionOps(
+      private val self: (GroupId, Nel[Nel[ArtifactId]], String)
+  ) extends AnyVal {
+    def %>(nextVersion: String): (GroupId, Nel[Nel[ArtifactId]], String, String) =
+      (self._1, self._2, self._3, nextVersion)
+  }
+
+  implicit class DependencyAndNextVersionOps(
+      private val self: (Dependency, String)
+  ) extends AnyVal {
+    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2))
+  }
+
+  implicit class DependencyAndNewerVersionsOps(
+      private val self: (Dependency, Nel[String])
+  ) extends AnyVal {
+    def single: Update.Single = Update.Single(CrossDependency(self._1), self._2)
+  }
+
+  implicit class DependenciesAndNextVersionOps(
+      private val self: (Nel[Dependency], String)
+  ) extends AnyVal {
+    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2))
+  }
+
+  implicit class GroupIdAndArtifactIdsAndVersionAndNextVersionOps(
+      private val self: (GroupId, Nel[ArtifactId], String, String)
+  ) extends AnyVal {
+    def single: Update.Single = {
+      val crossDependency = CrossDependency(self._2.map(aId => Dependency(self._1, aId, self._3)))
+      Update.Single(crossDependency, Nel.of(self._4))
+    }
+
+    def group: Update.Group = {
+      val crossDependencies = self._2.map(aId => CrossDependency(Dependency(self._1, aId, self._3)))
+      Update.Group(crossDependencies, Nel.of(self._4))
+    }
+  }
+
+  implicit class GroupIdAndManyArtifactIdsAndVersionAndNextVersionOps(
+      private val self: (GroupId, Nel[Nel[ArtifactId]], String, String)
+  ) extends AnyVal {
+    def group: Update.Group = {
+      val crossDependencies =
+        self._2.map(aIds => CrossDependency(aIds.map(aId => Dependency(self._1, aId, self._3))))
+      Update.Group(crossDependencies, Nel.of(self._4))
+    }
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
@@ -2,7 +2,6 @@ package org.scalasteward.core.buildtool.maven
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.ArtifactId
 import org.scalasteward.core.data.Resolver.MavenRepository
 
 class parserTest extends FunSuite {
@@ -31,10 +30,10 @@ class parserTest extends FunSuite {
          |""".stripMargin.linesIterator.toList
     val dependencies = parser.parseDependencies(input)
     val expected = List(
-      "org.typelevel" % ArtifactId("cats-core", "cats-core_2.12") % "1.5.0",
-      "org.hamcrest" % "hamcrest-core" % "1.3" % "test",
-      "junit" % "junit" % "4.12" % "test",
-      "ch.qos.logback" % "logback-core" % "1.1.11"
+      "org.typelevel".g % ("cats-core", "cats-core_2.12").a % "1.5.0",
+      "org.hamcrest".g % "hamcrest-core".a % "1.3" % "test",
+      "junit".g % "junit".a % "4.12" % "test",
+      "ch.qos.logback".g % "logback-core".a % "1.1.11"
     )
     assertEquals(dependencies, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
@@ -5,7 +5,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.buildtool.sbt.parser._
 import org.scalasteward.core.data.Resolver.{Credentials, IvyRepository, MavenRepository}
-import org.scalasteward.core.data.{ArtifactId, Scope}
+import org.scalasteward.core.data.Scope
 
 class parserTest extends FunSuite {
   test("parseBuildProperties: with whitespace") {
@@ -35,9 +35,9 @@ class parserTest extends FunSuite {
     val expected = List(
       Scope(
         List(
-          "org.scala-lang" % "scala-library" % "2.12.7",
-          "com.github.pathikrit" % ArtifactId("better-files", "better-files_2.12") % "3.6.0",
-          "org.typelevel" % ArtifactId("cats-effect", "cats-effect_2.12") % "1.0.0"
+          "org.scala-lang".g % "scala-library".a % "2.12.7",
+          "com.github.pathikrit".g % ("better-files", "better-files_2.12").a % "3.6.0",
+          "org.typelevel".g % ("cats-effect", "cats-effect_2.12").a % "1.0.0"
         ),
         List(
           MavenRepository("bintray-ovotech-maven", "https://dl.bintray.com/ovotech/maven/", None),
@@ -50,11 +50,13 @@ class parserTest extends FunSuite {
       ),
       Scope(
         List(
-          "org.scala-lang" % "scala-library" % "2.12.6",
-          ("com.dwijnand" % "sbt-travisci" % "1.1.3").copy(sbtVersion = Some(SbtVersion("1.0"))),
-          ("com.eed3si9n" % "sbt-assembly" % "0.14.8" % "foo")
+          "org.scala-lang".g % "scala-library".a % "2.12.6",
+          ("com.dwijnand".g % "sbt-travisci".a % "1.1.3")
             .copy(sbtVersion = Some(SbtVersion("1.0"))),
-          ("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC4").copy(sbtVersion = Some(SbtVersion("1.0")))
+          ("com.eed3si9n".g % "sbt-assembly".a % "0.14.8" % "foo")
+            .copy(sbtVersion = Some(SbtVersion("1.0"))),
+          ("com.geirsson".g % "sbt-scalafmt".a % "1.6.0-RC4")
+            .copy(sbtVersion = Some(SbtVersion("1.0")))
         ),
         List(
           IvyRepository(

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -2,82 +2,69 @@ package org.scalasteward.core.data
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 
 class UpdateTest extends FunSuite {
   test("Group.mainArtifactId") {
-    val update = Group(
-      "org.http4s" %
-        Nel.of("http4s-blaze-server", "http4s-circe", "http4s-core", "http4s-dsl") % "0.18.16",
-      Nel.of("0.18.18")
-    )
+    val update = ("org.http4s".g %
+      Nel.of("http4s-blaze-server".a, "http4s-circe".a, "http4s-core".a, "http4s-dsl".a) % "0.18.16"
+      %> "0.18.18").group
     assertEquals(update.mainArtifactId, "http4s-core")
   }
 
   test("Group.mainArtifactId: artifactIds contains a common suffix") {
-    val update =
-      Group("com.softwaremill.sttp" % Nel.of("circe", "core", "monix") % "1.3.2", Nel.of("1.3.3"))
+    val update = ("com.softwaremill.sttp".g % Nel.of("circe".a, "core".a, "monix".a) % "1.3.2"
+      %> "1.3.3").group
     assertEquals(update.mainArtifactId, "circe")
   }
 
   test("groupByGroupId: 1 update") {
-    val updates = List(Single("org.specs2" % "specs2-core" % "3.9.4", Nel.of("3.9.5")))
+    val updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single)
     assertEquals(Update.groupByGroupId(updates), updates)
   }
 
   test("groupByGroupId: 2 updates") {
-    val update0 = Single("org.specs2" % "specs2-core" % "3.9.4", Nel.of("3.9.5"))
-    val update1 = Single("org.specs2" % "specs2-scalacheck" % "3.9.4", Nel.of("3.9.5"))
+    val update0 = ("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single
+    val update1 = ("org.specs2".g % "specs2-scalacheck".a % "3.9.4" %> "3.9.5").single
     val expected = List(
-      Group("org.specs2" % Nel.of("specs2-core", "specs2-scalacheck") % "3.9.4", Nel.of("3.9.5"))
+      ("org.specs2".g % Nel.of("specs2-core".a, "specs2-scalacheck".a) % "3.9.4" %> "3.9.5").group
     )
     assertEquals(Update.groupByGroupId(List(update0, update1)), expected)
   }
 
   test("groupByArtifactIdName: 2 updates") {
-    val update0 = Single(
-      "org.specs2" % ArtifactId("specs2-core", "specs2-core_2.12") % "3.9.4",
-      Nel.of("3.9.5")
-    )
-    val update1 = Single(
-      "org.specs2" % ArtifactId("specs2-core", "specs2-core_2.13") % "3.9.4" % "test",
-      Nel.of("3.9.5")
-    )
+    val update0 =
+      ("org.specs2".g % ("specs2-core", "specs2-core_2.12").a % "3.9.4" %> "3.9.5").single
+    val update1 =
+      ("org.specs2".g % ("specs2-core", "specs2-core_2.13").a % "3.9.4" % "test" %> "3.9.5").single
     val expected = List(
-      Single(
-        update0.crossDependency.dependencies ::: update1.crossDependency.dependencies,
-        Nel.of("3.9.5")
-      )
+      ((update0.crossDependency.dependencies ::: update1.crossDependency.dependencies) -> "3.9.5").single
     )
     assertEquals(Update.groupByArtifactIdName(List(update0, update1)), expected)
   }
 
   test("groupByArtifactIdName: 3 updates ") {
-    val update0 = Single("org.specs2" % "specs2-core" % "3.9.4", Nel.of("3.9.5"))
-    val update1 = Single("org.specs2" % "specs2-core" % "3.9.4" % "test", Nel.of("3.9.5"))
-    val update2 = Single("org.specs2" % "specs2-scalacheck" % "3.9.4", Nel.of("3.9.5"))
+    val update0 = ("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single
+    val update1 = ("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single
+    val update2 = ("org.specs2".g % "specs2-scalacheck".a % "3.9.4" %> "3.9.5").single
     val expected = List(
-      Single(
-        Nel.of(
-          "org.specs2" % "specs2-core" % "3.9.4",
-          "org.specs2" % "specs2-core" % "3.9.4" % "test"
-        ),
-        Nel.of("3.9.5")
-      ),
+      (Nel.of(
+        "org.specs2".g % "specs2-core".a % "3.9.4",
+        "org.specs2".g % "specs2-core".a % "3.9.4" % "test"
+      ) %> "3.9.5").single,
       update2
     )
     assertEquals(Update.groupByArtifactIdName(List(update0, update1, update2)), expected)
   }
 
   test("Single.show") {
-    val update = Single("org.specs2" % "specs2-core" % "3.9.4" % "test", Nel.of("3.9.5"))
+    val update = ("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single
     assertEquals(update.show, "org.specs2:specs2-core : 3.9.4 -> 3.9.5")
   }
 
   test("Group.show") {
     val update =
-      Group("org.scala-sbt" % Nel.of("sbt-launch", "scripted-plugin") % "1.2.1", Nel.of("1.2.4"))
+      ("org.scala-sbt".g % Nel.of("sbt-launch".a, "scripted-plugin".a) % "1.2.1" %> "1.2.4").group
     assertEquals(update.show, "org.scala-sbt:{sbt-launch, scripted-plugin} : 1.2.1 -> 1.2.4")
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -7,14 +7,14 @@ import org.scalasteward.core.util.Nel
 class UpdateTest extends FunSuite {
   test("Group.mainArtifactId") {
     val update = ("org.http4s".g %
-      Nel.of("http4s-blaze-server".a, "http4s-circe".a, "http4s-core".a, "http4s-dsl".a) % "0.18.16"
-      %> "0.18.18").group
+      Nel.of("http4s-blaze-server".a, "http4s-circe".a, "http4s-core".a, "http4s-dsl".a) %
+      "0.18.16" %> "0.18.18").group
     assertEquals(update.mainArtifactId, "http4s-core")
   }
 
   test("Group.mainArtifactId: artifactIds contains a common suffix") {
-    val update = ("com.softwaremill.sttp".g % Nel.of("circe".a, "core".a, "monix".a) % "1.3.2"
-      %> "1.3.3").group
+    val update = ("com.softwaremill.sttp".g %
+      Nel.of("circe".a, "core".a, "monix".a) % "1.3.2" %> "1.3.3").group
     assertEquals(update.mainArtifactId, "circe")
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -26,7 +26,7 @@ class EditAlgTest extends FunSuite {
     val repo = Repo("edit-alg", "test-1")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
     val repoDir = config.workspace / repo.toPath
-    val update = Update.Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
+    val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single
     val file1 = repoDir / "build.sbt"
     val file2 = repoDir / "project/Dependencies.scala"
 
@@ -65,7 +65,7 @@ class EditAlgTest extends FunSuite {
     )
     val data = RepoData(repo, cache, RepoConfig.empty)
     val repoDir = config.workspace / repo.toPath
-    val update = Update.Single("org.scalameta" % "scalafmt-core" % "2.0.0", Nel.of("2.1.0"))
+    val update = ("org.scalameta".g % "scalafmt-core".a % "2.0.0" %> "2.1.0").single
     val scalafmtConf = repoDir / scalafmtConfName
     val scalafmtConfContent = """maxColumn = 100
                                 |version = 2.0.0
@@ -130,7 +130,7 @@ class EditAlgTest extends FunSuite {
     val repo = Repo("edit-alg", "test-3")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
     val repoDir = config.workspace / repo.toPath
-    val update = Update.Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
+    val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single
     val file1 = repoDir / "script.sc"
     val file2 = repoDir / "build.sbt"
 
@@ -169,7 +169,7 @@ class EditAlgTest extends FunSuite {
     val repo = Repo("edit-alg", "test-3-1")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
     val repoDir = config.workspace / repo.toPath
-    val update = Update.Single(sbtGroupId.value % sbtArtifactId.name % "1.4.9", Nel.of("1.5.5"))
+    val update = (sbtGroupId % sbtArtifactId % "1.4.9" %> "1.5.5").single
 
     val state = MockState.empty
       .addFiles(
@@ -187,7 +187,7 @@ class EditAlgTest extends FunSuite {
   }
 
   test("https://github.com/circe/circe-config/pull/40") {
-    val update = Update.Single("com.typesafe" % "config" % "1.3.3", Nel.of("1.3.4"))
+    val update = ("com.typesafe".g % "config".a % "1.3.3" %> "1.3.4").single
     val original = Map(
       "build.sbt" -> """val config = "1.3.3"""",
       "project/plugins.sbt" -> """addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.3")"""
@@ -200,7 +200,7 @@ class EditAlgTest extends FunSuite {
   }
 
   test("file restriction when sbt update") {
-    val update = Update.Single("org.scala-sbt" % "sbt" % "1.1.2", Nel.of("1.2.8"))
+    val update = ("org.scala-sbt".g % "sbt".a % "1.1.2" %> "1.2.8").single
     val original = Map(
       "build.properties" -> """sbt.version=1.1.2""",
       "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""
@@ -213,10 +213,8 @@ class EditAlgTest extends FunSuite {
   }
 
   test("keyword with extra underscore") {
-    val update = Update.Group(
-      "org.scala-js" % Nel.of("sbt-scalajs", "scalajs-compiler") % "1.1.0",
-      Nel.of("1.1.1")
-    )
+    val update =
+      ("org.scala-js".g % Nel.of("sbt-scalajs".a, "scalajs-compiler".a) % "1.1.0" %> "1.1.1").group
     val original = Map(
       ".travis.yml" -> """ - SCALA_JS_VERSION=1.1.0""",
       "project/plugins.sbt" -> """val scalaJsVersion = Option(System.getenv("SCALA_JS_VERSION")).getOrElse("1.1.0")"""
@@ -229,12 +227,8 @@ class EditAlgTest extends FunSuite {
   }
 
   test("test updating group id and version") {
-    val update = Update.Single(
-      crossDependency = "com.github.mpilquist" % "simulacrum" % "0.19.0",
-      newerVersions = Nel.of("1.0.0"),
-      newerGroupId = Some(GroupId("org.typelevel")),
-      newerArtifactId = Some("simulacrum")
-    )
+    val update = ("com.github.mpilquist".g % "simulacrum".a % "0.19.0" %> "1.0.0").single
+      .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("simulacrum"))
     val original = Map(
       "build.sbt" -> """val simulacrum = "0.19.0"
                        |"com.github.mpilquist" %% "simulacrum" % simulacrum
@@ -249,12 +243,8 @@ class EditAlgTest extends FunSuite {
   }
 
   test("test updating artifact id and version") {
-    val update = Update.Single(
-      crossDependency = "com.test" % "artifact" % "1.0.0",
-      newerVersions = Nel.of("2.0.0"),
-      newerGroupId = Some(GroupId("com.test")),
-      newerArtifactId = Some("newer-artifact")
-    )
+    val update = ("com.test".g % "artifact".a % "1.0.0" %> "2.0.0").single
+      .copy(newerGroupId = Some("com.test".g), newerArtifactId = Some("newer-artifact"))
     val original = Map(
       "Dependencies.scala" -> """val testVersion = "1.0.0"
                                 |val test = "com.test" %% "artifact" % testVersion
@@ -269,11 +259,8 @@ class EditAlgTest extends FunSuite {
   }
 
   test("NOK artifact change: version and groupId/artifactId in different files") {
-    val update = Update.Single(
-      crossDependency = "io.chrisdavenport" % "log4cats" % "1.1.1",
-      newerVersions = Nel.of("1.2.0"),
-      newerGroupId = Some(GroupId("org.typelevel"))
-    )
+    val update = ("io.chrisdavenport".g % "log4cats".a % "1.1.1" %> "1.2.0").single
+      .copy(newerGroupId = Some("org.typelevel".g))
     val original = Map(
       "Dependencies.scala" -> """val log4catsVersion = "1.1.1" """,
       "build.sbt" -> """ "io.chrisdavenport" %% "log4cats" % log4catsVersion """
@@ -287,10 +274,7 @@ class EditAlgTest extends FunSuite {
   }
 
   test("mill version file update") {
-    val update = Update.Single(
-      crossDependency = "com.lihaoyi" % "mill-main" % "0.9.5",
-      newerVersions = Nel.of("0.9.9")
-    )
+    val update = ("com.lihaoyi".g % "mill-main".a % "0.9.5" %> "0.9.9").single
     val original = Map(
       ".mill-version" -> "0.9.5 \n ",
       ".travis.yml" -> """- TEST_MILL_VERSION=0.9.5"""

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -2,8 +2,7 @@ package org.scalasteward.core.edit
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update.{Group, Single}
-import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.UpdateHeuristicTest.UpdateOps
 import org.scalasteward.core.util.Nel
 
@@ -11,7 +10,7 @@ class UpdateHeuristicTest extends FunSuite {
   test("sbt: build.properties") {
     val original = """sbt.version=1.3.0-RC1"""
     val expected = """sbt.version=1.3.0"""
-    val update = Single("org.scala-sbt" % "sbt" % "1.3.0-RC1", Nel.of("1.3.0"))
+    val update = ("org.scala-sbt".g % "sbt".a % "1.3.0-RC1" %> "1.3.0").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -26,7 +25,7 @@ class UpdateHeuristicTest extends FunSuite {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    val update = Single("org.scala-js" % "sbt-scalajs" % "0.6.24", Nel.of("0.6.25"))
+    val update = ("org.scala-js".g % "sbt-scalajs".a % "0.6.24" %> "0.6.25").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -36,42 +35,42 @@ class UpdateHeuristicTest extends FunSuite {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    val update = Single("org.scala-js" % "sbt-scalajs" % "0.6.24", Nel.of("0.6.25"))
+    val update = ("org.scala-js".g % "sbt-scalajs".a % "0.6.24" %> "0.6.25").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("all on one line") {
     val original = """"be.doeraene" %% "scalajs-jquery"  % "0.9.3""""
     val expected = """"be.doeraene" %% "scalajs-jquery"  % "0.9.4""""
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("ignore hyphen in artifactId") {
     val original = """val scalajsJqueryVersion = "0.9.3""""
     val expected = """val scalajsJqueryVersion = "0.9.4""""
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("with single quotes around val") {
     val original = """val `scalajs-jquery-version` = "0.9.3""""
     val expected = """val `scalajs-jquery-version` = "0.9.4""""
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("all upper case") {
     val original = """val SCALAJSJQUERYVERSION = "0.9.3""""
     val expected = """val SCALAJSJQUERYVERSION = "0.9.4""""
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("just artifactId without version") {
     val original = """val scalajsjquery = "0.9.3""""
     val expected = """val scalajsjquery = "0.9.4""""
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -84,7 +83,7 @@ class UpdateHeuristicTest extends FunSuite {
       """// val scalajsJqueryVersion = "0.9.3
         |val scalajsJqueryVersion = "0.9.4" //bla
         |"""".stripMargin.trim
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -101,21 +100,21 @@ class UpdateHeuristicTest extends FunSuite {
         |   addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.4")
         |   //addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
         |"""".stripMargin.trim
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("ignore '-core' suffix") {
     val original = """val specs2Version = "4.2.0""""
     val expected = """val specs2Version = "4.3.4""""
-    val update = Single("org.specs2" % "specs2-core" % "4.2.0", Nel.of("4.3.4"))
+    val update = ("org.specs2".g % "specs2-core".a % "4.2.0" %> "4.3.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("use groupId if artifactId is 'core'") {
     val original = """lazy val sttpVersion = "1.3.2""""
     val expected = """lazy val sttpVersion = "1.3.3""""
-    val update = Single("com.softwaremill.sttp" % "core" % "1.3.2", Nel.of("1.3.3"))
+    val update = ("com.softwaremill.sttp".g % "core".a % "1.3.2" %> "1.3.3").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -131,7 +130,7 @@ class UpdateHeuristicTest extends FunSuite {
                       |  ).map("com.sky" %% _ % "1.3.0")
                       |""".stripMargin
     val update =
-      Group("com.sky" % Nel.of("akka-streams", "akka-streams-kafka") % "1.2.0", Nel.one("1.3.0"))
+      ("com.sky".g % Nel.of("akka-streams".a, "akka-streams-kafka".a) % "1.2.0" %> "1.3.0").group
     assertEquals(
       update.replaceVersionIn(original),
       Some(expected) -> UpdateHeuristic.completeGroupId.name
@@ -141,30 +140,24 @@ class UpdateHeuristicTest extends FunSuite {
   test("version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""
-    val update = Single("org.specs2" % "specs2-core" % "3.+", Nel.of("4.3.4"))
+    val update = ("org.specs2".g % "specs2-core".a % "3.+" %> "4.3.4").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("group with prefix val") {
     val original = """ val circe = "0.10.0-M1" """
     val expected = """ val circe = "0.10.0-M2" """
-    val update = Group(
-      "io.circe" %
-        Nel.of("circe-generic", "circe-literal", "circe-parser", "circe-testing") % "0.10.0-M1",
-      Nel.of("0.10.0-M2")
-    )
+    val update = ("io.circe".g %
+      Nel.of("circe-generic".a, "circe-literal".a, "circe-parser".a, "circe-testing".a)
+      % "0.10.0-M1" %> "0.10.0-M2").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("update under different group id") {
     val original = """ "org.spire-math" %% "kind-projector" % "0.9.0""""
     val expected = """ "org.typelevel" %% "kind-projector" % "0.10.0""""
-    val update = Single(
-      "org.spire-math" % "kind-projector" % "0.9.0",
-      Nel.of("0.10.0"),
-      Some(GroupId("org.typelevel")),
-      Some("kind-projector")
-    )
+    val update = ("org.spire-math".g % "kind-projector".a % "0.9.0" %> "0.10.0").single
+      .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -178,7 +171,7 @@ class UpdateHeuristicTest extends FunSuite {
         | "com.pepegar" %% "hammock-circe" % "0.8.5"
       """.stripMargin.trim
     val update =
-      Group("com.pepegar" % Nel.of("hammock-core", "hammock-circe") % "0.8.1", Nel.of("0.8.5"))
+      ("com.pepegar".g % Nel.of("hammock-core".a, "hammock-circe".a) % "0.8.1" %> "0.8.5").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -194,7 +187,7 @@ class UpdateHeuristicTest extends FunSuite {
         | "org.typelevel" %% "jawn-play" % "0.14.1"
       """.stripMargin.trim
     val update =
-      Group("org.typelevel" % Nel.of("jawn-json4s", "jawn-play") % "0.14.0", Nel.of("0.14.1"))
+      ("org.typelevel".g % Nel.of("jawn-json4s".a, "jawn-play".a) % "0.14.0" %> "0.14.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -207,10 +200,8 @@ class UpdateHeuristicTest extends FunSuite {
       """lazy val scalajsReactVersion = "1.3.1"
         |lazy val logbackVersion = "1.2.3"
       """.stripMargin
-    val update = Group(
-      "com.github.japgolly.scalajs-react" % Nel.of("core", "extra") % "1.2.3",
-      Nel.of("1.3.1")
-    )
+    val update = ("com.github.japgolly.scalajs-react".g %
+      Nel.of("core".a, "extra".a) % "1.2.3" %> "1.3.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -224,7 +215,7 @@ class UpdateHeuristicTest extends FunSuite {
         |val previousCirceIterateeVersion = "0.10.0"
       """.stripMargin
     val update =
-      Group("io.circe" % Nel.of("circe-jawn", "circe-testing") % "0.10.0", Nel.of("0.10.1"))
+      ("io.circe".g % Nel.of("circe-jawn".a, "circe-testing".a) % "0.10.0" %> "0.10.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -237,34 +228,30 @@ class UpdateHeuristicTest extends FunSuite {
       """"io.dropwizard.metrics" % "metrics-core" % "4.0.3"
         |mimaPreviousArtifacts := Set("io.dropwizard.metrics" %% "metrics-core" % "4.0.1")
       """.stripMargin
-    val update = Group(
-      "io.dropwizard.metrics" % Nel.of("metrics-core", "metrics-healthchecks") % "4.0.1",
-      Nel.of("4.0.3")
-    )
+    val update = ("io.dropwizard.metrics".g %
+      Nel.of("metrics-core".a, "metrics-healthchecks".a) % "4.0.1" %> "4.0.3").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("artifactId with dot") {
     val original = """ def plotlyJs = "1.41.3" """
     val expected = """ def plotlyJs = "1.43.2" """
-    val update = Single("org.webjars.bower" % "plotly.js" % "1.41.3", Nel.of("1.43.2"))
+    val update = ("org.webjars.bower".g % "plotly.js".a % "1.41.3" %> "1.43.2").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("val with backticks") {
     val original = """ val `plotly.js` = "1.41.3" """
     val expected = """ val `plotly.js` = "1.43.2" """
-    val update = Single("org.webjars.bower" % "plotly.js" % "1.41.3", Nel.of("1.43.2"))
+    val update = ("org.webjars.bower".g % "plotly.js".a % "1.41.3" %> "1.43.2").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("word from artifactId") {
     val original = """lazy val circeVersion = "0.9.3""""
     val expected = """lazy val circeVersion = "0.11.1""""
-    val update = Single(
-      "io.circe" % ArtifactId("circe-generic", "circe-generic_2.12") % "0.9.3",
-      Nel.of("0.11.1")
-    )
+    val update =
+      ("io.circe".g % ("circe-generic", "circe-generic_2.12").a % "0.9.3" %> "0.11.1").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
@@ -272,38 +259,36 @@ class UpdateHeuristicTest extends FunSuite {
     val original = """val scShapelessV = "1.1.6""""
     val expected = """val scShapelessV = "1.1.8""""
     val update =
-      Single("com.github.alexarchambault" % "scalacheck-shapeless_1.13" % "1.1.6", Nel.of("1.1.8"))
+      ("com.github.alexarchambault".g % "scalacheck-shapeless_1.13".a % "1.1.6" %> "1.1.8").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("camel case artifactId") {
     val original = """val hikariVersion = "3.3.0" """
     val expected = """val hikariVersion = "3.4.0" """
-    val update = Single("com.zaxxer" % "HikariCP" % "3.3.0", Nel.of("3.4.0"))
+    val update = ("com.zaxxer".g % "HikariCP".a % "3.3.0" %> "3.4.0").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("mongo from mongodb") {
     val original = """val mongoVersion = "3.7.0" """
     val expected = """val mongoVersion = "3.7.1" """
-    val update = Group(
-      "org.mongodb" %
-        Nel.of("mongodb-driver", "mongodb-driver-async", "mongodb-driver-core") % "3.7.0",
-      Nel.of("3.7.1")
-    )
+    val update = ("org.mongodb".g %
+      Nel.of("mongodb-driver".a, "mongodb-driver-async".a, "mongodb-driver-core".a)
+      % "3.7.0" %> "3.7.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.sliding.name)
   }
 
   test("artifactId with common suffix") {
     val original = """case _ => "1.0.2" """
-    val update = Single("co.fs2" % "fs2-core" % "1.0.2", Nel.of("1.0.4"))
+    val update = ("co.fs2".g % "fs2-core".a % "1.0.2" %> "1.0.4").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("word from groupId") {
     val original = """val acolyteVersion = "1.0.49" """
     val expected = """val acolyteVersion = "1.0.51" """
-    val update = Single("org.eu.acolyte" % "jdbc-driver" % "1.0.49", Nel.of("1.0.51"))
+    val update = ("org.eu.acolyte".g % "jdbc-driver".a % "1.0.49" %> "1.0.51").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.groupId.name)
   }
 
@@ -314,10 +299,8 @@ class UpdateHeuristicTest extends FunSuite {
       ("""version = 2.0.0 """, """version = 2.0.1 """),
       ("""version=2.0.0 """, """version=2.0.1 """)
     ).foreach { case (original, expected) =>
-      val update = Single(
-        "org.scalameta" % ArtifactId("scalafmt-core", "scalafmt-core_2.12") % "2.0.0",
-        Nel.of("2.0.1")
-      )
+      val update =
+        ("org.scalameta".g % ("scalafmt-core", "scalafmt-core_2.12").a % "2.0.0" %> "2.0.1").single
       assertEquals(
         update.replaceVersionIn(original),
         Some(expected) -> UpdateHeuristic.specific.name
@@ -325,25 +308,25 @@ class UpdateHeuristicTest extends FunSuite {
     }
 
     val original = """version=2.0.0"""
-    val update = Single("org.scalameta" % "other-artifact" % "2.0.0", Nel.of("2.0.1"))
+    val update = ("org.scalameta".g % "other-artifact".a % "2.0.0" %> "2.0.1").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore TLD") {
     val original = """ "com.propensive" %% "contextual" % "1.0.1" """
-    val update = Single("com.slamdata" % "fs2-gzip" % "1.0.1", Nel.of("1.1.1"))
+    val update = ("com.slamdata".g % "fs2-gzip".a % "1.0.1" %> "1.1.1").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore short words") {
     val original = "SBT_VERSION=1.2.7"
-    val update = Single("org.scala-sbt" % "scripted-plugin" % "1.2.7", Nel.of("1.2.8"))
+    val update = ("org.scala-sbt".g % "scripted-plugin".a % "1.2.7" %> "1.2.8").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore 'scala' substring") {
     val original = """ val scalaTestVersion = "3.0.7" """
-    val update = Single("org.scalactic" % "scalactic" % "3.0.7", Nel.of("3.0.8"))
+    val update = ("org.scalactic".g % "scalactic".a % "3.0.7" %> "3.0.8").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -358,10 +341,8 @@ class UpdateHeuristicTest extends FunSuite {
       libraryDependencies += "com.thoughtworks.dsl" %%% "keywords-using" % "1.3.0" % Optional
       libraryDependencies += "com.thoughtworks.dsl" %%% "keywords-each"  % "1.2.0+14-7a373cbd" % Optional
       """
-    val update = Group(
-      "com.thoughtworks.dsl" % Nel.of("keywords-each", "keywords-using") % "1.2.0",
-      Nel.of("1.3.0")
-    )
+    val update = ("com.thoughtworks.dsl".g %
+      Nel.of("keywords-each".a, "keywords-using".a) % "1.2.0" %> "1.3.0").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -369,16 +350,14 @@ class UpdateHeuristicTest extends FunSuite {
     val original = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.8.0""""
     val expected = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.9.1""""
     val update =
-      Group("org.nd4j" % Nel.of("nd4j-api", "nd4j-native-platform") % "0.8.0", Nel.of("0.9.1"))
+      ("org.nd4j".g % Nel.of("nd4j-api".a, "nd4j-native-platform".a) % "0.8.0" %> "0.9.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.strict.name)
   }
 
   test("unrelated ModuleID with same version number") {
     val original = """ "com.geirsson" % "sbt-ci-release" % "1.2.1" """
-    val update = Group(
-      "org.scala-sbt" % Nel.of("sbt-launch", "scripted-plugin", "scripted-sbt") % "1.2.1",
-      Nel.of("1.2.4")
-    )
+    val update = ("org.scala-sbt".g %
+      Nel.of("sbt-launch".a, "scripted-plugin".a, "scripted-sbt".a) % "1.2.1" %> "1.2.4").group
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -389,7 +368,7 @@ class UpdateHeuristicTest extends FunSuite {
     val expected = """val scalafmt = "2.0.7"
                      |addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
                      |""".stripMargin
-    val update = Single("org.scalameta" % "sbt-scalafmt" % "2.0.1", Nel.of("2.0.7"))
+    val update = ("org.scalameta".g % "sbt-scalafmt".a % "2.0.1" %> "2.0.7").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
@@ -397,7 +376,7 @@ class UpdateHeuristicTest extends FunSuite {
     val original = """ "org.webjars.npm" % "bootstrap" % "3.4.1", // scala-steward:off
                      | "org.webjars.npm" % "jquery" % "3.4.1",
                      |""".stripMargin
-    val update = Single("org.webjars.npm" % "bootstrap" % "3.4.1", Nel.of("4.3.1"))
+    val update = ("org.webjars.npm".g % "bootstrap".a % "3.4.1" %> "4.3.1").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -411,7 +390,7 @@ class UpdateHeuristicTest extends FunSuite {
         |  "com.typesafe.akka" %% "akka-testkit" % "2.5.0",
         |  """.stripMargin.trim
     val update =
-      Group("com.typesafe.akka" % Nel.of("akka-actor", "akka-testkit") % "2.4.0", Nel.of("2.5.0"))
+      ("com.typesafe.akka".g % Nel.of("akka-actor".a, "akka-testkit".a) % "2.4.0" %> "2.5.0").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -421,8 +400,8 @@ class UpdateHeuristicTest extends FunSuite {
         |  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
         |  "com.typesafe.akka" %% "akka-testkit" % "2.4.0",
         |  """.stripMargin.trim
-    val update =
-      Group("com.typesafe.akka" % Nel.of("akka-actor", "akka-testkit") % "2.4.0", Nel.of("2.5.0"))
+    val update = ("com.typesafe.akka".g %
+      Nel.of("akka-actor".a, "akka-testkit".a) % "2.4.0" %> "2.5.0").group
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -443,10 +422,8 @@ class UpdateHeuristicTest extends FunSuite {
         |  // scala-steward:off
         |  "com.typesafe.akka" %% "akka-testkit" % "2.4.20" % "test"
         |  """.stripMargin.trim
-    val update = Group(
-      "com.typesafe.akka" % Nel.of("akka-actor", "akka-testkit", "akka-slf4j") % "2.4.20",
-      Nel.of("2.5.0")
-    )
+    val update = ("com.typesafe.akka".g %
+      Nel.of("akka-actor".a, "akka-testkit".a, "akka-slf4j".a) % "2.4.20" %> "2.5.0").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -455,7 +432,7 @@ class UpdateHeuristicTest extends FunSuite {
       """# scala-steward:off
         |sbt.version=1.2.8
         |""".stripMargin
-    val update = Single("org.scala-sbt" % "sbt" % "1.2.8", Nel.of("1.4.3"))
+    val update = ("org.scala-sbt".g % "sbt".a % "1.2.8" %> "1.4.3").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -473,44 +450,39 @@ class UpdateHeuristicTest extends FunSuite {
         | "org.typelevel" %%% "cats-effect-laws" % "2.0.0-M4" % "test",
         |""".stripMargin
     val update =
-      Group("org.typelevel" % Nel.of("cats-core", "cats-laws") % "2.0.0-M4", Nel.of("2.0.0-RC1"))
+      ("org.typelevel".g % Nel.of("cats-core".a, "cats-laws".a) % "2.0.0-M4" %> "2.0.0-RC1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("ammonite script syntax") {
     val original = " import $ivy.`org.typelevel::cats-core:1.2.0` ".stripMargin
     val expected = " import $ivy.`org.typelevel::cats-core:1.3.0` ".stripMargin
-
-    val update = Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
+    val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("fail on versions with line break") {
     val original = """val scalajsJqueryVersion =
                      |  "0.9.3"""".stripMargin
-    val update = Single("be.doeraene" % "scalajs-jquery" % "0.9.3", Nel.of("0.9.4"))
+    val update = ("be.doeraene".g % "scalajs-jquery".a % "0.9.3" %> "0.9.4").single
     assertEquals(update.replaceVersionIn(original)._1, None)
   }
 
   test("cognito value for aws-java-sdk-cognitoidp artifact") {
     val original = """val cognito       = "1.11.690" """
     val expected = """val cognito       = "1.11.700" """
-    val update =
-      Single("com.amazonaws" % "aws-java-sdk-cognitoidp" % "1.11.690", Nel.of("1.11.700"))
+    val update = ("com.amazonaws".g % "aws-java-sdk-cognitoidp".a % "1.11.690" %> "1.11.700").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.sliding.name)
   }
 
   test("issue 1586: tracing value for opentracing library") {
     val original = """val tracing = "2.4.1" """
     val expected = """val tracing = "2.5.0" """
-    val update = Group(
-      "com.colisweb" % Nel.of(
-        "scala-opentracing-core",
-        "scala-opentracing-context",
-        "scala-opentracing-http4s-server-tapir"
-      ) % "2.4.1",
-      Nel.of("2.5.0")
-    )
+    val update = ("com.colisweb".g % Nel.of(
+      "scala-opentracing-core".a,
+      "scala-opentracing-context".a,
+      "scala-opentracing-http4s-server-tapir".a
+    ) % "2.4.1" %> "2.5.0").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.sliding.name)
   }
 
@@ -523,26 +495,22 @@ class UpdateHeuristicTest extends FunSuite {
       """ val jsoniter = "2.4.1"
         | addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
         |""".stripMargin
-    val update = Group(
-      "com.github.plokhotnyuk.jsoniter-scala" %
-        Nel.of("jsoniter-scala-core", "jsoniter-scala-macros")
-        % "2.4.0",
-      Nel.of("2.4.1")
-    )
+    val update = ("com.github.plokhotnyuk.jsoniter-scala".g %
+      Nel.of("jsoniter-scala-core".a, "jsoniter-scala-macros".a) % "2.4.0" %> "2.4.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("missing enclosing quote before") {
     val original =
       """.add("scalatestplus", version = "3.2.2.0", org = "org.scalatestplus", "scalacheck-1-14")"""
-    val update = Single("org.typelevel" % "cats-effect" % "2.2.0", Nel.of("2.3.0"))
+    val update = ("org.typelevel".g % "cats-effect".a % "2.2.0" %> "2.3.0").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
   test("missing enclosing quote after") {
     val original =
       """.add("scalatestplus", version = "2.2.0.3", org = "org.scalatestplus", "scalacheck-1-14")"""
-    val update = Single("org.typelevel" % "cats-effect" % "2.2.0", Nel.of("2.3.0"))
+    val update = ("org.typelevel".g % "cats-effect".a % "2.2.0" %> "2.3.0").single
     assertEquals(update.replaceVersionIn(original), None -> UpdateHeuristic.all.last.name)
   }
 
@@ -551,7 +519,7 @@ class UpdateHeuristicTest extends FunSuite {
       """val scalaTest = "3.2.0"  // scalaTest 3.2.0-M2 is causing a failure on scala 2.13..."""
     val expected =
       """val scalaTest = "3.2.2"  // scalaTest 3.2.0-M2 is causing a failure on scala 2.13..."""
-    val update = Single("org.scalatest" % "scalatest" % "3.2.0", Nel.of("3.2.2"))
+    val update = ("org.scalatest".g % "scalatest".a % "3.2.0" %> "3.2.2").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -562,7 +530,7 @@ class UpdateHeuristicTest extends FunSuite {
     val expected = """val cats = "2.4.2"
                      |val scalaReactJsTestState = "2.4.1"
                      |""".stripMargin
-    val update = Single("org.typelevel" % "cats-core" % "2.4.1", Nel.of("2.4.2"))
+    val update = ("org.typelevel".g % "cats-core".a % "2.4.1" %> "2.4.2").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -148,8 +148,8 @@ class UpdateHeuristicTest extends FunSuite {
     val original = """ val circe = "0.10.0-M1" """
     val expected = """ val circe = "0.10.0-M2" """
     val update = ("io.circe".g %
-      Nel.of("circe-generic".a, "circe-literal".a, "circe-parser".a, "circe-testing".a)
-      % "0.10.0-M1" %> "0.10.0-M2").group
+      Nel.of("circe-generic".a, "circe-literal".a, "circe-parser".a, "circe-testing".a) %
+      "0.10.0-M1" %> "0.10.0-M2").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -274,8 +274,8 @@ class UpdateHeuristicTest extends FunSuite {
     val original = """val mongoVersion = "3.7.0" """
     val expected = """val mongoVersion = "3.7.1" """
     val update = ("org.mongodb".g %
-      Nel.of("mongodb-driver".a, "mongodb-driver-async".a, "mongodb-driver-core".a)
-      % "3.7.0" %> "3.7.1").group
+      Nel.of("mongodb-driver".a, "mongodb-driver-async".a, "mongodb-driver-core".a) %
+      "3.7.0" %> "3.7.1").group
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.sliding.name)
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.edit.hooks
 import munit.CatsEffectSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{RepoData, Update}
+import org.scalasteward.core.data.RepoData
 import org.scalasteward.core.git.FileGitAlg
 import org.scalasteward.core.mock.MockConfig.gitCmd
 import org.scalasteward.core.mock.MockContext.context.{hookExecutor, workspaceAlg}
@@ -12,7 +12,6 @@ import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{RepoConfig, ScalafmtConfig}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}
-import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
 class HookExecutorTest extends CatsEffectSuite {
@@ -21,14 +20,13 @@ class HookExecutorTest extends CatsEffectSuite {
   private val repoDir = workspaceAlg.repoDir(repo).runA(MockState.empty).unsafeRunSync()
 
   test("no hook") {
-    val update = Update.Single("org.typelevel" % "cats-core" % "1.2.0", Nel.of("1.3.0"))
+    val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
     state.map(assertEquals(_, MockState.empty))
   }
 
   test("scalafmt: enabled by config") {
-    val update =
-      Update.Single(scalafmtGroupId.value % scalafmtArtifactId % "2.7.4", Nel.of("2.7.5"))
+    val update = (scalafmtGroupId % scalafmtArtifactId % "2.7.4" %> "2.7.5").single
     val initial = MockState.empty.copy(commandOutputs =
       Map(
         FileGitAlg.gitCmd.toList ++
@@ -70,15 +68,14 @@ class HookExecutorTest extends CatsEffectSuite {
     val repoConfig =
       RepoConfig.empty.copy(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(false)))
     val data = RepoData(repo, dummyRepoCache, repoConfig)
-    val update =
-      Update.Single(scalafmtGroupId.value % scalafmtArtifactId % "2.7.4", Nel.of("2.7.5"))
+    val update = (scalafmtGroupId % scalafmtArtifactId % "2.7.4" %> "2.7.5").single
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
 
     state.map(assertEquals(_, MockState.empty))
   }
 
   test("sbt-github-actions") {
-    val update = Update.Single("com.codecommit" % "sbt-github-actions" % "0.9.4", Nel.of("0.9.5"))
+    val update = ("com.codecommit".g % "sbt-github-actions".a % "0.9.4" %> "0.9.5").single
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
 
     val expected = MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
@@ -2,13 +2,13 @@ package org.scalasteward.core.edit.scalafix
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{GroupId, Update, Version}
+import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.mock.MockContext.context.scalafixMigrationsFinder
 import org.scalasteward.core.util.Nel
 
 class ScalafixMigrationsFinderTest extends FunSuite {
   test("findMigrations") {
-    val update = Update.Single("org.typelevel" % "cats-core" % "2.1.0", Nel.of("2.2.0"))
+    val update = ("org.typelevel".g % "cats-core".a % "2.1.0" %> "2.2.0").single
     val migrations = scalafixMigrationsFinder.findMigrations(update)
     val expected = (
       List(

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -5,7 +5,6 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
@@ -22,10 +21,10 @@ class PullRequestRepositoryTest extends FunSuite {
     assertEquals(state.copy(files = Map.empty), MockState.empty.copy(trace = trace))
 
   private val portableScala =
-    Update.Single("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1", Nel.of("1.0.0"))
+    ("org.portable-scala".g % "sbt-scalajs-crossproject".a % "0.6.1" %> "1.0.0").single
 
   private val catsCore =
-    Update.Single("org.typelevel" % "cats-core" % "1.0.0", Nel.of("1.0.1"))
+    ("org.typelevel".g % "cats-core".a % "1.0.0" %> "1.0.1").single
 
   private val url = uri"https://github.com/typelevel/cats/pull/3291"
   private val sha1 = Sha1(HexString.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -187,8 +187,8 @@ class PruningAlgTest extends FunSuite {
       List(
         Scope(
           List(
-            DependencyInfo("org.scala-lang" % "scala-library" % "2.12.14", List("build.sbt")),
-            DependencyInfo("org.scala-lang" % "scala-library" % "2.13.5", List("build.sbt"))
+            DependencyInfo("org.scala-lang".g % "scala-library".a % "2.12.14", List("build.sbt")),
+            DependencyInfo("org.scala-lang".g % "scala-library".a % "2.13.5", List("build.sbt"))
           ),
           List(MavenRepository("public", "https://repo5.org/maven/", None))
         )

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
@@ -2,22 +2,19 @@ package org.scalasteward.core.update
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{ArtifactId, Update}
 import org.scalasteward.core.util.Nel
 
 class UpdateAlgTest extends FunSuite {
   test("isUpdateFor") {
-    val dependency = "io.circe" % ArtifactId("circe-refined", "circe-refined_2.12") % "0.11.2"
-    val update = Update.Group(
+    val dependency = ("io.circe".g % ("circe-refined", "circe-refined_2.12").a % "0.11.2").cross
+    val update = ("io.circe".g %%
       Nel.of(
-        "io.circe" % ArtifactId("circe-core", "circe-core_2.12") % "0.11.2",
-        "io.circe" % Nel.of(
-          ArtifactId("circe-refined", "circe-refined_2.12"),
-          ArtifactId("circe-refined", "circe-refined_sjs0.6_2.12")
-        ) % "0.11.2"
-      ),
-      Nel.of("0.12.3")
-    )
+        Nel.of(("circe-core", "circe-core_2.12").a),
+        Nel.of(
+          ("circe-refined", "circe-refined_2.12").a,
+          ("circe-refined", "circe-refined_sjs0.6_2.12").a
+        )
+      ) % "0.11.2" %> "0.12.3").group
     assert(UpdateAlg.isUpdateFor(update, dependency))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
@@ -2,79 +2,67 @@ package org.scalasteward.core.update
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.ArtifactId
-import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 
 class showTest extends FunSuite {
   test("oneLiner: cats-core") {
-    val update = Single(
-      "org.typelevel" % Nel.of(
-        ArtifactId("cats-core", "cats-core_2.11"),
-        ArtifactId("cats-core", "cats-core_2.12")
-      ) % "0.9.0",
-      Nel.one("1.0.0")
-    )
+    val update = ("org.typelevel".g %
+      Nel.of(("cats-core", "cats-core_2.11").a, ("cats-core", "cats-core_2.12").a) %
+      "0.9.0" %> "1.0.0").single
     assertEquals(show.oneLiner(update), "cats-core")
   }
 
   test("oneLiner: fs2-core") {
-    val update = Single("co.fs2" % "fs2-core" % "0.9.7", Nel.one("1.0.0"))
+    val update = ("co.fs2".g % "fs2-core".a % "0.9.7" %> "1.0.0").single
     assertEquals(show.oneLiner(update), "fs2-core")
   }
 
   test("oneLiner: monix") {
-    val update = Single("io.monix" % "monix" % "2.3.3", Nel.one("3.0.0"))
+    val update = ("io.monix".g % "monix".a % "2.3.3" %> "3.0.0").single
     assertEquals(show.oneLiner(update), "monix")
   }
 
   test("oneLiner: sttp:core") {
-    val update = Single("com.softwaremill.sttp" % "core" % "1.3.3", Nel.one("1.3.5"))
+    val update = ("com.softwaremill.sttp".g % "core".a % "1.3.3" %> "1.3.5").single
     assertEquals(show.oneLiner(update), "sttp:core")
   }
 
   test("oneLiner: typesafe:config") {
-    val update = Single("com.typesafe" % "config" % "1.3.0", Nel.one("1.3.3"))
+    val update = ("com.typesafe".g % "config".a % "1.3.0" %> "1.3.3").single
     assertEquals(show.oneLiner(update), "typesafe:config")
   }
 
   test("oneLiner: single update with very long artifactId") {
     val artifactId = "1234567890" * 5
-    val update = Single("org.example" % artifactId % "1.0.0", Nel.one("2.0.0"))
+    val update = ("org.example".g % artifactId.a % "1.0.0" %> "2.0.0").single
     assertEquals(show.oneLiner(update), artifactId)
   }
 
   test("oneLiner: group update with two artifacts") {
     val update =
-      Group(
-        "org.typelevel" % Nel.of("cats-core", "cats-free") % "0.9.0",
-        Nel.one("1.0.0")
-      )
+      ("org.typelevel".g % Nel.of("cats-core".a, "cats-free".a) % "0.9.0" %> "1.0.0").group
     val expected = "cats-core, cats-free"
     assertEquals(show.oneLiner(update), expected)
   }
 
   test("oneLiner: group update with four artifacts") {
-    val update = Group(
-      "org.typelevel" % Nel.of("cats-core", "cats-free", "cats-laws", "cats-macros") % "0.9.0",
-      Nel.one("1.0.0")
-    )
+    val update = ("org.typelevel".g %
+      Nel.of("cats-core".a, "cats-free".a, "cats-laws".a, "cats-macros".a) %
+      "0.9.0" %> "1.0.0").group
     val expected = "cats-core, cats-free, cats-laws, ..."
     assertEquals(show.oneLiner(update), expected)
   }
 
   test("oneLiner: group update with four short artifacts") {
     val update =
-      Group("group" % Nel.of("data", "free", "laws", "macros") % "0.9.0", Nel.one("1.0.0"))
+      ("group".g % Nel.of("data".a, "free".a, "laws".a, "macros".a) % "0.9.0" %> "1.0.0").group
     val expected = "data, free, laws, macros"
     assertEquals(show.oneLiner(update), expected)
   }
 
   test("oneLiner: group update where one artifactId is a common suffix") {
-    val update = Group(
-      "com.softwaremill.sttp" % Nel.of("circe", "core", "okhttp-backend-monix") % "1.3.3",
-      Nel.one("1.3.5")
-    )
+    val update = ("com.softwaremill.sttp".g %
+      Nel.of("circe".a, "core".a, "okhttp-backend-monix".a) % "1.3.3" %> "1.3.5").group
     val expected = "sttp:circe, sttp:core, ..."
     assertEquals(show.oneLiner(update), expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -10,9 +10,9 @@ import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.VCSCfg
-import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
+import org.scalasteward.core.data.ReleaseRelatedUrl
 import org.scalasteward.core.mock.MockConfig
-import org.scalasteward.core.util.{Nel, UrlChecker}
+import org.scalasteward.core.util.UrlChecker
 
 class VCSExtraAlgTest extends FunSuite {
   val routes: HttpRoutes[IO] =
@@ -26,9 +26,9 @@ class VCSExtraAlgTest extends FunSuite {
   implicit val urlChecker: UrlChecker[IO] =
     UrlChecker.create[IO](MockConfig.config).unsafeRunSync()
 
-  private val updateFoo = Update.Single("com.example" % "foo" % "0.1.0", Nel.of("0.2.0"))
-  private val updateBar = Update.Single("com.example" % "bar" % "0.1.0", Nel.of("0.2.0"))
-  private val updateBuz = Update.Single("com.example" % "buz" % "0.1.0", Nel.of("0.2.0"))
+  private val updateFoo = ("com.example".g % "foo".a % "0.1.0" %> "0.2.0").single
+  private val updateBar = ("com.example".g % "bar".a % "0.1.0" %> "0.2.0").single
+  private val updateBuz = ("com.example".g % "buz".a % "0.1.0" %> "0.2.0").single
 
   test("getBranchCompareUrl: std vsc") {
     val vcsExtraAlg = VCSExtraAlg.create[IO](MockConfig.config.vcsCfg)

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -3,16 +3,13 @@ package org.scalasteward.core.vcs
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update
 import org.scalasteward.core.git
-import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.VCSType.{GitHub, GitLab}
 import org.scalasteward.core.vcs.data.Repo
 
 class VCSPackageTest extends FunSuite {
   private val repo = Repo("foo", "bar")
-  private val update =
-    Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3"))
+  private val update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
   private val updateBranch = git.branchFor(update, None)
 
   test("listingBranch") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -17,7 +17,7 @@ class NewPullRequestDataTest extends FunSuite {
     val data = UpdateData(
       RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),
-      Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3")),
+      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
       Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
       Branch("update/logback-classic-1.2.3")
@@ -39,9 +39,7 @@ class NewPullRequestDataTest extends FunSuite {
 
   test("fromTo") {
     assertEquals(
-      NewPullRequestData.fromTo(
-        Update.Single("com.example" % "foo" % "1.2.0", Nel.of("1.2.3"))
-      ),
+      NewPullRequestData.fromTo(("com.example".g % "foo".a % "1.2.0" %> "1.2.3").single),
       "from 1.2.0 to 1.2.3"
     )
   }
@@ -79,14 +77,14 @@ class NewPullRequestDataTest extends FunSuite {
   test("showing artifacts with URL in Markdown format") {
     assertEquals(
       NewPullRequestData.artifactsWithOptionalUrl(
-        Update.Single("com.example" % "foo" % "1.2.0", Nel.of("1.2.3")),
+        ("com.example".g % "foo".a % "1.2.0" %> "1.2.3").single,
         Map("foo" -> uri"https://github.com/foo/foo")
       ),
       "[com.example:foo](https://github.com/foo/foo)"
     )
     assertEquals(
       NewPullRequestData.artifactsWithOptionalUrl(
-        Update.Group("com.example" % Nel.of("foo", "bar") % "1.2.0", Nel.of("1.2.3")),
+        ("com.example".g % Nel.of("foo".a, "bar".a) % "1.2.0" %> "1.2.3").group,
         Map("foo" -> uri"https://github.com/foo/foo", "bar" -> uri"https://github.com/bar/bar")
       ),
       """
@@ -105,7 +103,7 @@ class NewPullRequestDataTest extends FunSuite {
   }
 
   test("migrationNote: when artifact has migrations") {
-    val update = Update.Single("com.spotify" % "scio-core" % "0.6.0", Nel.of("0.7.0"))
+    val update = ("com.spotify".g % "scio-core".a % "0.6.0" %> "0.7.0").single
     val migration = ScalafixMigration(
       update.groupId,
       Nel.of(update.artifactId.name),
@@ -127,7 +125,7 @@ class NewPullRequestDataTest extends FunSuite {
   }
 
   test("migrationNote: when artifact has migrations with docs") {
-    val update = Update.Single("com.spotify" % "scio-core" % "0.6.0", Nel.of("0.7.0"))
+    val update = ("com.spotify".g % "scio-core".a % "0.6.0" %> "0.7.0").single
     val migration = ScalafixMigration(
       update.groupId,
       Nel.of(update.artifactId.name),
@@ -154,40 +152,38 @@ class NewPullRequestDataTest extends FunSuite {
   }
 
   test("updateType") {
-    val dependency = "com.example" % "foo" % "0.1"
-    val single = Update.Single(dependency, Nel.of("0.2"))
-    val group = Update.Group("com.example" % Nel.of("foo", "bar") % "0.1", Nel.of("0.2"))
+    val dependency = "com.example".g % "foo".a % "0.1"
+    val single = (dependency %> "0.2").single
+    val group = ("com.example".g % Nel.of("foo".a, "bar".a) % "0.1" %> "0.2").group
     assertEquals(NewPullRequestData.updateType(single), "library-update")
     assertEquals(NewPullRequestData.updateType(group), "library-update")
 
     assertEquals(
-      NewPullRequestData.updateType(Update.Single(dependency % "test", Nel.of("0.2"))),
+      NewPullRequestData.updateType((dependency % "test" %> "0.2").single),
       "test-library-update"
     )
     assertEquals(
       NewPullRequestData.updateType(
-        Update.Single(dependency.copy(sbtVersion = Some(SbtVersion("1.0"))), Nel.of("0.2"))
+        (dependency.copy(sbtVersion = Some(SbtVersion("1.0"))) %> "0.2").single
       ),
       "sbt-plugin-update"
     )
     assertEquals(
-      NewPullRequestData.updateType(
-        Update.Single(dependency.copy(configurations = Some("scalafix-rule")), Nel.of("0.2"))
-      ),
+      NewPullRequestData.updateType((dependency % "scalafix-rule" %> "0.2").single),
       "scalafix-rule-update"
     )
   }
 
   test("oldVersionNote without files") {
     val files = List.empty
-    val update = Update.Single("com.example" % "foo" % "0.1", Nel.of("0.2"))
+    val update = ("com.example".g % "foo".a % "0.1" %> "0.2").single
 
     assertEquals(NewPullRequestData.oldVersionNote(files, update), (None, None))
   }
 
   test("oldVersionNote with files") {
     val files = List("Readme.md", "travis.yml")
-    val update = Update.Single("com.example" % "foo" % "0.1", Nel.of("0.2"))
+    val update = ("com.example".g % "foo".a % "0.1" %> "0.2").single
 
     val (label, note) = NewPullRequestData.oldVersionNote(files, update)
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -15,11 +15,11 @@ import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg
-import org.scalasteward.core.data.{RepoData, Update, UpdateData}
+import org.scalasteward.core.data.{RepoData, UpdateData}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.util.{HttpJsonClient, Nel}
+import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.vcs.gitlab.GitLabJsonCodec._
 import org.typelevel.log4cats.Logger
@@ -85,7 +85,7 @@ class GitLabApiAlgTest extends FunSuite {
   private val data = UpdateData(
     RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
     Repo("scala-steward", "bar"),
-    Update.Single("ch.qos.logback" % "logback-classic" % "1.2.0", Nel.of("1.2.3")),
+    ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
     Branch("master"),
     Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
     Branch("update/logback-classic-1.2.3")


### PR DESCRIPTION
This reworks the syntax for creating updates in tests. It
* does not use the `Update.Single.apply` and `Update.Group.apply` methods anymore. This will make it easier to change both classes since we  need to update the `apply` method in a lot less places.
* gets rid of implicit conversions in `TestSyntax`. The syntax is now based on extension methods via implicit classes only.
* makes creating `Update`s more concise.