### PR TITLE
Do not run scalafmt with `--quiet`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -52,7 +52,7 @@ final class ScalafmtAlg[F[_]](config: Config)(implicit
       .value
 
   def reformatChanged(repo: Repo): F[Unit] = {
-    val cmd = Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet) ++ opts.modeChanged
+    val cmd = Nel.of(scalafmtBinary, opts.nonInteractive) ++ opts.modeChanged
     workspaceAlg.repoDir(repo).flatMap(processAlg.exec(cmd, _)).void
   }
 
@@ -66,12 +66,11 @@ object ScalafmtAlg {
   object opts {
     val modeChanged = List("--mode", "changed")
     val nonInteractive = "--non-interactive"
-    val quiet = "--quiet"
     val version = "--version"
   }
 
   val postUpdateHookCommand: Nel[String] =
-    Nel.of(scalafmtBinary, opts.nonInteractive, opts.quiet)
+    Nel.of(scalafmtBinary, opts.nonInteractive)
 
   private[scalafmt] def parseScalafmtConf(s: String): Either[ParsingFailure, Option[Version]] =
     io.circe.config.parser.parse(s).map {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -102,14 +102,12 @@ class EditAlgTest extends FunSuite {
         Cmd("read", scalafmtConf.pathAsString),
         Cmd("write", scalafmtConf.pathAsString),
         Cmd(
-          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
-            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: opts.modeChanged
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString :: scalafmtBinary :: opts.nonInteractive :: opts.modeChanged
         ),
         Cmd(gitStatus(repoDir)),
         Log("Executing post-update hook for org.scalameta:scalafmt-core"),
         Cmd(
-          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
-            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: Nil
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString :: scalafmtBinary :: opts.nonInteractive :: Nil
         ),
         Cmd(gitStatus(repoDir))
       ),

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -40,8 +40,7 @@ class HookExecutorTest extends CatsEffectSuite {
       trace = Vector(
         Log("Executing post-update hook for org.scalameta:scalafmt-core"),
         Cmd(
-          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString ::
-            scalafmtBinary :: opts.nonInteractive :: opts.quiet :: Nil
+          "VAR1=val1" :: "VAR2=val2" :: repoDir.toString :: scalafmtBinary :: opts.nonInteractive :: Nil
         ),
         Cmd(
           gitCmd(repoDir),


### PR DESCRIPTION
This partially reverts #2321.

The `--quiet` option also suppresses helpful error messages:
```
$ scalafmt --non-interactive --quiet

$ scalafmt --non-interactive
Invalid config: Default dialect is deprecated; use explicit: [sbt0137,sbt1,scala211,scala212,scala212source3,scala213,scala213source3,scala3]
Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
: ~/.scalafmt.conf
```
Which means we currently get unhelpful error messages like this:
```
[info] 2021-12-23 16:34:31,733 WARN  Reformatting changed files failed
[info] java.io.IOException: 'scalafmt --non-interactive --quiet --mode changed' exited with code 8
[info] 	at org.scalasteward.core.io.process$.$anonfun$slurp$9(process.scala:54)
```

With this change, the above exception will contain the message about the
invalid config.