### PR TITLE
Spread config parsing failures into the pull request body

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -80,7 +80,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
       logger.attemptError.label(util.string.lineLeftRight(label), Some(label)) {
         F.guarantee(
           repoCacheAlg.checkCache(repo).flatMap { case (data, fork) =>
-            pruningAlg.needsAttention(data).flatMap {
+            pruningAlg.needsAttention(data.repoData).flatMap {
               _.traverse_(states => nurtureAlg.nurture(data, fork, states.map(_.update)))
             }
           },

--- a/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
@@ -27,8 +27,8 @@ final case class RepoData(
 )
 
 final case class RepoDataWithMeta(
-  repoData: RepoData,
-  configParsingError: Option[String]
+    repoData: RepoData,
+    configParsingError: Option[String]
 ) {
   def repo: Repo = repoData.repo
   def cache: RepoCache = repoData.cache
@@ -36,9 +36,11 @@ final case class RepoDataWithMeta(
 }
 
 object RepoDataWithMeta {
-  def apply(repo: Repo,
-            cache: RepoCache,
-            config: RepoConfig,
-            configParsingError: Option[String]): RepoDataWithMeta =
+  def apply(
+      repo: Repo,
+      cache: RepoCache,
+      config: RepoConfig,
+      configParsingError: Option[String]
+  ): RepoDataWithMeta =
     new RepoDataWithMeta(RepoData(repo, cache, config), configParsingError)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
@@ -25,3 +25,20 @@ final case class RepoData(
     cache: RepoCache,
     config: RepoConfig
 )
+
+final case class RepoDataWithMeta(
+  repoData: RepoData,
+  configParsingError: Option[String]
+) {
+  def repo: Repo = repoData.repo
+  def cache: RepoCache = repoData.cache
+  def config: RepoConfig = repoData.config
+}
+
+object RepoDataWithMeta {
+  def apply(repo: Repo,
+            cache: RepoCache,
+            config: RepoConfig,
+            configParsingError: Option[String]): RepoDataWithMeta =
+    new RepoDataWithMeta(RepoData(repo, cache, config), configParsingError)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -21,13 +21,13 @@ import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.vcs.data.Repo
 
 final case class UpdateData(
-    repoData: RepoData,
+    repoDataWithMeta: RepoDataWithMeta,
     fork: Repo,
     update: Update,
     baseBranch: Branch,
     baseSha1: Sha1,
     updateBranch: Branch
 ) {
-  def repo: Repo = repoData.repo
-  def repoConfig: RepoConfig = repoData.config
+  def repo: Repo = repoDataWithMeta.repo
+  def repoConfig: RepoConfig = repoDataWithMeta.config
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -152,14 +152,15 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
     gitAlg.returnToCurrentBranch(data.repo) {
       val createBranch = logger.info(s"Create branch ${data.updateBranch.name}") >>
         gitAlg.createBranch(data.repo, data.updateBranch)
-      editAlg.applyUpdate(data.repoDataWithMeta.repoData, data.update, createBranch).flatMap { edits =>
-        val editCommits = edits.flatMap(_.maybeCommit)
-        if (editCommits.isEmpty) logger.warn("No commits created").as(Ignored)
-        else
-          gitAlg.branchesDiffer(data.repo, data.baseBranch, data.updateBranch).flatMap {
-            case true  => pushCommits(data, editCommits) >> createPullRequest(data, edits)
-            case false => logger.warn("No diff between base and update branch").as(Ignored)
-          }
+      editAlg.applyUpdate(data.repoDataWithMeta.repoData, data.update, createBranch).flatMap {
+        edits =>
+          val editCommits = edits.flatMap(_.maybeCommit)
+          if (editCommits.isEmpty) logger.warn("No commits created").as(Ignored)
+          else
+            gitAlg.branchesDiffer(data.repo, data.baseBranch, data.updateBranch).flatMap {
+              case true  => pushCommits(data, editCommits) >> createPullRequest(data, edits)
+              case false => logger.warn("No diff between base and update branch").as(Ignored)
+            }
       }
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -40,12 +40,13 @@ final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(impli
       .repoDir(repo)
       .flatMap(dir => readRepoConfigFromFile(dir / repoConfigBasename))
 
-  private def readRepoConfigFromFile(configFile: File): F[ConfigParsingResult] = {
+  private def readRepoConfigFromFile(configFile: File): F[ConfigParsingResult] =
     for {
       parsedConfig <- fileAlg.readFile(configFile).map(_.map(parseRepoConfig))
-      _ <- parsedConfig.fold(F.unit)(_.fold(logger.info(_), repoConfig => logger.info(s"Parsed repo config ${repoConfig.show}")))
+      _ <- parsedConfig.fold(F.unit)(
+        _.fold(logger.info(_), repoConfig => logger.info(s"Parsed repo config ${repoConfig.show}"))
+      )
     } yield parsedConfig
-  }
 }
 
 object RepoConfigAlg {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.repoconfig
 
 import better.files.File
 import cats.MonadThrow
-import cats.data.OptionT
 import cats.syntax.all._
 import io.circe.config.parser
 import org.scalasteward.core.data.Update
@@ -36,21 +35,25 @@ final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(impli
   def mergeWithGlobal(maybeRepoConfig: Option[RepoConfig]): RepoConfig =
     (maybeRepoConfig |+| maybeGlobalRepoConfig).getOrElse(RepoConfig.empty)
 
-  def readRepoConfig(repo: Repo): F[Option[Either[String, RepoConfig]]] =
+  def readRepoConfig(repo: Repo): F[ConfigParsingResult] =
     workspaceAlg
       .repoDir(repo)
-      .flatMap(dir => readRepoConfigFromFile(dir / repoConfigBasename).value)
+      .flatMap(dir => readRepoConfigFromFile(dir / repoConfigBasename))
 
-  private def readRepoConfigFromFile(configFile: File): OptionT[F, Either[String, RepoConfig]] =
-    OptionT(fileAlg.readFile(configFile)).map(parseRepoConfig).flatMapF {
-      case Right(repoConfig) =>
-        logger.info(s"Parsed repo config ${repoConfig.show}").as(repoConfig.asRight.some)
-      case Left(errorMsg) =>
-        logger.info(errorMsg).as(errorMsg.asLeft.some)
-    }
+  private def readRepoConfigFromFile(configFile: File): F[ConfigParsingResult] = {
+    for {
+      parsedConfig <- fileAlg.readFile(configFile).map(_.map(parseRepoConfig))
+      _ <- parsedConfig.fold(F.unit)(_.fold(logger.info(_), repoConfig => logger.info(s"Parsed repo config ${repoConfig.show}")))
+    } yield parsedConfig
+  }
 }
 
 object RepoConfigAlg {
+
+  // None stands for the non-existing config file.
+  // Otherwise, you got either a config error, either parsed config.
+  type ConfigParsingResult = Option[Either[String, RepoConfig]]
+
   val repoConfigBasename: String = ".scala-steward.conf"
 
   def parseRepoConfig(input: String): Either[String, RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -179,9 +179,17 @@ object NewPullRequestData {
       filesWithOldVersion: List[String] = List.empty
   ): NewPullRequestData =
     NewPullRequestData(
-      title =
-        git.commitMsgFor(data.update, data.repoConfig.commits, data.repoDataWithMeta.repo.branch).title,
-      body = bodyFor(data.update, edits, artifactIdToUrl, releaseRelatedUrls, filesWithOldVersion, data.repoDataWithMeta.configParsingError),
+      title = git
+        .commitMsgFor(data.update, data.repoConfig.commits, data.repoDataWithMeta.repo.branch)
+        .title,
+      body = bodyFor(
+        data.update,
+        edits,
+        artifactIdToUrl,
+        releaseRelatedUrls,
+        filesWithOldVersion,
+        data.repoDataWithMeta.configParsingError
+      ),
       head = branchName,
       base = data.baseBranch
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -17,7 +17,7 @@ class RepoConfigAlgTest extends FunSuite {
   test("default config is not empty") {
     val config = repoConfigAlg
       .readRepoConfig(Repo("repo-config-alg", "test-1"))
-      .map(repoConfigAlg.mergeWithGlobal)
+      .map(c => repoConfigAlg.mergeWithGlobal(c.flatMap(_.toOption)))
       .runA(MockState.empty)
       .unsafeRunSync()
 
@@ -45,7 +45,7 @@ class RepoConfigAlgTest extends FunSuite {
     val initialState = MockState.empty.addFiles(configFile -> content).unsafeRunSync()
     val config = repoConfigAlg
       .readRepoConfig(repo)
-      .map(_.getOrElse(RepoConfig.empty))
+      .map(_.getOrElse(Right(RepoConfig.empty)))
       .runA(initialState)
       .unsafeRunSync()
 
@@ -76,7 +76,7 @@ class RepoConfigAlgTest extends FunSuite {
       ),
       buildRoots = Some(List(BuildRootConfig.repoRoot, BuildRootConfig("subfolder/subfolder")))
     )
-    assertEquals(config, expected)
+    assertEquals(config, Right(expected))
   }
 
   test("config with 'updatePullRequests = false'") {
@@ -167,9 +167,14 @@ class RepoConfigAlgTest extends FunSuite {
       MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
     val (state, config) = repoConfigAlg.readRepoConfig(repo).runSA(initialState).unsafeRunSync()
 
-    assertEquals(config, None)
+    val startOfErrorMsg = "Failed to parse .scala-steward.conf"
+    val expectedErrorMsg = Some(Left(startOfErrorMsg))
+    val obtainedConfig = config.map(_.leftMap(_.take(startOfErrorMsg.length)))
+
+    assertEquals(obtainedConfig, expectedErrorMsg)
+
     val log = state.trace.collectFirst { case Log((_, msg)) => msg }.getOrElse("")
-    assert(clue(log).startsWith("Failed to parse .scala-steward.conf"))
+    assert(clue(log).startsWith(startOfErrorMsg))
   }
 
   test("configToIgnoreFurtherUpdates with single update") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -38,7 +38,12 @@ class NewPullRequestDataTest extends FunSuite {
 
   test("body of pull request data should contain notion about config parsing error") {
     val data = UpdateData(
-      RepoDataWithMeta(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty, Some("Failed to parse .scala-steward.conf")),
+      RepoDataWithMeta(
+        Repo("foo", "bar"),
+        dummyRepoCache,
+        RepoConfig.empty,
+        Some("Failed to parse .scala-steward.conf")
+      ),
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -6,7 +6,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data.{ReleaseRelatedUrl, RepoData, UpdateData, Version}
+import org.scalasteward.core.data.{ReleaseRelatedUrl, RepoDataWithMeta, UpdateData, Version}
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.git.{Branch, Commit, Sha1}
@@ -17,7 +17,7 @@ import org.scalasteward.core.vcs.data.NewPullRequestData._
 class NewPullRequestDataTest extends FunSuite {
   test("asJson") {
     val data = UpdateData(
-      RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
+      RepoDataWithMeta(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty, None),
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
@@ -29,6 +29,27 @@ class NewPullRequestDataTest extends FunSuite {
       raw"""|{
             |  "title" : "Update logback-classic to 1.2.3",
             |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nConfigure Scala Steward for your repository with a [`.scala-steward.conf`](https://github.com/scala-steward-org/scala-steward/blob/${org.scalasteward.core.BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n\nlabels: library-update, early-semver-patch, semver-spec-patch, commit-count:0",
+            |  "head" : "scala-steward:update/logback-classic-1.2.3",
+            |  "base" : "master",
+            |  "draft" : false
+            |}""".stripMargin
+    assertEquals(obtained, expected)
+  }
+
+  test("body of pull request data should contain notion about config parsing error") {
+    val data = UpdateData(
+      RepoDataWithMeta(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty, Some("Failed to parse .scala-steward.conf")),
+      Repo("scala-steward", "bar"),
+      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
+      Branch("master"),
+      Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
+      Branch("update/logback-classic-1.2.3")
+    )
+    val obtained = from(data, "scala-steward:update/logback-classic-1.2.3").asJson.spaces2
+    val expected =
+      raw"""|{
+            |  "title" : "Update logback-classic to 1.2.3",
+            |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nConfigure Scala Steward for your repository with a [`.scala-steward.conf`](https://github.com/scala-steward-org/scala-steward/blob/${org.scalasteward.core.BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n<details>\n<summary>Note that the Scala Steward config file `.scala-steward.conf` wasn't parsed correctly</summary>\n\n```\nFailed to parse .scala-steward.conf\n```\n</details>\n\nlabels: library-update, early-semver-patch, semver-spec-patch, commit-count:0",
             |  "head" : "scala-steward:update/logback-classic-1.2.3",
             |  "base" : "master",
             |  "draft" : false

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -15,7 +15,7 @@ import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg
-import org.scalasteward.core.data.{RepoData, UpdateData}
+import org.scalasteward.core.data.{RepoDataWithMeta, UpdateData}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.repoconfig.RepoConfig
@@ -83,7 +83,7 @@ class GitLabApiAlgTest extends FunSuite {
     new GitLabApiAlg[IO](config.vcsCfg, GitLabCfg(mergeWhenPipelineSucceeds = false), _ => IO.pure)
 
   private val data = UpdateData(
-    RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
+    RepoDataWithMeta(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty, None),
     Repo("scala-steward", "bar"),
     ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
     Branch("master"),


### PR DESCRIPTION
This PR adds the spreading of config parsing failures into the pull request body. That should be useful for the OSS projects maintainers. It was born from the situation we got in  https://github.com/typelevel/keypool/pull/328.
The implementation is pretty straightforward, so I'm open to any suggestions/points about it.
And yeah, thanks for the Scala Steward! So cool to have it in our OSS ecosystem.