### PR TITLE
Add artifact migration for sbt-twirl

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -144,6 +144,12 @@ changes = [
     initialVersion = 1.9.0
   },
   {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = sbt-twirl
+    initialVersion = 1.6.0
+  },
+  {
     groupIdBefore = com.jsuereth
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-pgp


### PR DESCRIPTION
See [sbt/sbt-native-packager#1419](https://github.com/playframework/twirl/commit/68c08806ea3e877d39d0c98bb43a38e7d3dece86)

Old artifacts: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/ (e.g. [download link](https://scala.jfrog.io/ui/api/v1/download?repoKey=sbt-plugin-releases&path=com.typesafe.sbt%252Fsbt-twirl%252Fscala_2.12%252Fsbt_1.0%252F1.5.1%252Fjars%252Fsbt-twirl.jar&isNativeBrowsing=false&isFreeTier=false) for the jar file)
New artifacts: https://repo1.maven.org/maven2/com/typesafe/play/sbt-twirl_2.12_1.0/1.6.0-M1/

I published 1.6.0-M1 for now, however I opened this pull request for 1.6.0 the final release already.