### PR TITLE
Ensure post update hooks having a `command` set via it's type

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -88,7 +88,7 @@ buildRoots = [ ".", "subfolder/projectA" ]
 # Define commands that are executed after an update via a hook.
 # A groupId and/or artifactId can be defined to only execute after certain dependencies are updated. If neither is defined, the hook runs for every update.
 postUpdateHooks = [{
-  command = "sbt protobufGenerate",
+  command = ["sbt", "protobufGenerate"],
   commitMessage = "Regenerated protobuf files",
   groupId = "com.github.sbt",
   artifiactId = "sbt-protobuf"

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
@@ -27,25 +27,19 @@ import org.scalasteward.core.util.Nel
 final case class PostUpdateHookConfig(
     groupId: Option[GroupId],
     artifactId: Option[String],
-    command: String,
+    command: Nel[String],
     commitMessage: String
 ) {
   def toHook: PostUpdateHook =
-    Nel
-      .fromList(command.split(' ').toList)
-      .fold(
-        throw new Exception("Post update hooks must have a command defined.")
-      ) { cmd =>
-        PostUpdateHook(
-          groupId,
-          artifactId.map(ArtifactId(_)),
-          command = cmd,
-          useSandbox = true,
-          commitMessage = _ => CommitMsg(commitMessage),
-          enabledByCache = _ => true,
-          enabledByConfig = _ => true
-        )
-      }
+    PostUpdateHook(
+      groupId,
+      artifactId.map(ArtifactId(_)),
+      command = command,
+      useSandbox = true,
+      commitMessage = _ => CommitMsg(commitMessage),
+      enabledByCache = _ => true,
+      enabledByConfig = _ => true
+    )
 }
 
 object PostUpdateHookConfig {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -12,6 +12,7 @@ import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{PostUpdateHookConfig, RepoConfig, ScalafmtConfig}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}
+import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
 class HookExecutorTest extends CatsEffectSuite {
@@ -108,7 +109,7 @@ class HookExecutorTest extends CatsEffectSuite {
         PostUpdateHookConfig(
           groupId = None,
           artifactId = None,
-          command = "sbt mySbtCommand",
+          command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -195,7 +195,7 @@ class RepoConfigAlgTest extends FunSuite {
   test("config with postUpdateHook without group and artifact id") {
     val content =
       """|postUpdateHooks = [{
-         |  command = "sbt mySbtCommand"
+         |  command = ["sbt", "mySbtCommand"]
          |  commitMessage = "Updated with a hook!"
          |  }]
          |""".stripMargin
@@ -205,7 +205,7 @@ class RepoConfigAlgTest extends FunSuite {
         PostUpdateHookConfig(
           groupId = None,
           artifactId = None,
-          command = "sbt mySbtCommand",
+          command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
       )
@@ -219,7 +219,7 @@ class RepoConfigAlgTest extends FunSuite {
       """|postUpdateHooks = [{
          |  groupId = "eu.timepit"
          |  artifactId = "refined.1"
-         |  command = "sbt mySbtCommand"
+         |  command = ["sbt", "mySbtCommand"]
          |  commitMessage = "Updated with a hook!"
          |  }]
          |""".stripMargin
@@ -229,7 +229,7 @@ class RepoConfigAlgTest extends FunSuite {
         PostUpdateHookConfig(
           groupId = Some("eu.timepit".g),
           artifactId = Some("refined.1"),
-          command = "sbt mySbtCommand",
+          command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
       )


### PR DESCRIPTION
- use `Nel[String]` instead of throwing an Exception

see https://github.com/scala-steward-org/scala-steward/pull/2434#discussion_r779472755_