### PR TITLE
Make RepoConfig.postUpdateHooks optional

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -39,7 +39,7 @@ final class HookExecutor[F[_]](implicit
     F: MonadThrow[F]
 ) {
   def execPostUpdateHooks(data: RepoData, update: Update): F[List[EditAttempt]] =
-    (HookExecutor.postUpdateHooks ++ data.config.postUpdateHooks.map(_.toHook))
+    (HookExecutor.postUpdateHooks ++ data.config.postUpdateHooksOrDefault)
       .filter { hook =>
         hook.groupId.forall(update.groupId === _) &&
         hook.artifactId.forall(aid => update.artifactIds.exists(_.name === aid.name)) &&

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -22,13 +22,14 @@ import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.syntax._
+import org.scalasteward.core.edit.hooks.PostUpdateHook
 
 final case class RepoConfig(
     commits: CommitsConfig = CommitsConfig(),
     pullRequests: PullRequestsConfig = PullRequestsConfig(),
     scalafmt: ScalafmtConfig = ScalafmtConfig(),
     updates: UpdatesConfig = UpdatesConfig(),
-    postUpdateHooks: List[PostUpdateHookConfig] = Nil,
+    postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
     buildRoots: Option[List[BuildRootConfig]] = None
 ) {
@@ -36,6 +37,9 @@ final case class RepoConfig(
     buildRoots
       .map(_.filterNot(_.relativePath.contains("..")))
       .getOrElse(List(BuildRootConfig.repoRoot))
+
+  def postUpdateHooksOrDefault: List[PostUpdateHook] =
+    postUpdateHooks.getOrElse(Nil).map(_.toHook)
 
   def updatePullRequestsOrDefault: PullRequestUpdateStrategy =
     updatePullRequests.getOrElse(PullRequestUpdateStrategy.default)
@@ -69,7 +73,7 @@ object RepoConfig {
               pullRequests = x.pullRequests |+| y.pullRequests,
               scalafmt = x.scalafmt |+| y.scalafmt,
               updates = x.updates |+| y.updates,
-              postUpdateHooks = x.postUpdateHooks ++ y.postUpdateHooks,
+              postUpdateHooks = x.postUpdateHooks |+| y.postUpdateHooks,
               updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests),
               buildRoots = x.buildRoots |+| y.buildRoots
             )

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.edit.hooks
 
+import cats.syntax.all._
 import munit.CatsEffectSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
@@ -112,7 +113,7 @@ class HookExecutorTest extends CatsEffectSuite {
           command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
-      )
+      ).some
     )
     val data = RepoData(repo, dummyRepoCache, config)
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -208,7 +208,7 @@ class RepoConfigAlgTest extends FunSuite {
           command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
-      )
+      ).some
     )
 
     assertEquals(config, Right(expected))
@@ -232,7 +232,7 @@ class RepoConfigAlgTest extends FunSuite {
           command = Nel.of("sbt", "mySbtCommand"),
           commitMessage = "Updated with a hook!"
         )
-      )
+      ).some
     )
     assertEquals(config, Right(expected))
   }


### PR DESCRIPTION
For the same reason as given in #1339.