### PR TITLE
check if the version of the migrated artifact exists

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -3,282 +3,235 @@ changes = [
     groupIdBefore = com.eed3si9n
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-unidoc
-    initialVersion = 0.5.0
   },
   {
     groupIdBefore = com.cavorite
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-avro
-    initialVersion = 3.3.0
   },
   {
     groupIdBefore = com.geirsson
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-ci-release
-    initialVersion = 1.5.9
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-core
-    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-macro
-    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-laws
-    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-refined
-    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-argonaut
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-circe
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-core
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json-common
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-common
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-jackson
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-native
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-play-json
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-play
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-spray-json
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-upickle
-    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.github.gseitz
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-protobuf
-    initialVersion = 0.7.0
   },
   {
     groupIdBefore = com.github.gseitz
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-release
-    initialVersion = 1.0.15
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = guardrail
-    initialVersion = 0.65.2
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = sbt-guardrail-core
-    initialVersion = 0.65.3
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = sbt-guardrail
-    initialVersion = 0.65.3
   },
   {
     groupIdBefore = com.typesafe.sbt
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-native-packager
-    initialVersion = 1.9.0
   },
   {
     groupIdBefore = com.jsuereth
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-pgp
-    initialVersion = 2.1.2
   },
   {
     groupIdBefore = com.geirsson
     groupIdAfter = org.scalameta
     artifactIdAfter = sbt-scalafmt
-    initialVersion = 2.0.0
   },
   {
     groupIdBefore = com.github.mpilquist
     groupIdAfter = org.typelevel
     artifactIdAfter = simulacrum
-    initialVersion = 1.0.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-core
-    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-noop
-    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-slf4j
-    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-testing
-    initialVersion = 1.2.0
   },
   {
     groupIdBefore = net.ceedubs
     groupIdAfter = com.iheart
     artifactIdAfter = ficus
-    initialVersion = 1.3.4
   },
   {
     groupIdBefore = org.spire-math
     groupIdAfter = org.typelevel
     artifactIdAfter = kind-projector
-    initialVersion = 0.10.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = junit-4-12
     artifactIdAfter = junit-4-13
-    initialVersion = 3.2.3.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = mockito-3-3
     artifactIdAfter = mockito-3-4
-    initialVersion = 3.2.3.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = scalacheck-1-14
     artifactIdAfter = scalacheck-1-15
-    initialVersion = 3.2.2.0
   },
   {
     groupIdBefore = io.github.nafg
     groupIdAfter = io.github.nafg.slick-migration-api
     artifactIdAfter = slick-migration-api
-    initialVersion = 0.8.2
   },
   {
     groupIdBefore = io.github.nafg
     groupIdAfter = io.github.nafg.slick-migration-api
     artifactIdAfter = slick-migration-api-flyway
-    initialVersion = 0.8.1
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = scalacheck-shapeless_1.14
     artifactIdAfter = scalacheck-shapeless_1.15
-    initialVersion = 1.3.0
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = argonaut-shapeless_6.2
     artifactIdAfter = argonaut-shapeless_6.3
-    initialVersion = 1.3.0
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = argonaut-refined_6.2
     artifactIdAfter = argonaut-refined_6.3
-    initialVersion = 1.3.0
   },
   {
     groupIdBefore = com.kubukoz
     groupIdAfter = org.polyvariant
     artifactIdAfter = better-tostring
-    initialVersion = 0.3.8
   },
   {
     groupIdBefore = com.novocode
     groupIdAfter = com.github.sbt
     artifactIdAfter = junit-interface
-    initialVersion = 0.13.2
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = cats-time
-    initialVersion = 0.5.0
   },
   {
     groupIdBefore = com.lightbend.sbt
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-proguard
-    initialVersion = 0.5.0
   },
   {
     groupIdBefore = ky.korins
     groupIdAfter = pt.kcry
     artifactIdAfter = sha
-    initialVersion = 2.0.0
   },
   {
     groupIdBefore = ky.korins
     groupIdAfter = pt.kcry
     artifactIdAfter = blake3
-    initialVersion = 3.0.0
   }
 ]

--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -218,7 +218,6 @@ changes = [
     groupIdBefore = com.xebia
     groupIdAfter = nl.wehkamp.cakemix
     artifactIdAfter = cakemix
-    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactChange.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactChange.scala
@@ -24,8 +24,7 @@ final case class ArtifactChange(
     groupIdBefore: Option[GroupId],
     groupIdAfter: GroupId,
     artifactIdBefore: Option[String],
-    artifactIdAfter: String,
-    initialVersion: String
+    artifactIdAfter: String
 )
 
 object ArtifactChange {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
@@ -17,11 +17,10 @@
 package org.scalasteward.core.update.artifact
 
 import cats.syntax.all._
-import org.scalasteward.core.data.{CrossDependency, Dependency, Update}
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.data.Dependency
 
 final class ArtifactMigrationsFinder(migrations: List[ArtifactChange]) {
-  def findUpdateWithRenamedArtifact(dependency: Dependency): Option[Update.Single] =
+  def findUpdateWithRenamedArtifact(dependency: Dependency): Option[ArtifactChange] =
     migrations
       .find { migration =>
         (migration.groupIdBefore, migration.artifactIdBefore) match {
@@ -36,13 +35,5 @@ final class ArtifactMigrationsFinder(migrations: List[ArtifactChange]) {
             artifactId === dependency.artifactId.name
           case (None, None) => false
         }
-      }
-      .map { migration =>
-        Update.Single(
-          CrossDependency(dependency),
-          Nel.one(migration.initialVersion),
-          Some(migration.groupIdAfter),
-          Some(migration.artifactIdAfter)
-        )
       }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
@@ -6,6 +6,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.mock.MockContext.context.updateAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.update.UpdateAlg
 
 class ArtifactMigrationsFinderTest extends FunSuite {
 
@@ -113,5 +114,31 @@ class ArtifactMigrationsFinderTest extends FunSuite {
       .runA(MockState.empty)
       .unsafeRunSync()
     assertEquals(obtained, Some(expected))
+  }
+
+  test("migratedDependency: newer groupId") {
+    val dependency = "org.spire-math".g % ("kind-projector", "kind-projector_2.12").a % "0.9.10"
+    val migratedArtifact =
+      ("org.spire-math".g % (
+        "kind-projector",
+        "kind-projector_2.12"
+      ).a % "0.9.10" %> "0.10.0").single
+        .copy(newerGroupId = Some("org.typelevel".g))
+    val expected = "org.typelevel".g % ("kind-projector", "kind-projector_2.12").a % "0.10.0"
+    val obtained = UpdateAlg.migratedDependency(dependency.withMavenCentral, migratedArtifact)
+    assertEquals(obtained, expected.withMavenCentral)
+  }
+
+  test("migratedDependency: newer ArtifactId") {
+    val dependency = "org.spire-math".g % ("kind-projector", "kind-projector_2.12").a % "0.9.10"
+    val migratedArtifact =
+      ("org.spire-math".g % (
+        "kind-projector",
+        "kind-projector_2.12"
+      ).a % "0.9.10" %> "1.0.0").single
+        .copy(newerArtifactId = Some("new-projector"))
+    val expected = "org.spire-math".g % ("new-projector", "new-projector_2.12").a % "1.0.0"
+    val obtained = UpdateAlg.migratedDependency(dependency.withMavenCentral, migratedArtifact)
+    assertEquals(obtained, expected.withMavenCentral)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoaderTest.scala
@@ -17,15 +17,13 @@ class ArtifactMigrationsLoaderTest extends FunSuite {
        |    groupIdBefore = com.evilcorp
        |    groupIdAfter = org.ice.cream
        |    artifactIdAfter = yumyum
-       |    initialVersion = 2.0.0
        |  }
        |]""".stripMargin
   val migration: ArtifactChange = ArtifactChange(
     groupIdBefore = Some(GroupId("com.evilcorp")),
     groupIdAfter = GroupId("org.ice.cream"),
     artifactIdBefore = None,
-    artifactIdAfter = "yumyum",
-    initialVersion = "2.0.0"
+    artifactIdAfter = "yumyum"
   )
 
   test("loadAll: without extra file, without defaults") {
@@ -80,7 +78,6 @@ class ArtifactMigrationsLoaderTest extends FunSuite {
                                                              |  {
                                                              |    groupIdAfter = org.ice.cream
                                                              |    artifactIdAfter = yumyum
-                                                             |    initialVersion = 2.0.0
                                                              |  }
                                                              |]""".stripMargin)
     val migrations = artifactMigrationsLoader


### PR DESCRIPTION
Check if the version of the migrated artifact exists using the `versionCache`. As now the version of the migrated artifact is detected `ArtifactChange#initialVersion` is no longer needed.

fixes #2450 

This should prevent problems like in #2447