### PR TITLE
Discard changes after refreshing the repo cache

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -76,6 +76,7 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
       dependencies <- buildToolDispatcher.getDependencies(repo, config)
       dependencyInfos <-
         dependencies.traverse(_.traverse(_.traverse(gatherDependencyInfo(repo, _))))
+      _ <- gitAlg.discardChanges(repo)
       cache = RepoCache(latestSha1, dependencyInfos, maybeConfig)
     } yield RepoData(repo, cache, config)
 


### PR DESCRIPTION
This discards all local unstaged changes after executing the build for
refreshing the repo cache. If local changes are not discarded, switching
branches later will fail.

Closes #2416.