### PR TITLE
Add initialVersion again to artifact-migrations.conf

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -3,245 +3,288 @@ changes = [
     groupIdBefore = com.eed3si9n
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-unidoc
+    initialVersion = 0.5.0
   },
   {
     groupIdBefore = com.cavorite
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-avro
+    initialVersion = 3.3.0
   },
   {
     groupIdBefore = com.geirsson
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-ci-release
+    initialVersion = 1.5.9
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-core
+    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-macro
+    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-laws
+    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.github.julien-truffaut
     groupIdAfter = dev.optics
     artifactIdAfter = monocle-refined
+    initialVersion = 3.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-argonaut
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-circe
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-core
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json-common
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-common
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-jackson
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-json4s-native
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-play-json
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-play
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-spray-json
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.pauldijou
     groupIdAfter = com.github.jwt-scala
     artifactIdAfter = jwt-upickle
+    initialVersion = 6.0.0
   },
   {
     groupIdBefore = com.github.gseitz
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-protobuf
+    initialVersion = 0.7.0
   },
   {
     groupIdBefore = com.github.gseitz
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-release
+    initialVersion = 1.0.15
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = guardrail
+    initialVersion = 0.65.2
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = sbt-guardrail-core
+    initialVersion = 0.65.3
   },
   {
     groupIdBefore = com.twilio
     groupIdAfter = dev.guardrail
     artifactIdAfter = sbt-guardrail
+    initialVersion = 0.65.3
   },
   {
     groupIdBefore = com.typesafe.sbt
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-native-packager
-  },
-  {
-    groupIdBefore = com.typesafe.sbt
-    groupIdAfter = com.typesafe.play
-    artifactIdAfter = sbt-twirl
+    initialVersion = 1.9.0
   },
   {
     groupIdBefore = com.jsuereth
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-pgp
+    initialVersion = 2.1.2
   },
   {
     groupIdBefore = com.geirsson
     groupIdAfter = org.scalameta
     artifactIdAfter = sbt-scalafmt
+    initialVersion = 2.0.0
   },
   {
     groupIdBefore = com.github.mpilquist
     groupIdAfter = org.typelevel
     artifactIdAfter = simulacrum
+    initialVersion = 1.0.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-core
+    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-noop
+    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-slf4j
+    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = log4cats-testing
+    initialVersion = 1.2.0
   },
   {
     groupIdBefore = net.ceedubs
     groupIdAfter = com.iheart
     artifactIdAfter = ficus
+    initialVersion = 1.3.4
   },
   {
     groupIdBefore = org.spire-math
     groupIdAfter = org.typelevel
     artifactIdAfter = kind-projector
+    initialVersion = 0.10.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = junit-4-12
     artifactIdAfter = junit-4-13
+    initialVersion = 3.2.3.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = mockito-3-3
     artifactIdAfter = mockito-3-4
+    initialVersion = 3.2.3.0
   },
   {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = scalacheck-1-14
     artifactIdAfter = scalacheck-1-15
+    initialVersion = 3.2.2.0
   },
   {
     groupIdBefore = io.github.nafg
     groupIdAfter = io.github.nafg.slick-migration-api
     artifactIdAfter = slick-migration-api
+    initialVersion = 0.8.2
   },
   {
     groupIdBefore = io.github.nafg
     groupIdAfter = io.github.nafg.slick-migration-api
     artifactIdAfter = slick-migration-api-flyway
+    initialVersion = 0.8.1
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = scalacheck-shapeless_1.14
     artifactIdAfter = scalacheck-shapeless_1.15
+    initialVersion = 1.3.0
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = argonaut-shapeless_6.2
     artifactIdAfter = argonaut-shapeless_6.3
+    initialVersion = 1.3.0
   },
   {
     groupIdAfter = com.github.alexarchambault
     artifactIdBefore = argonaut-refined_6.2
     artifactIdAfter = argonaut-refined_6.3
+    initialVersion = 1.3.0
   },
   {
     groupIdBefore = com.kubukoz
     groupIdAfter = org.polyvariant
     artifactIdAfter = better-tostring
+    initialVersion = 0.3.8
   },
   {
     groupIdBefore = com.novocode
     groupIdAfter = com.github.sbt
     artifactIdAfter = junit-interface
+    initialVersion = 0.13.2
   },
   {
     groupIdBefore = com.xebia
     groupIdAfter = nl.wehkamp.cakemix
     artifactIdAfter = cakemix
+    initialVersion = 1.2.0
   },
   {
     groupIdBefore = io.chrisdavenport
     groupIdAfter = org.typelevel
     artifactIdAfter = cats-time
+    initialVersion = 0.5.0
   },
   {
     groupIdBefore = com.lightbend.sbt
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-proguard
+    initialVersion = 0.5.0
   },
   {
     groupIdBefore = ky.korins
     groupIdAfter = pt.kcry
     artifactIdAfter = sha
+    initialVersion = 2.0.0
   },
   {
     groupIdBefore = ky.korins
     groupIdAfter = pt.kcry
     artifactIdAfter = blake3
+    initialVersion = 3.0.0
   }
 ]


### PR DESCRIPTION
These are needed so that older versions of Scala Steward can read this
file again.

Closes: #2471