### PR TITLE
Add new version of artifact-migrations file

### DIFF
--- a/docs/artifact-migrations.md
+++ b/docs/artifact-migrations.md
@@ -31,6 +31,6 @@ to be greater than the latest version with the old groupId / old artifact id.
 
 Pull requests that added artifact migrations can be found [here][migration-prs].
 
-[migrations]: https://github.com/scala-steward-org/scala-steward/blob/master/modules/core/src/main/resources/artifact-migrations.conf
+[migrations]: https://github.com/scala-steward-org/scala-steward/blob/master/modules/core/src/main/resources/artifact-migrations.v2.conf
 [migration-prs]: https://github.com/scala-steward-org/scala-steward/pulls?q=label%3Aartifact-migration
 [HOCON]: https://github.com/lightbend/config/blob/master/HOCON.md

--- a/docs/artifact-migrations.md
+++ b/docs/artifact-migrations.md
@@ -15,19 +15,17 @@ changes = [
     groupIdBefore = com.geirsson
     groupIdAfter = org.scalameta
     artifactIdAfter = sbt-scalafmt
-    initialVersion = 2.0.0
   }
 ]
 ```
 In this example, scala-steward will look in the project for dependencies with the before group id, "com.geirsson", and 
 artifact id "sbt-scalafmt". If found, scala-steward will search for updates using the after group id, "org.scalameta", 
-artifact id "sbt-scalafmt", and version greater than the initial version, 2.0.0. If found, scala-steward will update
+artifact id "sbt-scalafmt", and version greater than the current version of the old artifact. If found, scala-steward will update
 to the after group id and latest version.
 
 The fields `groupIdBefore` and `artifactIdBefore` are optional. If just `groupIdBefore` is specified, as in the previous
 example, then only the group id will get renamed. If just `artifactIdBefore` is specified, then only the artifact id
-will get renamed. Specifying both `groupIdBefore` and `artifactIdBefore` will rename both. The `initialVersion` needs
-to be greater than the latest version with the old groupId / old artifact id.
+will get renamed. Specifying both `groupIdBefore` and `artifactIdBefore` will rename both.
 
 Pull requests that added artifact migrations can be found [here][migration-prs].
 

--- a/modules/core/src/main/resources/artifact-migrations.conf
+++ b/modules/core/src/main/resources/artifact-migrations.conf
@@ -1,3 +1,4 @@
+// This file is deprecated. Add new migrations to artifact-migrations.v2.conf.
 changes = [
    {
     groupIdBefore = com.eed3si9n

--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1,5 +1,5 @@
 changes = [
-   {
+  {
     groupIdBefore = com.eed3si9n
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-unidoc

--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1,0 +1,247 @@
+changes = [
+   {
+    groupIdBefore = com.eed3si9n
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-unidoc
+  },
+  {
+    groupIdBefore = com.cavorite
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-avro
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-ci-release
+  },
+  {
+    groupIdBefore = com.github.julien-truffaut
+    groupIdAfter = dev.optics
+    artifactIdAfter = monocle-core
+  },
+  {
+    groupIdBefore = com.github.julien-truffaut
+    groupIdAfter = dev.optics
+    artifactIdAfter = monocle-macro
+  },
+  {
+    groupIdBefore = com.github.julien-truffaut
+    groupIdAfter = dev.optics
+    artifactIdAfter = monocle-laws
+  },
+  {
+    groupIdBefore = com.github.julien-truffaut
+    groupIdAfter = dev.optics
+    artifactIdAfter = monocle-refined
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-argonaut
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-circe
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-core
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-json-common
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-json4s-common
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-json4s-jackson
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-json4s-native
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-play-json
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-play
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-spray-json
+  },
+  {
+    groupIdBefore = com.pauldijou
+    groupIdAfter = com.github.jwt-scala
+    artifactIdAfter = jwt-upickle
+  },
+  {
+    groupIdBefore = com.github.gseitz
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-protobuf
+  },
+  {
+    groupIdBefore = com.github.gseitz
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-release
+  },
+  {
+    groupIdBefore = com.twilio
+    groupIdAfter = dev.guardrail
+    artifactIdAfter = guardrail
+  },
+  {
+    groupIdBefore = com.twilio
+    groupIdAfter = dev.guardrail
+    artifactIdAfter = sbt-guardrail-core
+  },
+  {
+    groupIdBefore = com.twilio
+    groupIdAfter = dev.guardrail
+    artifactIdAfter = sbt-guardrail
+  },
+  {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-native-packager
+  },
+  {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = sbt-twirl
+  },
+  {
+    groupIdBefore = com.jsuereth
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-pgp
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = sbt-scalafmt
+  },
+  {
+    groupIdBefore = com.github.mpilquist
+    groupIdAfter = org.typelevel
+    artifactIdAfter = simulacrum
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-core
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-noop
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-slf4j
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = log4cats-testing
+  },
+  {
+    groupIdBefore = net.ceedubs
+    groupIdAfter = com.iheart
+    artifactIdAfter = ficus
+  },
+  {
+    groupIdBefore = org.spire-math
+    groupIdAfter = org.typelevel
+    artifactIdAfter = kind-projector
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-4-12
+    artifactIdAfter = junit-4-13
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-3-3
+    artifactIdAfter = mockito-3-4
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = scalacheck-1-14
+    artifactIdAfter = scalacheck-1-15
+  },
+  {
+    groupIdBefore = io.github.nafg
+    groupIdAfter = io.github.nafg.slick-migration-api
+    artifactIdAfter = slick-migration-api
+  },
+  {
+    groupIdBefore = io.github.nafg
+    groupIdAfter = io.github.nafg.slick-migration-api
+    artifactIdAfter = slick-migration-api-flyway
+  },
+  {
+    groupIdAfter = com.github.alexarchambault
+    artifactIdBefore = scalacheck-shapeless_1.14
+    artifactIdAfter = scalacheck-shapeless_1.15
+  },
+  {
+    groupIdAfter = com.github.alexarchambault
+    artifactIdBefore = argonaut-shapeless_6.2
+    artifactIdAfter = argonaut-shapeless_6.3
+  },
+  {
+    groupIdAfter = com.github.alexarchambault
+    artifactIdBefore = argonaut-refined_6.2
+    artifactIdAfter = argonaut-refined_6.3
+  },
+  {
+    groupIdBefore = com.kubukoz
+    groupIdAfter = org.polyvariant
+    artifactIdAfter = better-tostring
+  },
+  {
+    groupIdBefore = com.novocode
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = junit-interface
+  },
+  {
+    groupIdBefore = com.xebia
+    groupIdAfter = nl.wehkamp.cakemix
+    artifactIdAfter = cakemix
+  },
+  {
+    groupIdBefore = io.chrisdavenport
+    groupIdAfter = org.typelevel
+    artifactIdAfter = cats-time
+  },
+  {
+    groupIdBefore = com.lightbend.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-proguard
+  },
+  {
+    groupIdBefore = ky.korins
+    groupIdAfter = pt.kcry
+    artifactIdAfter = sha
+  },
+  {
+    groupIdBefore = ky.korins
+    groupIdAfter = pt.kcry
+    artifactIdAfter = blake3
+  }
+]

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoader.scala
@@ -52,6 +52,6 @@ final class ArtifactMigrationsLoader[F[_]](implicit
 
 object ArtifactMigrationsLoader {
   val defaultArtifactMigrationsUrl: Uri = Uri.unsafeFromString(
-    s"${org.scalasteward.core.BuildInfo.gitHubUserContent}/modules/core/src/main/resources/artifact-migrations.conf"
+    s"${org.scalasteward.core.BuildInfo.gitHubUserContent}/modules/core/src/main/resources/artifact-migrations.v2.conf"
   )
 }

--- a/modules/docs/mdoc/artifact-migrations.md
+++ b/modules/docs/mdoc/artifact-migrations.md
@@ -31,6 +31,6 @@ to be greater than the latest version with the old groupId / old artifact id.
 
 Pull requests that added artifact migrations can be found [here][migration-prs].
 
-[migrations]: @GITHUB_URL@/blob/@MAIN_BRANCH@/modules/core/src/main/resources/artifact-migrations.conf
+[migrations]: @GITHUB_URL@/blob/@MAIN_BRANCH@/modules/core/src/main/resources/artifact-migrations.v2.conf
 [migration-prs]: @GITHUB_URL@/pulls?q=label%3Aartifact-migration
 [HOCON]: https://github.com/lightbend/config/blob/master/HOCON.md

--- a/modules/docs/mdoc/artifact-migrations.md
+++ b/modules/docs/mdoc/artifact-migrations.md
@@ -15,19 +15,17 @@ changes = [
     groupIdBefore = com.geirsson
     groupIdAfter = org.scalameta
     artifactIdAfter = sbt-scalafmt
-    initialVersion = 2.0.0
   }
 ]
 ```
 In this example, scala-steward will look in the project for dependencies with the before group id, "com.geirsson", and 
 artifact id "sbt-scalafmt". If found, scala-steward will search for updates using the after group id, "org.scalameta", 
-artifact id "sbt-scalafmt", and version greater than the initial version, 2.0.0. If found, scala-steward will update
+artifact id "sbt-scalafmt", and version greater than the current version of the old artifact. If found, scala-steward will update
 to the after group id and latest version.
 
 The fields `groupIdBefore` and `artifactIdBefore` are optional. If just `groupIdBefore` is specified, as in the previous
 example, then only the group id will get renamed. If just `artifactIdBefore` is specified, then only the artifact id
-will get renamed. Specifying both `groupIdBefore` and `artifactIdBefore` will rename both. The `initialVersion` needs
-to be greater than the latest version with the old groupId / old artifact id.
+will get renamed. Specifying both `groupIdBefore` and `artifactIdBefore` will rename both.
 
 Pull requests that added artifact migrations can be found [here][migration-prs].
 


### PR DESCRIPTION
This adds a new default file for artifacts migrations that does not contain the `initialVersion` fields. Since older Scala Steward instances load the list of artifact migrations from this repository, removing fields is a backward-incompatible change so that we cannot remove them in the old default file.

See #2455 and #2472 for context.

@mzuehlke What do you think about this change. Is there a better way to keep older Scala Steward versions happy and still getting rid of the `initialVersion` field?