### PR TITLE
dynamic sbt-scalafix version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -98,7 +98,11 @@ final class SbtAlg[F[_]](config: Config)(implicit
     }
 
   private def sbtScalaFixPluginVersion: OptionT[F, String] =
-    OptionT(versionsCache.getVersions(sbtScalaFixDependency, None).map(_.lastOption.map(_.value)))
+    OptionT(
+      versionsCache
+        .getVersions(Scope(sbtScalaFixDependency, List(config.defaultResolver)), None)
+        .map(_.lastOption.map(_.value))
+    )
 
   private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.buildtool
 
 import cats.Functor
 import cats.syntax.all._
-import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
+import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver, Scope, Version}
 import org.scalasteward.core.io.{FileAlg, FileData}
 
 package object sbt {
@@ -35,10 +35,22 @@ package object sbt {
       Dependency(sbtGroupId, sbtArtifactId, sbtVersion.value)
     }
 
-  val scalaStewardScalafixSbt: FileData =
+  val sbtScalaFixDependency: Scope[Dependency] =
+    Scope(
+      Dependency(
+        GroupId("ch.epfl.scala"),
+        ArtifactId("sbt-scalafix"),
+        "",
+        Some(SbtVersion("1.0")),
+        Some(ScalaVersion("2.12"))
+      ),
+      List(Resolver.mavenCentral)
+    )
+
+  def scalaStewardScalafixSbt(version: String): FileData =
     FileData(
       "scala-steward-scalafix.sbt",
-      """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")"""
+      s"""addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "$version")"""
     )
 
   def scalaStewardScalafixOptions(scalacOptions: List[String]): FileData = {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.buildtool
 import cats.Functor
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
-import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver, Scope, Version}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 import org.scalasteward.core.io.{FileAlg, FileData}
 
 package object sbt {
@@ -35,16 +35,13 @@ package object sbt {
       Dependency(sbtGroupId, sbtArtifactId, sbtVersion.value)
     }
 
-  val sbtScalaFixDependency: Scope[Dependency] =
-    Scope(
-      Dependency(
-        GroupId("ch.epfl.scala"),
-        ArtifactId("sbt-scalafix"),
-        "",
-        Some(SbtVersion("1.0")),
-        Some(ScalaVersion("2.12"))
-      ),
-      List(Resolver.mavenCentral)
+  val sbtScalaFixDependency: Dependency =
+    Dependency(
+      GroupId("ch.epfl.scala"),
+      ArtifactId("sbt-scalafix"),
+      "",
+      Some(SbtVersion("1.0")),
+      Some(ScalaVersion("2.12"))
     )
 
   def scalaStewardScalafixSbt(version: String): FileData =

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -74,6 +74,10 @@ class SbtAlgTest extends FunSuite {
     val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       trace = Vector(
+        Cmd(
+          "read",
+          s"$mockRoot/workspace/store/versions/v2/https/repo1.maven.org/maven2/ch/epfl/scala/sbt-scalafix_2.12_1.0/versions.json"
+        ),
         Cmd("write", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
         Cmd("write", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         Cmd(
@@ -110,6 +114,10 @@ class SbtAlgTest extends FunSuite {
     val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(
       trace = Vector(
+        Cmd(
+          "read",
+          s"$mockRoot/workspace/store/versions/v2/https/repo1.maven.org/maven2/ch/epfl/scala/sbt-scalafix_2.12_1.0/versions.json"
+        ),
         Cmd("write", s"$mockRoot/.sbt/0.13/plugins/scala-steward-scalafix.sbt"),
         Cmd("write", s"$mockRoot/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         Cmd("write", s"$repoDir/scala-steward-scalafix-options.sbt"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -71,8 +71,13 @@ class SbtAlgTest extends FunSuite {
       Version("1.0.0"),
       Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
     )
-    val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
-    val expected = MockState.empty.copy(
+    val initialState = MockState.empty
+      .addFiles(
+        mockRoot / s"workspace/store/versions/v2/https/repo1.maven.org/maven2/ch/epfl/scala/sbt-scalafix_2.12_1.0/versions.json" -> sbtScalafixVersionJson
+      )
+      .unsafeRunSync()
+    val state = sbtAlg.runMigration(buildRoot, migration).runS(initialState).unsafeRunSync()
+    val expected = initialState.copy(
       trace = Vector(
         Cmd(
           "read",
@@ -111,8 +116,13 @@ class SbtAlgTest extends FunSuite {
       Nel.of("github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"),
       scalacOptions = Some(Nel.of("-P:semanticdb:synthetics:on"))
     )
-    val state = sbtAlg.runMigration(buildRoot, migration).runS(MockState.empty).unsafeRunSync()
-    val expected = MockState.empty.copy(
+    val initialState = MockState.empty
+      .addFiles(
+        mockRoot / s"workspace/store/versions/v2/https/repo1.maven.org/maven2/ch/epfl/scala/sbt-scalafix_2.12_1.0/versions.json" -> sbtScalafixVersionJson
+      )
+      .unsafeRunSync()
+    val state = sbtAlg.runMigration(buildRoot, migration).runS(initialState).unsafeRunSync()
+    val expected = initialState.copy(
       trace = Vector(
         Cmd(
           "read",
@@ -141,4 +151,13 @@ class SbtAlgTest extends FunSuite {
     )
     assertEquals(state, expected)
   }
+
+  private val sbtScalafixVersionJson =
+    s"""|{
+        |  "updatedAt" : 9999999999999,
+        |  "versions" : [
+        |    "0.9.33",
+        |    "0.9.34"
+        |  ]
+        |}""".stripMargin
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,3 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
-
-// This is only here so that Scala Steward updates the version in sbt/package.scala too.
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")


### PR DESCRIPTION
Retrieve the latest `sbt-scalafix` plugin version from coursier (`versionCache`) instead of relying on a hardcoded version.

Fixes #2357