### PR TITLE
Update Coursier to 2.1.0-M2-19-g5a34ba7c1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,10 @@ ThisBuild / githubWorkflowBuild :=
     )
   )
 
+/// global build settings
+
+ThisBuild / evictionErrorLevel := Level.Info
+
 /// projects
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -127,20 +127,14 @@ lazy val core = myCrossProject("core")
     ),
     assembly / test := {},
     assembly / assemblyMergeStrategy := {
-      val nativeSuffix = "\\.(?:dll|jnilib|so)$".r
-
-      {
-        case PathList(ps @ _*) if nativeSuffix.findFirstMatchIn(ps.last).isDefined =>
-          MergeStrategy.first
-        case PathList("org", "fusesource", _*) =>
-          // (core / assembly) deduplicate: different file contents found in the following:
-          // https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar:org/fusesource/hawtjni/runtime/Callback.class
-          // https/repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.18/jansi-1.18.jar:org/fusesource/hawtjni/runtime/Callback.class
-          MergeStrategy.first
-        case otherwise =>
-          val defaultStrategy = (assembly / assemblyMergeStrategy).value
-          defaultStrategy(otherwise)
-      }
+      case PathList("META-INF", "versions", "9", "module-info.class") =>
+        // (core / assembly) deduplicate: different file contents found in the following:
+        // https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.4.20/kotlin-stdlib-1.4.20.jar:META-INF/versions/9/module-info.class
+        // https/repo1.maven.org/maven2/org/tukaani/xz/1.9/xz-1.9.jar:META-INF/versions/9/module-info.class
+        MergeStrategy.first
+      case otherwise =>
+        val defaultStrategy = (assembly / assemblyMergeStrategy).value
+        defaultStrategy(otherwise)
     },
     buildInfoKeys := Seq[BuildInfoKey](
       organization,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeGeneric.revision
   val circeRefined = "io.circe" %% "circe-refined" % circeGeneric.revision
   val commonsIo = "commons-io" % "commons-io" % "2.11.0"
-  val coursierCore = "io.get-coursier" %% "coursier" % "2.0.16"
+  val coursierCore = "io.get-coursier" %% "coursier" % "2.1.0-M2-19-g5a34ba7c1"
   val cron4sCore = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.1"
   val decline = "com.monovore" %% "decline" % "2.2.0"
   val disciplineMunit = "org.typelevel" %% "discipline-munit" % "1.0.9"


### PR DESCRIPTION
This includes https://github.com/coursier/coursier/pull/2332.