### PR TITLE
Rename `master` to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val projectName = "scala-steward"
 val rootPkg = groupId.replace("-", "")
 val gitHubOwner = "scala-steward-org"
 val gitHubUrl = s"https://github.com/$gitHubOwner/$projectName"
-val mainBranch = "master"
+val mainBranch = "main"
 val gitHubUserContent = s"https://raw.githubusercontent.com/$gitHubOwner/$projectName/$mainBranch"
 
 val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(

--- a/docs/artifact-migrations.md
+++ b/docs/artifact-migrations.md
@@ -29,6 +29,6 @@ will get renamed. Specifying both `groupIdBefore` and `artifactIdBefore` will re
 
 Pull requests that added artifact migrations can be found [here][migration-prs].
 
-[migrations]: https://github.com/scala-steward-org/scala-steward/blob/master/modules/core/src/main/resources/artifact-migrations.v2.conf
+[migrations]: https://github.com/scala-steward-org/scala-steward/blob/main/modules/core/src/main/resources/artifact-migrations.v2.conf
 [migration-prs]: https://github.com/scala-steward-org/scala-steward/pulls?q=label%3Aartifact-migration
 [HOCON]: https://github.com/lightbend/config/blob/master/HOCON.md

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -75,7 +75,7 @@ a  `scm.url` or an `url` attribute.
 
 You can use [Mergify](https://mergify.io) to automatically merge Scala Steward's
 pull requests. Mergify rules that does this can be found in Scala Steward's own
-repository [here](https://github.com/scala-steward-org/scala-steward/blob/master/.mergify.yml).
+repository [here](https://github.com/scala-steward-org/scala-steward/blob/main/.mergify.yml).
 Mergify can also be configured to only merge patch updates (in case the version
 number adheres to [Semantic Versioning](https://semver.org/)) as demonstrated
 [here](https://github.com/fthomas/refined/blob/master/.mergify.yml).

--- a/docs/running.md
+++ b/docs/running.md
@@ -261,5 +261,5 @@ echo "${SCALA_STEWARD_TOKEN}"
 8. (*optional*) create a new schedule to trigger the pipeline on a daily/weekly basis
 
 
-[scalafixmigrations]: https://github.com/scala-steward-org/scala-steward/blob/master/docs/scalafix-migrations.md
-[artifactmigrations]: https://github.com/scala-steward-org/scala-steward/blob/master/docs/artifact-migrations.md
+[scalafixmigrations]: https://github.com/scala-steward-org/scala-steward/blob/main/docs/scalafix-migrations.md
+[artifactmigrations]: https://github.com/scala-steward-org/scala-steward/blob/main/docs/artifact-migrations.md

--- a/docs/scalafix-migrations.md
+++ b/docs/scalafix-migrations.md
@@ -60,7 +60,7 @@ migrations = [
 Pull requests that added migration rules can be found [here][scalafix-prs].
 
 [Scalafix]: https://scalacenter.github.io/scalafix/
-[migrations]: https://github.com/scala-steward-org/scala-steward/blob/master/modules/core/src/main/resources/scalafix-migrations.conf
+[migrations]: https://github.com/scala-steward-org/scala-steward/blob/main/modules/core/src/main/resources/scalafix-migrations.conf
 [scalafix-dev-guide]: https://scalacenter.github.io/scalafix/docs/developers/setup.html
 [using-dependency]: https://scalacenter.github.io/scalafix/docs/rules/external-rules.html
 [using-github]: https://scalacenter.github.io/scalafix/docs/developers/sharing-rules.html#using-github

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -32,7 +32,7 @@ final case class Version(value: String) {
   /** Selects the next version from a list of potentially newer versions.
     *
     * Implements the scheme described in this FAQ:
-    * https://github.com/scala-steward-org/scala-steward/blob/master/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to
+    * https://github.com/scala-steward-org/scala-steward/blob/main/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to
     */
   def selectNext(versions: List[Version]): Option[Version] = {
     val cutoff = alnumComponentsWithoutPreRelease.length - 1


### PR DESCRIPTION
I'd like to rename the default branch of this repo from `master` to `main`. If this is done, I'd check that older Scala Steward versions can still read the default `artifact-migrations.conf` and `scalafix-migrations.conf` files using the old URLs. I think GitHub redirects those.