### PR TITLE
Use Version in Dependency and Update

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -29,9 +29,10 @@ class UpdatesConfigBenchmark {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   def keepBench: Any = {
     val groupId = GroupId("org.example")
-    val dependency = CrossDependency(Dependency(groupId, ArtifactId("artifact"), "1.0.0"))
-    val newerVersions =
-      Nel.of("2.0.0", "2.1.0", "2.1.1", "2.2.0", "3.0.0", "3.1.0", "3.2.1", "3.3.3", "4.0", "5.0")
+    val dependency = CrossDependency(Dependency(groupId, ArtifactId("artifact"), Version("1.0.0")))
+    val newerVersions = Nel
+      .of("2.0.0", "2.1.0", "2.1.1", "2.2.0", "3.0.0", "3.1.0", "3.2.1", "3.3.3", "4.0", "5.0")
+      .map(Version.apply)
     val update = Update.Single(dependency, newerVersions)
 
     UpdatesConfig().keep(update)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
@@ -54,7 +54,7 @@ object parser {
       _ <- Parser.string("[INFO]").? ~ wsp.rep0
       groupId <- stringNoSpaceNoColon.map(GroupId.apply) <* colon
       artifactId <- artifactId <* colon <* Parser.string("jar") <* colon
-      version <- stringNoSpaceNoColon <* colon
+      version <- stringNoSpaceNoColon.map(Version.apply) <* colon
       configurations <- configurations
     } yield Dependency(
       groupId = groupId,

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -60,7 +60,7 @@ final class MillAlg[F[_]](implicit
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     F.unit
 
-  private def getMillVersion(buildRootDir: File): F[Option[String]] =
+  private def getMillVersion(buildRootDir: File): F[Option[Version]] =
     for {
       millVersionFileContent <- fileAlg.readFile(buildRootDir / ".mill-version")
       version = millVersionFileContent.flatMap(parser.parseMillVersion)
@@ -84,7 +84,7 @@ object MillAlg {
   private val millMainGroupId = GroupId("com.lihaoyi")
   private val millMainArtifactId = ArtifactId("mill-main", "mill-main_2.13")
 
-  private def millMainArtifact(version: String): Dependency =
+  private def millMainArtifact(version: Version): Dependency =
     Dependency(millMainGroupId, millMainArtifactId, version)
 
   def isMillMainUpdate(update: Update): Boolean =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.buildtool.mill
 
 import cats.syntax.all._
 import io.circe.{Decoder, DecodingFailure}
-import org.scalasteward.core.data.{Dependency, Resolver}
+import org.scalasteward.core.data.{Dependency, Resolver, Version}
 
 object parser {
   sealed trait ParseError extends RuntimeException {
@@ -40,8 +40,8 @@ object parser {
           .leftMap(CirceParseError("Failed to decode Modules", _): ParseError)
     } yield json.modules
 
-  def parseMillVersion(s: String): Option[String] =
-    Option(s.trim()).filter(_.nonEmpty)
+  def parseMillVersion(s: String): Option[Version] =
+    Option(s.trim).filter(_.nonEmpty).map(Version.apply)
 
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -30,16 +30,16 @@ package object sbt {
 
   val sbtArtifactId: ArtifactId = ArtifactId("sbt")
 
-  def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
-    Option.when(sbtVersion.toVersion >= Version("1.0.0")) {
-      Dependency(sbtGroupId, sbtArtifactId, sbtVersion.value)
-    }
+  def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] = {
+    val version = sbtVersion.toVersion
+    Option.when(version >= Version("1.0.0"))(Dependency(sbtGroupId, sbtArtifactId, version))
+  }
 
   val sbtScalaFixDependency: Dependency =
     Dependency(
       GroupId("ch.epfl.scala"),
       ArtifactId("sbt-scalafix"),
-      "",
+      Version(""),
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -112,8 +112,10 @@ object CoursierAlg {
     }
   }
 
-  private def toCoursierDependency(dependency: Dependency): coursier.Dependency =
-    coursier.Dependency(toCoursierModule(dependency), dependency.version).withTransitive(false)
+  private def toCoursierDependency(dependency: Dependency): coursier.Dependency = {
+    val module = toCoursierModule(dependency)
+    coursier.Dependency(module, dependency.version.value).withTransitive(false)
+  }
 
   private def toCoursierModule(dependency: Dependency): Module =
     Module(

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -24,7 +24,7 @@ import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 final case class Dependency(
     groupId: GroupId,
     artifactId: ArtifactId,
-    version: String,
+    version: Version,
     sbtVersion: Option[SbtVersion] = None,
     scalaVersion: Option[ScalaVersion] = None,
     configurations: Option[String] = None

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -31,13 +31,13 @@ sealed trait Update extends Product with Serializable {
   def groupId: GroupId
   def artifactIds: Nel[ArtifactId]
   def mainArtifactId: String
-  def currentVersion: String
-  def newerVersions: Nel[String]
+  def currentVersion: Version
+  def newerVersions: Nel[Version]
 
   final def name: String =
     Update.nameOf(groupId, mainArtifactId)
 
-  final def nextVersion: String =
+  final def nextVersion: Version =
     newerVersions.head
 
   final def show: String = {
@@ -53,7 +53,7 @@ sealed trait Update extends Product with Serializable {
     s"$groupId:$artifacts : $versions"
   }
 
-  def withNewerVersions(versions: Nel[String]): Update = this match {
+  def withNewerVersions(versions: Nel[Version]): Update = this match {
     case s @ Single(_, _, _, _) =>
       s.copy(newerVersions = versions)
     case g @ Group(_, _) =>
@@ -64,7 +64,7 @@ sealed trait Update extends Product with Serializable {
 object Update {
   final case class Single(
       crossDependency: CrossDependency,
-      newerVersions: Nel[String],
+      newerVersions: Nel[Version],
       newerGroupId: Option[GroupId] = None,
       newerArtifactId: Option[String] = None
   ) extends Update {
@@ -83,7 +83,7 @@ object Update {
     override def mainArtifactId: String =
       artifactId.name
 
-    override def currentVersion: String =
+    override def currentVersion: Version =
       crossDependency.head.version
 
     def artifactId: ArtifactId =
@@ -92,7 +92,7 @@ object Update {
 
   final case class Group(
       crossDependencies: Nel[CrossDependency],
-      newerVersions: Nel[String]
+      newerVersions: Nel[Version]
   ) extends Update {
     override def dependencies: Nel[Dependency] =
       crossDependencies.flatMap(_.dependencies)
@@ -115,7 +115,7 @@ object Update {
         .getOrElse(artifactIds.head.name)
     }
 
-    override def currentVersion: String =
+    override def currentVersion: Version =
       dependencies.head.version
 
     def artifactIdsPrefix: Option[MinLengthString[3]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -23,6 +23,8 @@ import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
 
 final case class Version(value: String) {
+  override def toString: String = value
+
   private val components: List[Version.Component] =
     Version.Component.parse(value)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -85,7 +85,8 @@ final class EditAlg[F[_]](implicit
   ): F[Option[Nel[File]]] =
     workspaceAlg.repoDir(repo).flatMap { repoDir =>
       val fileFilter = isSourceFile(update, config.updates.fileExtensionsOrDefault) _
-      fileAlg.findFiles(repoDir, fileFilter, _.contains(update.currentVersion)).map(Nel.fromList)
+      val contentFilter = (_: String).contains(update.currentVersion.value)
+      fileAlg.findFiles(repoDir, fileFilter, contentFilter).map(Nel.fromList)
     }
 
   private def runScalafixMigrations(

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit.scalafix
 
 import cats.syntax.all._
-import org.scalasteward.core.data.{Update, Version}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.ExecutionOrder
 
 final class ScalafixMigrationsFinder(migrations: List[ScalafixMigration]) {
@@ -28,8 +28,8 @@ final class ScalafixMigrationsFinder(migrations: List[ScalafixMigration]) {
         migration.artifactIds.exists { re =>
           update.artifactIds.exists(artifactId => re.r.findFirstIn(artifactId.name).isDefined)
         } &&
-        Version(update.currentVersion) < migration.newVersion &&
-        Version(update.nextVersion) >= migration.newVersion
+        update.currentVersion < migration.newVersion &&
+        update.nextVersion >= migration.newVersion
       }
       .partition(_.executionOrderOrDefault === ExecutionOrder.PreUpdate)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -45,8 +45,8 @@ package object git {
     val title = commitsConfig.messageOrDefault
       .replace("${default}", defaultMessage)
       .replace("${artifactName}", artifact)
-      .replace("${currentVersion}", update.currentVersion)
-      .replace("${nextVersion}", update.nextVersion)
+      .replace("${currentVersion}", update.currentVersion.value)
+      .replace("${nextVersion}", update.nextVersion.value)
       .replace("${branchName}", branch.map(_.name).orEmpty)
     CommitMsg(title)
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -185,7 +185,7 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
         existingArtifactUrlsMap
           .get(data.update.mainArtifactId)
           .traverse(vcsExtraAlg.getReleaseRelatedUrls(_, data.update))
-      filesWithOldVersion <- gitAlg.findFilesContaining(data.repo, data.update.currentVersion)
+      filesWithOldVersion <- gitAlg.findFilesContaining(data.repo, data.update.currentVersion.value)
       branchName = vcs.createBranch(config.tpe, data.fork, data.updateBranch)
       requestData = NewPullRequestData.from(
         data,

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -72,7 +72,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
         case (url, entry)
             if entry.state === PullRequestState.Open &&
               entry.update.withNewerVersions(update.newerVersions) === update &&
-              Version(entry.update.nextVersion) < Version(update.nextVersion) =>
+              entry.update.nextVersion < update.nextVersion =>
           for {
             number <- entry.number
             updateBranch = entry.updateBranch.getOrElse(git.branchFor(entry.update, repo.branch))
@@ -90,7 +90,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
   def findLatestPullRequest(
       repo: Repo,
       crossDependency: CrossDependency,
-      newVersion: String
+      newVersion: Version
   ): F[Option[PullRequestData[Option]]] =
     kvStore.getOrElse(repo, Map.empty).map {
       _.filter { case (_, entry) =>

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -83,5 +83,5 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
     } yield RepoData(repo, cache, config)
 
   private def gatherDependencyInfo(repo: Repo, dependency: Dependency): F[DependencyInfo] =
-    gitAlg.findFilesContaining(repo, dependency.version).map(DependencyInfo(dependency, _))
+    gitAlg.findFilesContaining(repo, dependency.version.value).map(DependencyInfo(dependency, _))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repoconfig
 import cats.syntax.all._
 import io.circe.Codec
 import io.circe.generic.semiauto._
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{GroupId, Update, Version}
 
 final case class UpdatePattern(
     groupId: GroupId,
@@ -32,7 +32,7 @@ final case class UpdatePattern(
 object UpdatePattern {
   final case class MatchResult(
       byArtifactId: List[UpdatePattern],
-      filteredVersions: List[String]
+      filteredVersions: List[Version]
   )
 
   def findMatch(
@@ -43,7 +43,7 @@ object UpdatePattern {
     val byGroupId = patterns.filter(_.groupId === update.groupId)
     val byArtifactId = byGroupId.filter(_.artifactId.forall(_ === update.artifactId.name))
     val filteredVersions = update.newerVersions.filter(newVersion =>
-      byArtifactId.exists(_.version.forall(_.matches(newVersion))) === include
+      byArtifactId.exists(_.version.forall(_.matches(newVersion.value))) === include
     )
     MatchResult(byArtifactId, filteredVersions)
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -39,7 +39,7 @@ package object scalafmt {
     if (version > Version("2.0.0-RC1")) scalafmtGroupId else GroupId("com.geirsson")
 
   def scalafmtDependency(version: Version): Dependency =
-    Dependency(scalafmtGroupIdBy(version), scalafmtArtifactId, version.value)
+    Dependency(scalafmtGroupIdBy(version), scalafmtArtifactId, version)
 
   val scalafmtBinary: String = "scalafmt"
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -80,17 +80,17 @@ object FilterAlg {
     }
 
   private def selectSuitableNextVersion(update: Update.Single): FilterResult = {
-    val newerVersions = update.newerVersions.map(Version.apply).toList
-    val maybeNext = Version(update.currentVersion).selectNext(newerVersions)
+    val newerVersions = update.newerVersions.toList
+    val maybeNext = update.currentVersion.selectNext(newerVersions)
     maybeNext match {
-      case Some(next) => Right(update.copy(newerVersions = Nel.of(next.value)))
+      case Some(next) => Right(update.copy(newerVersions = Nel.of(next)))
       case None       => Left(NoSuitableNextVersion(update))
     }
   }
 
   private def checkVersionOrdering(update: Update.Single): FilterResult = {
-    val current = coursier.core.Version(update.currentVersion)
-    val next = coursier.core.Version(update.nextVersion)
+    val current = coursier.core.Version(update.currentVersion.value)
+    val next = coursier.core.Version(update.nextVersion.value)
     if (current > next) Left(VersionOrderingConflict(update)) else Right(update)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -175,9 +175,8 @@ object PruningAlg {
       dependencies.exists { dependency =>
         dependency.groupId === update.groupId &&
         dependency.artifactId === update.artifactId && {
-          val dependencyVersion = Version(dependency.version)
-          dependencyVersion > Version(update.currentVersion) &&
-          dependencyVersion <= Version(update.nextVersion)
+          dependency.version > update.currentVersion &&
+          dependency.version <= update.nextVersion
         }
       }
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -55,7 +55,7 @@ final class UpdateAlg[F[_]](implicit
       maxAge: Option[FiniteDuration]
   ): OptionT[F, Update.Single] =
     findNewerVersions(dependency, maxAge).map { newerVersions =>
-      Update.Single(CrossDependency(dependency.value), newerVersions.map(_.value))
+      Update.Single(CrossDependency(dependency.value), newerVersions)
     }
 
   private def findUpdateWithMigration(
@@ -68,7 +68,7 @@ final class UpdateAlg[F[_]](implicit
           newerVersions =>
             Update.Single(
               CrossDependency(dependency.value),
-              newerVersions.map(_.value),
+              newerVersions,
               Some(artifactChange.groupIdAfter),
               Some(artifactChange.artifactIdAfter)
             )
@@ -80,8 +80,7 @@ final class UpdateAlg[F[_]](implicit
       maxAge: Option[FiniteDuration]
   ): OptionT[F, Nel[Version]] =
     OptionT(versionsCache.getVersions(dependency, maxAge).map { versions =>
-      val current = Version(dependency.value.version)
-      Nel.fromList(versions.filter(_ > current))
+      Nel.fromList(versions.filter(_ > dependency.value.version))
     })
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -217,7 +217,7 @@ object NewPullRequestData {
       case n           => s"n:$n"
     })
     val semVerVersions =
-      (SemVer.parse(update.currentVersion), SemVer.parse(update.nextVersion)).tupled
+      (SemVer.parse(update.currentVersion.value), SemVer.parse(update.nextVersion.value)).tupled
     val earlySemVerLabel = semVerVersions.flatMap { case (curr, next) =>
       SemVer.getChangeEarly(curr, next).map(c => s"early-semver-${c.render}")
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core
 import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.data.ReleaseRelatedUrl.VersionDiff
-import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
+import org.scalasteward.core.data.{ReleaseRelatedUrl, Update, Version}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.vcs.VCSType.{Bitbucket, BitbucketServer, GitHub, GitLab}
 import org.scalasteward.core.vcs.data.Repo
@@ -50,8 +50,8 @@ package object vcs {
         updateBranch.name
     }
 
-  def possibleTags(version: String): List[String] =
-    List(s"v$version", version, s"release-$version")
+  def possibleTags(version: Version): List[String] =
+    List(s"v$version", version.value, s"release-$version")
 
   val possibleChangelogFilenames: List[String] = {
     val baseNames = List(

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -22,6 +22,7 @@ object TestSyntax {
   implicit class StringOps(private val self: String) extends AnyVal {
     def g: GroupId = GroupId(self)
     def a: ArtifactId = ArtifactId(self)
+    def v: Version = Version(self)
   }
 
   implicit class StringTupleOps(private val self: (String, String)) extends AnyVal {
@@ -35,7 +36,7 @@ object TestSyntax {
   }
 
   implicit class GroupIdAndArtifactIdOps(private val self: (GroupId, ArtifactId)) extends AnyVal {
-    def %(version: String): Dependency = Dependency(self._1, self._2, version)
+    def %(version: String): Dependency = Dependency(self._1, self._2, version.v)
   }
 
   implicit class GroupIdAndArtifactIdsOps(
@@ -78,32 +79,33 @@ object TestSyntax {
   implicit class DependencyAndNextVersionOps(
       private val self: (Dependency, String)
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2))
+    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2.v))
   }
 
   implicit class DependencyAndNewerVersionsOps(
       private val self: (Dependency, Nel[String])
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), self._2)
+    def single: Update.Single = Update.Single(CrossDependency(self._1), self._2.map(_.v))
   }
 
   implicit class DependenciesAndNextVersionOps(
       private val self: (Nel[Dependency], String)
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2))
+    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2.v))
   }
 
   implicit class GroupIdAndArtifactIdsAndVersionAndNextVersionOps(
       private val self: (GroupId, Nel[ArtifactId], String, String)
   ) extends AnyVal {
     def single: Update.Single = {
-      val crossDependency = CrossDependency(self._2.map(aId => Dependency(self._1, aId, self._3)))
-      Update.Single(crossDependency, Nel.of(self._4))
+      val crossDependency = CrossDependency(self._2.map(aId => Dependency(self._1, aId, self._3.v)))
+      Update.Single(crossDependency, Nel.of(self._4.v))
     }
 
     def group: Update.Group = {
-      val crossDependencies = self._2.map(aId => CrossDependency(Dependency(self._1, aId, self._3)))
-      Update.Group(crossDependencies, Nel.of(self._4))
+      val crossDependencies =
+        self._2.map(aId => CrossDependency(Dependency(self._1, aId, self._3.v)))
+      Update.Group(crossDependencies, Nel.of(self._4.v))
     }
   }
 
@@ -112,8 +114,8 @@ object TestSyntax {
   ) extends AnyVal {
     def group: Update.Group = {
       val crossDependencies =
-        self._2.map(aIds => CrossDependency(aIds.map(aId => Dependency(self._1, aId, self._3))))
-      Update.Group(crossDependencies, Nel.of(self._4))
+        self._2.map(aIds => CrossDependency(aIds.map(aId => Dependency(self._1, aId, self._3.v))))
+      Update.Group(crossDependencies, Nel.of(self._4.v))
     }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillVersionParserTest.scala
@@ -18,7 +18,7 @@ class MillVersionParserTest extends FunSuite {
   } yield test(
     s"parse version from .mill-version file with content '$versionFileContent'"
   ) {
-    val parsed = parser.parseMillVersion(versionFileContent)
+    val parsed = parser.parseMillVersion(versionFileContent).map(_.value)
     assertEquals(parsed, expected)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -38,7 +38,7 @@ class PullRequestRepositoryTest extends FunSuite {
 
     val p = for {
       _ <- pullRequestRepository.createOrUpdate(repo, data)
-      result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0")
+      result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0".v)
       createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
     } yield (result, createdAt)
     val (state, (result, createdAt)) = p.runSA(MockState.empty).unsafeRunSync()
@@ -60,7 +60,7 @@ class PullRequestRepositoryTest extends FunSuite {
   test("getObsoleteOpenPullRequests for single update") {
     val repo = Repo("pr-repo-test", "repo2")
     val update = portableScala
-    val nextUpdate = portableScala.copy(newerVersions = Nel.of("1.0.1"))
+    val nextUpdate = portableScala.copy(newerVersions = Nel.of("1.0.1".v))
     val data = PullRequestData[Id](url, sha1, update, Open, number, branch)
 
     val p = for {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -28,12 +28,12 @@ class FilterAlgTest extends FunSuite {
 
   test("localFilter: update without bad version") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.0" %> Nel.of("1.1.2", "2.0.0")).single
-    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("1.1.2"))))
+    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("1.1.2".v))))
   }
 
   test("localFilter: update with bad version") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("1.1.2", "2.0.0")).single
-    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("2.0.0"))))
+    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("2.0.0".v))))
   }
 
   test("localFilter: update with bad version 2") {
@@ -41,7 +41,7 @@ class FilterAlgTest extends FunSuite {
       Nel.of("7726", "8020", "2017.09", "1.2019.12")).single
     assertEquals(
       localFilter(update, config),
-      Right(update.copy(newerVersions = Nel.of("1.2019.12")))
+      Right(update.copy(newerVersions = Nel.of("1.2019.12".v)))
     )
   }
 
@@ -82,7 +82,7 @@ class FilterAlgTest extends FunSuite {
         )
       )
     )
-    val expected = Right(update.copy(newerVersions = Nel.of("2.13.7")))
+    val expected = Right(update.copy(newerVersions = Nel.of("2.13.7".v)))
     assertEquals(localFilter(update, config), expected)
   }
 
@@ -158,7 +158,7 @@ class FilterAlgTest extends FunSuite {
     )
 
     val filtered = localFilter(update, config)
-    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8"))))
+    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8".v))))
   }
 
   test("ignore update via config updates.ignore using suffix") {
@@ -178,7 +178,7 @@ class FilterAlgTest extends FunSuite {
     )
 
     val filtered = localFilter(update, config)
-    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8"))))
+    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8".v))))
   }
 
   test("ignore update via config updates.pin using prefix and suffix") {
@@ -207,7 +207,7 @@ class FilterAlgTest extends FunSuite {
       """updates.ignore = [ { groupId = "sqlserver", version = { contains = "feature" } } ]"""
     )
     val obtained = repoConfig.flatMap(localFilter(update, _).leftMap(_.show))
-    assertEquals(obtained, Right(update.copy(newerVersions = Nel.of("7.3.0"))))
+    assertEquals(obtained, Right(update.copy(newerVersions = Nel.of("7.3.0".v))))
   }
 
   test("isDependencyConfigurationIgnored: false") {


### PR DESCRIPTION
This uses `Version` instead of `String` for the version fields in
`Dependency` and `Update`. The benefit of this is type safety and less
manual conversions between `String` and `Version`.