### PR TITLE
Remove constant string from repo config parsing error

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -73,12 +73,12 @@ final class RepoCacheAlg[F[_]](config: Config)(implicit
       latestSha1 <- gitAlg.latestSha1(repo, branch)
       parsedConfig <- repoConfigAlg.readRepoConfig(repo)
       maybeConfig = parsedConfig.flatMap(_.toOption)
+      maybeConfigParsingError = parsedConfig.flatMap(_.left.toOption.map(_.getMessage))
       config = repoConfigAlg.mergeWithGlobal(maybeConfig)
       dependencies <- buildToolDispatcher.getDependencies(repo, config)
       dependencyInfos <-
         dependencies.traverse(_.traverse(_.traverse(gatherDependencyInfo(repo, _))))
       _ <- gitAlg.discardChanges(repo)
-      maybeConfigParsingError = parsedConfig.flatMap(_.left.toOption)
       cache = RepoCache(latestSha1, dependencyInfos, maybeConfig, maybeConfigParsingError)
     } yield RepoData(repo, cache, config)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigLoader.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.repoconfig
 
 import cats.MonadThrow
 import cats.syntax.all._
-import io.circe.config.parser.decode
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.RepoConfigCfg
 import org.scalasteward.core.io.FileAlg
@@ -47,7 +46,7 @@ final class RepoConfigLoader[F[_]](implicit
       fileAlg.readUri(uri).flatMap(decodeRepoConfig(_, uri))
 
   private def decodeRepoConfig(content: String, uri: Uri): F[RepoConfig] =
-    F.fromEither(decode[RepoConfig](content))
+    F.fromEither(RepoConfigAlg.parseRepoConfig(content))
       .adaptErr(new Throwable(s"Failed to load repo config from ${uri.renderString}", _))
 }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -167,14 +167,14 @@ class RepoConfigAlgTest extends FunSuite {
       MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
     val (state, config) = repoConfigAlg.readRepoConfig(repo).runSA(initialState).unsafeRunSync()
 
-    val startOfErrorMsg = "Failed to parse .scala-steward.conf"
+    val startOfErrorMsg = "String: 1: List should have ]"
     val expectedErrorMsg = Some(Left(startOfErrorMsg))
-    val obtainedConfig = config.map(_.leftMap(_.take(startOfErrorMsg.length)))
+    val obtainedConfig = config.map(_.leftMap(_.getMessage.take(startOfErrorMsg.length)))
 
     assertEquals(obtainedConfig, expectedErrorMsg)
 
     val log = state.trace.collectFirst { case Log((_, msg)) => msg }.getOrElse("")
-    assert(clue(log).startsWith(startOfErrorMsg))
+    assert(clue(log).contains(startOfErrorMsg))
   }
 
   test("configToIgnoreFurtherUpdates with single update") {


### PR DESCRIPTION
This removes the constant `Failed to parse .scala-steward.conf: ` from
`RepoCache.maybeRepoConfigParsingError`. It is unnecessary to have this
in the caches and in PR bodies.