### PR TITLE
Add artifact migration for sbt-play-ebean

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -125,6 +125,11 @@ changes = [
     artifactIdAfter = sbt-twirl
   },
   {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = sbt-play-ebean
+  },
+  {
     groupIdBefore = com.jsuereth
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-pgp


### PR DESCRIPTION
We already publishing snapshots with the new groupid:
https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/play/sbt-play-ebean_2.12_1.0/6.2.0-RC3+3-8ecd9ef2-SNAPSHOT/