### PR TITLE
Add custom `PostUpdateHook` for sbt-typelevel

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -124,7 +124,7 @@ object HookExecutor {
 
   private def sbtTypelevelHook(
       groupId: GroupId,
-      artifactId: ArtifactId,
+      artifactId: ArtifactId
   ): PostUpdateHook =
     PostUpdateHook(
       groupId = Some(groupId),

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -72,9 +72,12 @@ object HookExecutor {
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-bintray")),
     (GroupId("io.github.nafg.mergify"), ArtifactId("sbt-mergify-github-actions")),
     (GroupId("io.chrisdavenport"), ArtifactId("sbt-davenverse")),
-    (GroupId("org.http4s"), ArtifactId("sbt-http4s-org")),
-    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel")),
     (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-ci-release"))
+  )
+
+  private val sbtTypelevelModules = List(
+    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel")),
+    (GroupId("org.http4s"), ArtifactId("sbt-http4s-org"))
   )
 
   // Modules that most likely require the workflow to be regenerated if updated.
@@ -119,12 +122,30 @@ object HookExecutor {
       enabledByConfig = _ => true
     )
 
+  private def sbtTypelevelHook(
+      groupId: GroupId,
+      artifactId: ArtifactId,
+      enabledByCache: RepoCache => Boolean
+  ): PostUpdateHook =
+    PostUpdateHook(
+      groupId = Some(groupId),
+      artifactId = Some(artifactId),
+      command = Nel.of("sbt", "tlPrePrBotHook"),
+      useSandbox = true,
+      commitMessage = _ => CommitMsg("Run prePR with sbt-typelevel"),
+      enabledByCache = enabledByCache,
+      enabledByConfig = _ => true
+    )
+
   private val postUpdateHooks: List[PostUpdateHook] =
     scalafmtHook :: sbtJavaFormatterHook ::
       sbtGitHubActionsModules.map { case (gid, aid) =>
         sbtGithubActionsHook(gid, aid, _ => true)
       } ++
       conditionalSbtGitHubActionsModules.map { case (gid, aid) =>
-        sbtGithubActionsHook(gid, aid, _.dependsOn(sbtGitHubActionsModules))
+        sbtGithubActionsHook(gid, aid, _.dependsOn(sbtGitHubActionsModules ++ sbtTypelevelModules))
+      } ++
+      sbtTypelevelModules.map { case (gid, aid) =>
+        sbtTypelevelHook(gid, aid, _ => true)
       }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -125,7 +125,6 @@ object HookExecutor {
   private def sbtTypelevelHook(
       groupId: GroupId,
       artifactId: ArtifactId,
-      enabledByCache: RepoCache => Boolean
   ): PostUpdateHook =
     PostUpdateHook(
       groupId = Some(groupId),
@@ -133,7 +132,7 @@ object HookExecutor {
       command = Nel.of("sbt", "tlPrePrBotHook"),
       useSandbox = true,
       commitMessage = _ => CommitMsg("Run prePR with sbt-typelevel"),
-      enabledByCache = enabledByCache,
+      enabledByCache = _ => true,
       enabledByConfig = _ => true
     )
 
@@ -146,6 +145,6 @@ object HookExecutor {
         sbtGithubActionsHook(gid, aid, _.dependsOn(sbtGitHubActionsModules ++ sbtTypelevelModules))
       } ++
       sbtTypelevelModules.map { case (gid, aid) =>
-        sbtTypelevelHook(gid, aid, _ => true)
+        sbtTypelevelHook(gid, aid)
       }
 }


### PR DESCRIPTION
This adds a custom `PostUpdateHook` for sbt-typelevel, which calls a `tlPrePrBotHook` command alias. The idea is that:
1. Since sbt-typelevel subsumes several other plugins, it may require multiple post-update steps to be run.
2. We can easily update the command in sbt-typelevel without needing to change Scala Steward.
3. Downstream plugins can update the alias with their own custom steps, without needing to add their own `PostUpdateHook` to Steward.

Additional background in:
- https://github.com/typelevel/sbt-typelevel/pull/111.

Let me know what you think. Thanks in advance! :)