### PR TITLE
Throw RepositoryArchived in createFork/getRepo

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
@@ -28,7 +28,8 @@ final case class RepoOut(
     owner: UserOut,
     parent: Option[RepoOut],
     clone_url: Uri,
-    default_branch: Branch
+    default_branch: Branch,
+    archived: Boolean = false
 ) {
   def parentOrRaise[F[_]](implicit F: ApplicativeThrow[F]): F[RepoOut] =
     parent.fold(F.raiseError[RepoOut](new Throwable(s"repo $name has no parent")))(F.pure)

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
@@ -16,37 +16,35 @@
 
 package org.scalasteward.core.vcs.github
 
-import cats.ApplicativeThrow
+import cats.MonadThrow
 import cats.syntax.all._
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data._
+import org.scalasteward.core.vcs.github.GitHubException._
 
 final class GitHubApiAlg[F[_]](
     gitHubApiHost: Uri,
     modify: Repo => Request[F] => F[Request[F]]
 )(implicit
     client: HttpJsonClient[F],
-    F: ApplicativeThrow[F]
+    F: MonadThrow[F]
 ) extends VCSApiAlg[F] {
   private val url = new Url(gitHubApiHost)
 
   /** https://developer.github.com/v3/repos/forks/#create-a-fork */
   override def createFork(repo: Repo): F[RepoOut] =
-    client.post(url.forks(repo), modify(repo))
+    client.post[RepoOut](url.forks(repo), modify(repo)).flatTap { repoOut =>
+      F.raiseWhen(repoOut.parent.exists(_.archived))(RepositoryArchived(repo))
+    }
 
   /** https://developer.github.com/v3/pulls/#create-a-pull-request */
   override def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut] =
     client
       .postWithBody[PullRequestOut, NewPullRequestData](url.pulls(repo), data, modify(repo))
-      .adaptErr(
-        List(
-          GitHubException.RepositoryArchived.fromThrowable(repo),
-          GitHubException.SecondaryRateLimitExceeded.fromThrowable
-        ).reduceLeft(_ orElse _)
-      )
+      .adaptErr(SecondaryRateLimitExceeded.fromThrowable)
 
   /** https://developer.github.com/v3/repos/branches/#get-branch */
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
@@ -54,7 +52,9 @@ final class GitHubApiAlg[F[_]](
 
   /** https://developer.github.com/v3/repos/#get */
   override def getRepo(repo: Repo): F[RepoOut] =
-    client.get(url.repos(repo), modify(repo))
+    client.get[RepoOut](url.repos(repo), modify(repo)).flatTap { repoOut =>
+      F.raiseWhen(repoOut.archived)(RepositoryArchived(repo))
+    }
 
   /** https://developer.github.com/v3/pulls/#list-pull-requests */
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubException.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubException.scala
@@ -23,16 +23,8 @@ import scala.util.control.NoStackTrace
 sealed trait GitHubException extends RuntimeException with NoStackTrace
 
 object GitHubException {
-  final case class RepositoryArchived(repo: Repo, override val getCause: UnexpectedResponse)
-      extends GitHubException {
+  final case class RepositoryArchived(repo: Repo) extends GitHubException {
     override val getMessage: String = repo.show
-  }
-
-  object RepositoryArchived {
-    def fromThrowable(repo: Repo): PartialFunction[Throwable, Throwable] = {
-      case response: UnexpectedResponse if response.body.contains("Repository was archived") =>
-        RepositoryArchived(repo, response)
-    }
   }
 
   final case class SecondaryRateLimitExceeded(override val getCause: UnexpectedResponse)

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -24,7 +24,8 @@ class GitHubApiAlgTest extends FunSuite {
             "name": "base.g8",
             "owner": { "login": "fthomas" },
             "clone_url": "https://github.com/fthomas/base.g8.git",
-            "default_branch": "master"
+            "default_branch": "master",
+            "archived": false
           } """
         )
 
@@ -73,10 +74,12 @@ class GitHubApiAlgTest extends FunSuite {
               "name": "base.g8",
               "owner": { "login": "fthomas" },
               "clone_url": "https://github.com/fthomas/base.g8.git",
-              "default_branch": "master"
+              "default_branch": "master",
+              "archived": false
             },
             "clone_url": "https://github.com/scala-steward/base.g8-1.git",
-            "default_branch": "master"
+            "default_branch": "master",
+            "archived": false
           } """
         )
 


### PR DESCRIPTION
This throws `RepositoryArchived` in `createFork` and `getRepo` if
`RepoOut#archived` is `true` instead of later in `createPullRequest`.
Scala Steward cannot do anything meaningful on archived repositories,
so it is better to throw that exception sooner than later.