### PR TITLE
Limit precision for human readability

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -42,7 +42,7 @@ object dateTime {
         case MICROSECONDS => "µs"
         case NANOSECONDS  => "ns"
       }
-    splitDuration(d).map(d1 => d1.length.toString + symbol(d1.unit)).mkString(" ")
+    splitDuration(d).map(d1 => d1.length.toString + symbol(d1.unit)).take(3).mkString(" ")
   }
 
   def splitDuration(d: FiniteDuration): List[FiniteDuration] = {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
@@ -29,7 +29,7 @@ class dateTimeTest extends ScalaCheckSuite {
 
   test("showDuration: example 1") {
     val d = 2.days + 20.hours + 37.minutes + 3.seconds + 586.millis + 491.micros + 264.nanos
-    assertEquals(showDuration(d), "2d 20h 37m 3s 586ms 491µs 264ns")
+    assertEquals(showDuration(d), "2d 20h 37m")
   }
 
   test("showDuration: example 2") {


### PR DESCRIPTION
Context: https://github.com/scala-steward-org/scala-steward/pull/2515#discussion_r801344269

This also helps adding new time-related test in PR #2515