### PR TITLE
Adapt the check for hashes in versions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -87,8 +87,8 @@ final case class Version(value: String) {
   private def containsHash: Boolean =
     components.exists {
       case _: Version.Component.Hash => true
-      case _ => Rfc5234.hexdig.rep(8).string.filterNot(startsWithDate).parse(value).isRight
-    }
+      case _                         => false
+    } || Rfc5234.hexdig.rep(8).string.filterNot(startsWithDate).parse(value).isRight
 
   private[this] def alnumComponentsWithoutPreRelease: List[Version.Component] =
     alnumComponents.takeWhile {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -63,16 +63,12 @@ final case class Version(value: String) {
           v.alnumComponents === alnumComponents ||
           // Do not select a version with hash if this version contains no hash.
           (v.containsHash && !containsHash) ||
-          (v.isOnlyHash && !isOnlyHash) ||
           // Don't select "versions" like %5BWARNING%5D.
           !v.startsWithLetterOrDigit
         }.sorted
       }
       .lastOption
   }
-
-  private def isOnlyHash: Boolean =
-    Rfc5234.hexdig.rep(8).string.filterNot(startsWithDate).parseAll(value).isRight
 
   private def startsWithLetterOrDigit: Boolean =
     components.headOption.forall {
@@ -91,7 +87,7 @@ final case class Version(value: String) {
   private def containsHash: Boolean =
     components.exists {
       case _: Version.Component.Hash => true
-      case _                         => false
+      case _ => Rfc5234.hexdig.rep(8).string.filterNot(startsWithDate).parse(value).isRight
     }
 
   private[this] def alnumComponentsWithoutPreRelease: List[Version.Component] =

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -217,7 +217,7 @@ class VersionTest extends DisciplineSuite {
       ("2.0.16-200-ge888c6dea", List("2.0.16-200-ge888c6dea-14-c067d59f0-SNAPSHOT"), None),
       ("17.0.0.1", List("18-ea+4"), None),
       ("", List("", ".", "1", "a"), Some("1")),
-      ("1.4.12", List("1032048a", "1032048a4c2"), None),
+      ("1.4.12", List("1032048a", "1032048a4c2", "7d2bf0af+20171218-1522"), None),
       ("1.1", List("20000000"), None),
       ("10000000", List("20000000"), Some("20000000")),
       ("1032048a", List("2032048a4c2"), Some("2032048a4c2"))


### PR DESCRIPTION
From checking if the complete version value is a hash to only checking if it contains a hash (at least 8 characters long).
The hash component detected by the parser only requires 6 byte, but in addition some leading separator.

Fixes #2502
Improves predecessor #2498
Original issue #2483