### PR TITLE
Retry on Retry-After response header

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -83,9 +83,9 @@ object Context {
       _ <- Resource.eval(printBanner(logger))
       _ <- Resource.eval(F.delay(System.setProperty("http.agent", userAgentString)))
       userAgent <- Resource.eval(F.fromEither(`User-Agent`.parse(userAgentString)))
-      userAgentMiddleware = ClientConfiguration.setUserAgent[F](userAgent)
-      retryAfterMiddleware = ClientConfiguration.retryAfter[F](maxAttempts = 5)
-      middleware = userAgentMiddleware.andThen(retryAfterMiddleware)
+      middleware = ClientConfiguration
+        .setUserAgent[F](userAgent)
+        .andThen(ClientConfiguration.retryAfter[F](maxAttempts = 5))
       defaultClient <- ClientConfiguration.build(
         ClientConfiguration.BuilderMiddleware.default,
         middleware

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -83,13 +83,15 @@ object Context {
       _ <- Resource.eval(F.delay(System.setProperty("http.agent", userAgentString)))
       userAgent <- Resource.eval(F.fromEither(`User-Agent`.parse(userAgentString)))
       userAgentMiddleware = ClientConfiguration.setUserAgent[F](userAgent)
+      retryAfterMiddleware = ClientConfiguration.retryAfter[F]
+      middleware = userAgentMiddleware.andThen(retryAfterMiddleware)
       defaultClient <- ClientConfiguration.build(
         ClientConfiguration.BuilderMiddleware.default,
-        userAgentMiddleware
+        middleware
       )
       urlCheckerClient <- ClientConfiguration.build(
         ClientConfiguration.disableFollowRedirect[F],
-        userAgentMiddleware
+        middleware
       )
       fileAlg = FileAlg.create(logger, F)
       processAlg = ProcessAlg.create(config.processCfg)(logger, F)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.application
 import cats.effect._
 import cats.effect.implicits._
 import cats.syntax.all._
+import eu.timepit.refined.auto._
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.headers.`User-Agent`
@@ -83,7 +84,7 @@ object Context {
       _ <- Resource.eval(F.delay(System.setProperty("http.agent", userAgentString)))
       userAgent <- Resource.eval(F.fromEither(`User-Agent`.parse(userAgentString)))
       userAgentMiddleware = ClientConfiguration.setUserAgent[F](userAgent)
-      retryAfterMiddleware = ClientConfiguration.retryAfter[F]
+      retryAfterMiddleware = ClientConfiguration.retryAfter[F](maxAttempts = 5)
       middleware = userAgentMiddleware.andThen(retryAfterMiddleware)
       defaultClient <- ClientConfiguration.build(
         ClientConfiguration.BuilderMiddleware.default,


### PR DESCRIPTION
Partially addresses #2355 by implementing [Retry-After](https://httpwg.org/specs/rfc7231.html#header.retry-after) support.

### seconds, not dates
I'm only handling response headers of the form `Reply-After: 60` seconds since that's what github actually returns. Non-numeric/date-based values like the one in the RFC will be ignored:
```
scala> "Wed, 21 Oct 2015 07:28:00 GMT".toIntOption
val res0: Option[Int] = None
```