### PR TITLE
Add migration of sbt-sassify

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -258,5 +258,10 @@ changes = [
     groupIdBefore = ky.korins
     groupIdAfter = pt.kcry
     artifactIdAfter = blake3
+  },
+  {
+    groupIdBefore = org.irundaia.sbt
+    groupIdAfter = io.github.irundaia
+    artifactIdAfter = sbt-sassify
   }
 ]


### PR DESCRIPTION
Due to the closure of bintray, I had to migrate sbt-sassify to Sonatype OSS. As a result of that migration, and the stricter groupId policies of Sonatype, I had to change its groupId. 