### PR TITLE
Add sbt-typelevel-mergify to the list of plugins that depend on sbt-github-actions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -72,7 +72,8 @@ object HookExecutor {
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-bintray")),
     (GroupId("io.github.nafg.mergify"), ArtifactId("sbt-mergify-github-actions")),
     (GroupId("io.chrisdavenport"), ArtifactId("sbt-davenverse")),
-    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-ci-release"))
+    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-ci-release")),
+    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-mergify"))
   )
 
   private val sbtTypelevelModules = List(


### PR DESCRIPTION
So that Scala Steward runs `githubWorkflowGenerate` if a project uses sbt-typelevel-mergify
and not one of the other plugins listed in `sbtGitHubActionsModules`.