### PR TITLE
Add Scalafix to the list of artifacts that can cause sbt-github-actions workflows to be regenerated

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -35,10 +35,13 @@ package object sbt {
     Option.when(version >= Version("1.0.0"))(Dependency(sbtGroupId, sbtArtifactId, version))
   }
 
+  val sbtScalaFixGroupId = GroupId("ch.epfl.scala")
+  val sbtScalaFixArtifactId = ArtifactId("sbt-scalafix")
+
   val sbtScalaFixDependency: Dependency =
     Dependency(
-      GroupId("ch.epfl.scala"),
-      ArtifactId("sbt-scalafix"),
+      sbtScalaFixGroupId,
+      sbtScalaFixArtifactId,
       Version(""),
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -18,21 +18,19 @@ package org.scalasteward.core.edit.hooks
 
 import cats.MonadThrow
 import cats.syntax.all._
-import org.scalasteward.core.buildtool.sbt.sbtArtifactId
-import org.scalasteward.core.buildtool.sbt.sbtGroupId
-import org.scalasteward.core.buildtool.sbt.sbtScalaFixArtifactId
-import org.scalasteward.core.buildtool.sbt.sbtScalaFixGroupId
+import org.scalasteward.core.buildtool.sbt.{
+  sbtArtifactId,
+  sbtGroupId,
+  sbtScalaFixArtifactId,
+  sbtScalaFixGroupId
+}
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.EditAttempt
 import org.scalasteward.core.edit.EditAttempt.HookEdit
-import org.scalasteward.core.git.CommitMsg
-import org.scalasteward.core.git.GitAlg
-import org.scalasteward.core.io.ProcessAlg
-import org.scalasteward.core.io.WorkspaceAlg
+import org.scalasteward.core.git.{CommitMsg, GitAlg}
+import org.scalasteward.core.io.{ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.repocache.RepoCache
-import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.scalafmt.scalafmtArtifactId
-import org.scalasteward.core.scalafmt.scalafmtGroupId
+import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.logger._
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -18,14 +18,21 @@ package org.scalasteward.core.edit.hooks
 
 import cats.MonadThrow
 import cats.syntax.all._
-import org.scalasteward.core.buildtool.sbt.{sbtArtifactId, sbtGroupId}
+import org.scalasteward.core.buildtool.sbt.sbtArtifactId
+import org.scalasteward.core.buildtool.sbt.sbtGroupId
+import org.scalasteward.core.buildtool.sbt.sbtScalaFixArtifactId
+import org.scalasteward.core.buildtool.sbt.sbtScalaFixGroupId
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.EditAttempt
 import org.scalasteward.core.edit.EditAttempt.HookEdit
-import org.scalasteward.core.git.{CommitMsg, GitAlg}
-import org.scalasteward.core.io.{ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.git.CommitMsg
+import org.scalasteward.core.git.GitAlg
+import org.scalasteward.core.io.ProcessAlg
+import org.scalasteward.core.io.WorkspaceAlg
 import org.scalasteward.core.repocache.RepoCache
-import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
+import org.scalasteward.core.scalafmt.ScalafmtAlg
+import org.scalasteward.core.scalafmt.scalafmtArtifactId
+import org.scalasteward.core.scalafmt.scalafmtGroupId
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.logger._
 import org.scalasteward.core.vcs.data.Repo
@@ -86,7 +93,7 @@ object HookExecutor {
 
   // Modules that most likely require the workflow to be regenerated if updated.
   private val conditionalSbtGitHubActionsModules =
-    (sbtGroupId, sbtArtifactId) :: scalaLangModules
+    (sbtGroupId, sbtArtifactId) :: (sbtScalaFixGroupId, sbtScalaFixArtifactId) :: scalaLangModules
 
   private def sbtGithubActionsHook(
       groupId: GroupId,


### PR DESCRIPTION
This is a suggestion that came up on typelevel/typelevel-scalafix#6.

The [build file](https://github.com/scalacenter/scalafix.g8/blob/main/src/main/g8/scalafix/build.sbt#L3=) in projects generated by [scalafix.g8](https://github.com/scalacenter/scalafix.g8) determines its Scala versions based on properties provided by sbt-scalafix.

Any time that sbt-scalafix is updated in those projects it's possible that the `crossScalaVersions` will change.

Contributed on behalf of the @opencastsoftware open source team. 👋 