### PR TITLE
Add sttp 3.6.1 artifact migrations

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -288,5 +288,25 @@ changes = [
     groupIdBefore = io.github.davidgregory084
     groupIdAfter = org.typelevel
     artifactIdAfter = sbt-tpolecat
+  },
+  {
+    groupIdAfter = com.softwaremill.sttp.client3
+    artifactIdBefore = httpclient-backend
+    artifactIdAfter = core
+  },
+  {
+    groupIdAfter = com.softwaremill.sttp.client3
+    artifactIdBefore = httpclient-backend-fs2
+    artifactIdAfter = fs2
+  },
+  {
+    groupIdAfter = com.softwaremill.sttp.client3
+    artifactIdBefore = httpclient-backend-monix
+    artifactIdAfter = monix
+  },
+  {
+    groupIdAfter = com.softwaremill.sttp.client3
+    artifactIdBefore = httpclient-backend-zio
+    artifactIdAfter = zio
   }
 ]


### PR DESCRIPTION
In [sttp 3.6.1](https://github.com/softwaremill/sttp/releases/tag/v3.6.1) some artifacts are no longer published as they're included in their respective 'core' modules (`httpclient-backend-fs2` ➡ `fs2`). Example of the rename that needs to be done: https://github.com/stryker-mutator/stryker4s/pull/1154/files

This PR adds artifact migrations for the changed modules.

I haven't found a setting for what version the artifact is migrated, so I assume scala-steward uses the latest version when upgrading?