### PR TITLE
Add artifact migration for play-grpc

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -270,6 +270,41 @@ changes = [
     artifactIdAfter = play-socket-io
   },
   {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = lagom-javadsl-grpc-testkit
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = lagom-scaladsl-grpc-testkit
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = play-grpc-generators
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = play-grpc-runtime
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = play-grpc-scalatest
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = play-grpc-specs2
+  },
+  {
+    groupIdBefore = com.lightbend.play
+    groupIdAfter = com.typesafe.play
+    artifactIdAfter = play-grpc-testkit
+  },
+  {
     groupIdBefore = com.lightbend.sbt
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-proguard


### PR DESCRIPTION
Changed the groupId with this pull request: https://github.com/playframework/play-grpc/pull/420
Moving all the grpc artifacts from https://repo1.maven.org/maven2/com/lightbend/play/ to https://repo1.maven.org/maven2/com/typesafe/play/