### PR TITLE
Adding IteratorToVector rule for sbt-guardrail 0.72.0

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -57,6 +57,13 @@ migrations = [
     doc: "https://github.com/twilio/guardrail/blob/master/MIGRATING.md#0590-may-contain-type-and-package-naming-changes-that-will-require-changes-in-consuming-code"
   },
   {
+    groupId: "dev.guardrail",
+    artifactIds: ["sbt-guardrail"],
+    newVersion: "0.72.0",
+    rewriteRules: ["https://raw.githubusercontent.com/guardrail-dev/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailIteratorToVector.scala"],
+    doc: "https://github.com/guardrail-dev/guardrail/blob/master/MIGRATING.md#migrating-to-guardrail-core-0710"
+  },
+  {
     groupId: "com.typesafe.akka",
     artifactIds: ["akka-http.*"],
     newVersion: "10.2.0",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -60,7 +60,7 @@ migrations = [
     groupId: "dev.guardrail",
     artifactIds: ["sbt-guardrail"],
     newVersion: "0.72.0",
-    rewriteRules: ["https://raw.githubusercontent.com/guardrail-dev/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailIteratorToVector.scala"],
+    rewriteRules: ["https://raw.githubusercontent.com/guardrail-dev/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailIterableToVector.scala"],
     doc: "https://github.com/guardrail-dev/guardrail/blob/master/MIGRATING.md#migrating-to-guardrail-core-0710"
   },
   {


### PR DESCRIPTION
Attempt to reflect a change in defaults for generated code to reduce upgrade burden