### PR TITLE
add artifact migration for Bouncy Castle Crypto APIs

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -353,5 +353,55 @@ changes = [
     groupIdAfter = com.softwaremill.sttp.client3
     artifactIdBefore = httpclient-backend-zio
     artifactIdAfter = zio
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcprov-jdk15on
+    artifactIdAfter = bcprov-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcprov-ext-jdk15on
+    artifactIdAfter = bcprov-ext-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcprov-debug-jdk15on
+    artifactIdAfter = bcprov-debug-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcprov-ext-debug-jdk15on
+    artifactIdAfter = bcprov-ext-debug-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcutil-jdk15on
+    artifactIdAfter = bcutil-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcpkix-jdk15on
+    artifactIdAfter = bcpkix-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcmail-jdk15on
+    artifactIdAfter = bcmail-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcjmail-jdk15on
+    artifactIdAfter = bcjmail-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bcpg-jdk15on
+    artifactIdAfter = bcpg-jdk18on
+  },
+  {
+    groupIdAfter = org.bouncycastle
+    artifactIdBefore = bctls-jdk15on
+    artifactIdAfter = bctls-jdk18on
   }
 ]


### PR DESCRIPTION
from https://www.bouncycastle.org/latest_releases.html:

> **Packaging Change (users of 1.70 or earlier):** BC 1.71 changed the jdk15on jars to jdk18on so the base has now moved to Java 8. For earlier JVMs, or containers/applications that cannot cope with multi-release jars, you should now use the jdk15to18 jars.