### PR TITLE
Allow pre-release updates to specific dependencies

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -52,6 +52,12 @@ updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." }
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
+# The dependencies which match the given patterns are allowed to be updated to pre-release from stable.
+#
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will ignore all stable to pre-release update options.
+updates.allowPreReleases  = [ { groupId = "com.example", artifactId="foo" } ]
+
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: None

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -53,6 +53,7 @@ updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." }
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
 # The dependencies which match the given patterns are allowed to be updated to pre-release from stable.
+# This also implies, that it will be allowed for snapshot versions to be updated to snapshots of different series.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will ignore all stable to pre-release update options.

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -243,6 +243,16 @@ class VersionTest extends DisciplineSuite {
         List("0.21.6+99-a0087dd-SNAPSHOT"),
         Some("0.21.6+99-a0087dd-SNAPSHOT")
       ),
+      (
+        "0.21.6+75-6ad94f6f-SNAPSHOT",
+        List("0.21.7+99-a0087dd-SNAPSHOT"),
+        Some("0.21.7+99-a0087dd-SNAPSHOT")
+      ),
+      (
+        "0.21.6+75-6ad94f6f-SNAPSHOT",
+        List("0.22.0+99-a0087dd-SNAPSHOT"),
+        Some("0.22.0+99-a0087dd-SNAPSHOT")
+      ),
       ("0.1.1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-RC1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-ALPHA", List("0.2.1-SNAPSHOT"), None),

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -220,12 +220,49 @@ class VersionTest extends DisciplineSuite {
       ("1.4.12", List("1032048a", "1032048a4c2", "7d2bf0af+20171218-1522"), None),
       ("1.1", List("20000000"), None),
       ("10000000", List("20000000"), Some("20000000")),
-      ("1032048a", List("2032048a4c2"), Some("2032048a4c2"))
+      ("1032048a", List("2032048a4c2"), Some("2032048a4c2")),
+      ("0.1.1-3dfde9d7", List("0.2.1-485fdf3b"), None),
+      ("0.1.1", List("0.2.1-485fdf3b"), None),
+      ("0.1.1-ALPHA", List("0.2.1-485fdf3b"), None),
+      ("0.1.1-ALPHA", List("0.2.1-BETA"), None),
+      ("0.1.1", List("0.2.1-BETA"), None)
     )
 
     val rnd = new Random()
     nextVersions.foreach { case (current, versions, result) =>
       val obtained = Version(current).selectNext(rnd.shuffle(versions).map(Version.apply))
+      assertEquals(obtained, result.map(Version.apply))
+    }
+  }
+
+  test("selectNext, table PreReleases") {
+    val nextVersions = List(
+      ("0.1.1-3dfde9d7", List("0.2.1-485fdf3b"), Some("0.2.1-485fdf3b")),
+      (
+        "0.21.6+75-6ad94f6f-SNAPSHOT",
+        List("0.21.6+99-a0087dd-SNAPSHOT"),
+        Some("0.21.6+99-a0087dd-SNAPSHOT")
+      ),
+      ("0.1.1", List("0.2.1-485fdf3b"), None),
+      ("0.1.1-RC1", List("0.2.1-485fdf3b"), None),
+      ("0.1.1-ALPHA", List("0.2.1-SNAPSHOT"), None),
+      ("0.21.5", List("0.21.6+75-6ad94f6f-SNAPSHOT"), None),
+      ("0.21.6", List("0.21.6+75-6ad94f6f-SNAPSHOT"), None),
+      ("0.21.7", List("0.21.6+75-6ad94f6f-SNAPSHOT"), None),
+      ("0.1.1-RC1", List("0.1.1-RC2"), Some("0.1.1-RC2")),
+      ("0.1.1-RC1", List("0.1.2-RC1"), Some("0.1.2-RC1")),
+      ("0.1.1", List("0.2.1-BETA"), Some("0.2.1-BETA")),
+      ("0.1.1", List("0.2.0-M1"), Some("0.2.0-M1")),
+      ("0.1.1-ALPHA", List("0.2.1-BETA"), Some("0.2.1-BETA")),
+      ("0.1.1-3dfde9d7", List("0.1.2"), Some("0.1.2")),
+      ("0.1.1", List("0.1.2"), Some("0.1.2")),
+      ("0.1.1-RC1", List("0.1.2"), Some("0.1.2")),
+      ("0.1.1-ALPHA", List("0.1.2"), Some("0.1.2"))
+    )
+
+    val rnd = new Random()
+    nextVersions.foreach { case (current, versions, result) =>
+      val obtained = Version(current).selectNext(rnd.shuffle(versions).map(Version.apply), true)
       assertEquals(obtained, result.map(Version.apply))
     }
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -29,7 +29,7 @@ class RepoConfigAlgTest extends FunSuite {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = MockConfig.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
     val content =
-      """|updates.allow  = [ { groupId = "eu.timepit"} ]
+      """|updates.allow  = [ { groupId = "eu.timepit" } ]
          |updates.pin  = [
          |                 { groupId = "eu.timepit", artifactId = "refined.1", version = "0.8." },
          |                 { groupId = "eu.timepit", artifactId = "refined.2", version = { prefix="0.8." } },
@@ -37,6 +37,7 @@ class RepoConfigAlgTest extends FunSuite {
          |                 { groupId = "eu.timepit", artifactId = "refined.4", version = { prefix="0.8.", suffix="jre" } }
          |               ]
          |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
+         |updates.allowPreReleases = [ { groupId = "eu.timepit" } ]
          |updates.limit = 4
          |updates.fileExtensions = [ ".txt" ]
          |pullRequests.frequency = "@weekly"
@@ -74,6 +75,7 @@ class RepoConfigAlgTest extends FunSuite {
           )
         ),
         ignore = List(UpdatePattern("org.acme".g, None, Some(VersionPattern(Some("1.0"))))),
+        allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)),
         limit = Some(NonNegInt.unsafeFrom(4)),
         fileExtensions = Some(List(".txt"))
       ),

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -45,9 +45,20 @@ class FilterAlgTest extends FunSuite {
     )
   }
 
-  test("localFilter: update to pre-release of a different series") {
+  test("localFilter: update to pre-releases of a different series") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("2.0.1-M3")).single
     assertEquals(localFilter(update, config), Left(NoSuitableNextVersion(update)))
+  }
+
+  test("localFilter: allowed update to pre-releases of a different series") {
+    val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("2.0.1-M3")).single
+    val allowedPreReleases =
+      UpdatePattern("com.jsuereth".g, Some("sbt-pgp"), None) :: config.updates.allowPreReleases
+    val configWithAllowed =
+      config.copy(updates = config.updates.copy(allowPreReleases = allowedPreReleases))
+
+    val expected = Right(update.copy(newerVersions = Nel.of("2.0.1-M3".v)))
+    assertEquals(localFilter(update, configWithAllowed), expected)
   }
 
   test("ignore update via config updates.ignore") {


### PR DESCRIPTION
Fixes #2634 

Added dedicated configuration, which alters pre-release version checks for specified dependencies.

Similar features has been mentioned there https://github.com/scala-steward-org/scala-steward/issues/1023#issuecomment-551942307