### PR TITLE
Tag latest docker image with latest-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -325,6 +325,9 @@ lazy val dockerSettings = Def.settings(
   },
   Docker / packageName := s"fthomas/${name.value}",
   dockerUpdateLatest := true,
+  dockerAliases ++= {
+    if (!isSnapshot.value) Seq(dockerAlias.value.withTag(Option("latest-release"))) else Nil
+  },
   dockerEnvVars := Map(
     "PATH" -> "/opt/docker/sbt/bin:${PATH}",
     "COURSIER_PROGRESS" -> "false"


### PR DESCRIPTION
Closes #2613 

Tag the latest stable docker image with `latest-release`, see https://www.scala-sbt.org/sbt-native-packager/formats/docker.html#publishing-settings