### PR TITLE
Change commit message of hook that runs 'sbt githubWorkflowGenerate'

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -124,19 +124,17 @@ object HookExecutor {
       groupId: GroupId,
       artifactId: ArtifactId,
       enabledByCache: RepoCache => Boolean
-  ): PostUpdateHook = {
-    val task = "githubWorkflowGenerate"
+  ): PostUpdateHook =
     PostUpdateHook(
       groupId = Some(groupId),
       artifactId = Some(artifactId),
-      command = Nel.of("sbt", task),
+      command = Nel.of("sbt", "githubWorkflowGenerate"),
       useSandbox = true,
-      commitMessage = _ => CommitMsg(s"Regenerate workflow with 'sbt $task'"),
+      commitMessage = _ => CommitMsg(s"Regenerate GitHub Actions workflow"),
       enabledByCache = enabledByCache,
       enabledByConfig = _ => true,
       addToGitBlameIgnoreRevs = false
     )
-  }
 
   private val scalafmtHook =
     PostUpdateHook(

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -130,7 +130,7 @@ object HookExecutor {
       artifactId = Some(artifactId),
       command = Nel.of("sbt", "githubWorkflowGenerate"),
       useSandbox = true,
-      commitMessage = _ => CommitMsg(s"Regenerate GitHub Actions workflow"),
+      commitMessage = _ => CommitMsg("Regenerate GitHub Actions workflow"),
       enabledByCache = enabledByCache,
       enabledByConfig = _ => true,
       addToGitBlameIgnoreRevs = false

--- a/repos.md
+++ b/repos.md
@@ -3,5 +3,7 @@ The format is "- $owner/$repo".
 If you want Scala Steward to keep a non-default branch up-to-date, use "- $owner/$repo:$branch".
 All lines that do not start with a hyphen and space are ignored.
 
-
-- scala-steward-org/test-repo-2:2655
+- scala-steward-org/scala-steward
+- scala-steward-org/test-repo-2
+- scala-steward-org/test-repo-2:slash-syntax-2
+- scala-steward-org/test-repo-2:test-branch


### PR DESCRIPTION
New message:
```
Regenerate GitHub Actions workflow

Executed command: sbt githubWorkflowGenerate
```
Old message:
```
Regenerate workflow with sbt-github-actions

Executed command: sbt githubWorkflowGenerate
```

The rationale for changing the message is that Scala Steward also runs
this task if the project does not depend on sbt-github-actions but on a
plugin that provides the `githubWorkflowGenerate` task. For example,
sbt-typelevel provides [this task](https://github.com/typelevel/sbt-typelevel/blob/b2cabecd3441d6292a186b62d87892f3796ca17b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala#L23-L24) and does not depend on
sbt-github-actions. So the old message is misleading in this case.