### PR TITLE
Add sha1 field to Commit case class

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/Commit.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Commit.scala
@@ -16,4 +16,4 @@
 
 package org.scalasteward.core.git
 
-final case class Commit()
+final case class Commit(sha1: Sha1)

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -18,13 +18,11 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration.FiniteDuration
 
 object TestInstances {
+  val dummySha1: Sha1 =
+    Sha1(HexString.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709"))
+
   val dummyRepoCache: RepoCache =
-    RepoCache(
-      Sha1(HexString.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709")),
-      List.empty,
-      Option.empty,
-      Option.empty
-    )
+    RepoCache(dummySha1, List.empty, Option.empty, Option.empty)
 
   val dummyRepoCacheWithParsingError: RepoCache =
     dummyRepoCache.copy(maybeRepoConfigParsingError = Some("Failed to parse .scala-steward.conf"))

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.edit.hooks
 
 import cats.syntax.all._
 import munit.CatsEffectSuite
-import org.scalasteward.core.TestInstances.dummyRepoCache
+import org.scalasteward.core.TestInstances.{dummyRepoCache, dummySha1}
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.RepoData
 import org.scalasteward.core.git.FileGitAlg
@@ -33,7 +33,9 @@ class HookExecutorTest extends CatsEffectSuite {
       Map(
         FileGitAlg.gitCmd.toList ++
           List("status", "--porcelain", "--untracked-files=no", "--ignore-submodules") ->
-          List("build.sbt")
+          List("build.sbt"),
+        FileGitAlg.gitCmd.toList ++ List("rev-parse", "--verify", "HEAD") ->
+          List(dummySha1.value.value)
       )
     )
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(initial)
@@ -60,7 +62,8 @@ class HookExecutorTest extends CatsEffectSuite {
           "--no-gpg-sign",
           "-m",
           "Reformat with scalafmt 2.7.5"
-        )
+        ),
+        Cmd(gitCmd(repoDir), "rev-parse", "--verify", "HEAD")
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -9,7 +9,7 @@ import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{ReleaseRelatedUrl, RepoData, UpdateData, Version}
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
-import org.scalasteward.core.git.{Branch, Commit, Sha1}
+import org.scalasteward.core.git.{Branch, Commit}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.NewPullRequestData._
@@ -21,7 +21,7 @@ class NewPullRequestDataTest extends FunSuite {
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
-      Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
+      dummySha1,
       Branch("update/logback-classic-1.2.3")
     )
     val obtained = from(data, "scala-steward:update/logback-classic-1.2.3").asJson.spaces2
@@ -52,7 +52,7 @@ class NewPullRequestDataTest extends FunSuite {
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
-      Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
+      dummySha1,
       Branch("update/logback-classic-1.2.3")
     )
     val obtained = from(data, "scala-steward:update/logback-classic-1.2.3").asJson.spaces2
@@ -143,7 +143,7 @@ class NewPullRequestDataTest extends FunSuite {
         Nel.of("I am a rewrite rule")
       ),
       Right(()),
-      Some(Commit())
+      Some(Commit(dummySha1))
     )
     val edits = List(scalafixEdit)
     val appliedMigrations = migrationNote(edits)
@@ -173,7 +173,7 @@ class NewPullRequestDataTest extends FunSuite {
         Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
-      Some(Commit())
+      Some(Commit(dummySha1))
     )
     val edits = List(scalafixEdit)
     val detail = migrationNote(edits)
@@ -205,7 +205,7 @@ class NewPullRequestDataTest extends FunSuite {
         Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
-      Some(Commit())
+      Some(Commit(dummySha1))
     )
     val scalafixEdit2 = ScalafixEdit(
       ScalafixMigration(
@@ -288,7 +288,7 @@ class NewPullRequestDataTest extends FunSuite {
 
   test("commit-count label") {
     val update = ("a".g % "b".a % "1" -> "2").single
-    val updateEdit = UpdateEdit(update, Commit())
+    val updateEdit = UpdateEdit(update, Commit(dummySha1))
     val scalafixEdit = ScalafixEdit(
       ScalafixMigration(
         "com.spotify".g,
@@ -298,7 +298,7 @@ class NewPullRequestDataTest extends FunSuite {
         Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
-      Some(Commit())
+      Some(Commit(dummySha1))
     )
 
     val oneEdit = labelsFor(update, List(updateEdit), List.empty)


### PR DESCRIPTION
This could probably be used for implementing #2567. In the `HookExecutor` we could take the sha1 of the formatting commit and add it to `.git-blame-ignore-revs`.