### PR TITLE
Add command to the commit message of post-update hooks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -65,7 +65,9 @@ final class HookExecutor[F[_]](implicit
       result <- logger.attemptWarn.log("Post-update hook failed") {
         processAlg.execMaybeSandboxed(hook.useSandbox)(hook.command, repoDir)
       }
-      commitMessage = hook.commitMessage(update)
+      commitMessage = hook
+        .commitMessage(update)
+        .withParagraph(s"Executed command: ${hook.command.mkString_(" ")}")
       maybeHookCommit <- gitAlg.commitAllIfDirty(repo, commitMessage)
       maybeBlameIgnoreCommit <-
         maybeHookCommit.flatTraverse(addToGitBlameIgnoreRevs(repo, repoDir, hook, _, commitMessage))

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -29,6 +29,9 @@ final case class CommitMsg(
   def toNel: Nel[String] =
     Nel(title, body ++ trailers)
 
+  def withParagraph(paragraph: String): CommitMsg =
+    copy(body = body :+ paragraph)
+
   private def trailers: Option[String] = {
     val lines = coAuthoredBy.map(author => s"Co-authored-by: ${author.show}")
     Nel.fromList(lines).map(_.mkString_("\n"))

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -64,7 +64,9 @@ class HookExecutorTest extends CatsEffectSuite {
           "--all",
           "--no-gpg-sign",
           "-m",
-          "Reformat with scalafmt 2.7.5"
+          "Reformat with scalafmt 2.7.5",
+          "-m",
+          s"Executed command: $scalafmtBinary ${opts.nonInteractive}"
         ),
         Cmd(gitCmd(repoDir), "rev-parse", "--verify", "HEAD"),
         Cmd("read", gitBlameIgnoreRevs.pathAsString),


### PR DESCRIPTION
This adds the executed command of post-update hooks to their commit
message. It makes it obvious what Scala Steward did and is helpful for
users who want to reproduce the changes themselves.