### PR TITLE
A CLI command to validate repo configs 

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -3,7 +3,9 @@
 All command line arguments for the `scala-steward` application.
 
 ```
-Usage: scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>] [--default-maven-repo <string>] [--refresh-backoff-period <duration>] [--validate-repo-config <file>]
+Usage:
+    scala-steward validate-repo-config
+    scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>] [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
 
 
 
@@ -78,6 +80,8 @@ Options and flags:
         default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>
         Period of time a failed build won't be triggered again; default: 0days
-    --validate-repo-config <file>
+
+Subcommands:
+    validate-repo-config
         Validate the repo config file and exit; report errors if any
 ```

--- a/docs/help.md
+++ b/docs/help.md
@@ -3,7 +3,7 @@
 All command line arguments for the `scala-steward` application.
 
 ```
-Usage: scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>] [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
+Usage: scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>] [--default-maven-repo <string>] [--refresh-backoff-period <duration>] [--validate-repo-config <file>]
 
 
 
@@ -78,4 +78,6 @@ Options and flags:
         default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>
         Period of time a failed build won't be triggered again; default: 0days
+    --validate-repo-config <file>
+        Validate the repo config file and exit; report errors if any
 ```

--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -19,9 +19,7 @@ package org.scalasteward.core
 import cats.effect.std.Console
 import cats.effect.{ExitCode, IO, IOApp}
 import org.scalasteward.core.application.{Cli, Context}
-import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult.Ok
-import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult.FileDoesNotExist
-import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult.ConfigIsInvalid
+import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult
 
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
@@ -34,15 +32,15 @@ object Main extends IOApp {
               case None => ctx.stewardAlg.runF
               case Some(file) =>
                 ctx.validateRepoConfigAlg.validateConfigFile(file).flatMap {
-                  case Ok =>
+                  case ConfigValidationResult.Ok =>
                     Console[IO]
                       .println(s"Configuration file at $file is valid.")
                       .as(ExitCode.Success)
-                  case FileDoesNotExist =>
+                  case ConfigValidationResult.FileDoesNotExist =>
                     Console[IO]
                       .println(s"Configuration file at $file does not exist!")
                       .as(ExitCode.Error)
-                  case ConfigIsInvalid(err) =>
+                  case ConfigValidationResult.ConfigIsInvalid(err) =>
                     Console[IO]
                       .println(s"Configuration file at $file contains errors:\n  $err")
                       .as(ExitCode.Error)

--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -19,27 +19,12 @@ package org.scalasteward.core
 import cats.effect.std.Console
 import cats.effect.{ExitCode, IO, IOApp}
 import org.scalasteward.core.application.{Cli, Context}
-import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg
 
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     Cli.parseArgs(args) match {
-      case Cli.ParseResult.Success(config) =>
-        Context
-          .step0[IO](config)
-          .use(ctx =>
-            config.validateRepoConfig match {
-              case None => ctx.stewardAlg.runF
-              case Some(file) =>
-                ctx.validateRepoConfigAlg.validateConfigFile(file).flatMap { result =>
-                  ValidateRepoConfigAlg.presentValidationResult(file)(result) match {
-                    case Left(errMsg) => Console[IO].println(errMsg).as(ExitCode.Error)
-                    case Right(okMsg) => Console[IO].println(okMsg).as(ExitCode.Success)
-                  }
-                }
-            }
-          )
-      case Cli.ParseResult.Help(help)   => Console[IO].println(help).as(ExitCode.Success)
-      case Cli.ParseResult.Error(error) => Console[IO].errorln(error).as(ExitCode.Error)
+      case Cli.ParseResult.Success(config) => Context.step0[IO](config).use(_.runF)
+      case Cli.ParseResult.Help(help)      => Console[IO].println(help).as(ExitCode.Success)
+      case Cli.ParseResult.Error(error)    => Console[IO].errorln(error).as(ExitCode.Error)
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -257,6 +257,12 @@ object Cli {
       .withDefault(default)
   }
 
+  private val validateRepoConfig: Opts[Option[File]] =
+    option[File](
+      long = "validate-repo-config",
+      help = "validate the repo config file and exit, report errors if any"
+    ).orNone
+
   private val configOpts: Opts[Config] = (
     workspace,
     reposFile,
@@ -273,7 +279,8 @@ object Cli {
     gitHubApp,
     urlCheckerTestUrl,
     defaultMavenRepo,
-    refreshBackoffPeriod
+    refreshBackoffPeriod,
+    validateRepoConfig
   ).mapN(Config.apply)
 
   val command: Command[Config] =

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -260,7 +260,7 @@ object Cli {
   private val validateRepoConfig: Opts[Option[File]] =
     option[File](
       long = "validate-repo-config",
-      help = "validate the repo config file and exit, report errors if any"
+      help = "Validate the repo config file and exit; report errors if any"
     ).orNone
 
   private val configOpts: Opts[Config] = (

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -68,7 +68,8 @@ final case class Config(
     githubApp: Option[GitHubApp],
     urlCheckerTestUrl: Uri,
     defaultResolver: Resolver,
-    refreshBackoffPeriod: FiniteDuration
+    refreshBackoffPeriod: FiniteDuration,
+    validateRepoConfig: Option[File]
 ) {
   def vcsUser[F[_]](implicit
       processAlg: ProcessAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -68,8 +68,7 @@ final case class Config(
     githubApp: Option[GitHubApp],
     urlCheckerTestUrl: Uri,
     defaultResolver: Resolver,
-    refreshBackoffPeriod: FiniteDuration,
-    validateRepoConfig: Option[File]
+    refreshBackoffPeriod: FiniteDuration
 ) {
   def vcsUser[F[_]](implicit
       processAlg: ProcessAlg[F],
@@ -136,4 +135,10 @@ object Config {
   final case class GitLabCfg(
       mergeWhenPipelineSucceeds: Boolean
   )
+
+  sealed trait StewardUsage
+  object StewardUsage {
+    final case class Regular(config: Config) extends StewardUsage
+    final case class ValidateRepoConfig(file: File) extends StewardUsage
+  }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -37,7 +37,7 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository}
 import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
 import org.scalasteward.core.repocache._
-import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader}
+import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader, ValidateRepoConfigAlg}
 import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.update.artifact.{ArtifactMigrationsFinder, ArtifactMigrationsLoader}
 import org.scalasteward.core.update.{FilterAlg, PruningAlg, UpdateAlg}
@@ -73,7 +73,8 @@ final class Context[F[_]](implicit
     val stewardAlg: StewardAlg[F],
     val updateAlg: UpdateAlg[F],
     val vcsRepoAlg: VCSRepoAlg[F],
-    val workspaceAlg: WorkspaceAlg[F]
+    val workspaceAlg: WorkspaceAlg[F],
+    val validateRepoConfigAlg: ValidateRepoConfigAlg[F]
 )
 
 object Context {
@@ -178,6 +179,7 @@ object Context {
       implicit val gitHubAppApiAlg: GitHubAppApiAlg[F] =
         new GitHubAppApiAlg[F](config.vcsCfg.apiHost)
       implicit val stewardAlg: StewardAlg[F] = new StewardAlg[F](config)
+      implicit val validateRepoConfigAlg: ValidateRepoConfigAlg[F] = new ValidateRepoConfigAlg[F]
       new Context[F]
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -25,8 +25,7 @@ import org.scalasteward.core.io.FileAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 
 import ValidateRepoConfigAlg._
-import io.circe.{DecodingFailure, ParsingFailure}
-import io.circe.CursorOp
+import io.circe.{CursorOp, DecodingFailure, ParsingFailure}
 
 final class ValidateRepoConfigAlg[F[_]](implicit
     fileAlg: FileAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -1,0 +1,36 @@
+package org.scalasteward.core.repoconfig
+
+import cats.MonadThrow
+import cats.syntax.all._
+import better.files.File
+import org.scalasteward.core.io.FileAlg
+import org.scalasteward.core.repoconfig.RepoConfigAlg
+import ValidateRepoConfigAlg._
+
+final class ValidateRepoConfigAlg[F[_]](implicit
+    fileAlg: FileAlg[F],
+    F: MonadThrow[F]
+) {
+
+  def validateConfigFile(configFile: File): F[ConfigValidationResult] =
+    fileAlg.readFile(configFile).map {
+      case Some(content) => validateContent(content)
+      case None          => ConfigValidationResult.FileDoesNotExist
+    }
+}
+
+object ValidateRepoConfigAlg {
+  sealed trait ConfigValidationResult
+
+  object ConfigValidationResult {
+    case object FileDoesNotExist extends ConfigValidationResult
+    case class ConfigIsInvalid(err: io.circe.Error) extends ConfigValidationResult
+    case object Ok extends ConfigValidationResult
+  }
+
+  def validateContent(content: String): ConfigValidationResult =
+    RepoConfigAlg.parseRepoConfig(content) match {
+      case Left(err) => ConfigValidationResult.ConfigIsInvalid(err)
+      case Right(_)  => ConfigValidationResult.Ok
+    }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -30,7 +30,7 @@ import io.circe.{CursorOp, DecodingFailure, ParsingFailure}
 final class ValidateRepoConfigAlg[F[_]](implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
-    monadThrowF: MonadThrow[F]
+    F: MonadThrow[F]
 ) {
 
   def validateConfigFile(configFile: File): F[ConfigValidationResult] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -16,11 +16,12 @@
 
 package org.scalasteward.core.repoconfig
 
+import better.files.File
 import cats.MonadThrow
 import cats.syntax.all._
-import better.files.File
 import org.scalasteward.core.io.FileAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
+
 import ValidateRepoConfigAlg._
 
 final class ValidateRepoConfigAlg[F[_]](implicit
@@ -48,5 +49,17 @@ object ValidateRepoConfigAlg {
     RepoConfigAlg.parseRepoConfig(content) match {
       case Left(err) => ConfigValidationResult.ConfigIsInvalid(err)
       case Right(_)  => ConfigValidationResult.Ok
+    }
+
+  def presentValidationResult(
+      configFile: File
+  )(result: ConfigValidationResult): Either[String, String] =
+    result match {
+      case ConfigValidationResult.Ok =>
+        s"Configuration file at $configFile is valid.".asRight
+      case ConfigValidationResult.FileDoesNotExist =>
+        s"Configuration file at $configFile does not exist!".asLeft
+      case ConfigValidationResult.ConfigIsInvalid(err) =>
+        s"Configuration file at $configFile contains errors:\n  $err".asLeft
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalasteward.core.repoconfig
 
 import cats.MonadThrow

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -8,12 +8,13 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.Cli.ParseResult._
 import org.scalasteward.core.vcs.VCSType
 import org.scalasteward.core.vcs.github.GitHubApp
+import org.scalasteward.core.application.Config.StewardUsage
 
 import scala.concurrent.duration._
 
 class CliTest extends FunSuite {
   test("parseArgs: example") {
-    val Success(obtained) = Cli.parseArgs(
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -32,8 +33,7 @@ class CliTest extends FunSuite {
         List("--repo-config", "/opt/scala-steward/scala-steward.conf"),
         List("--github-app-id", "12345678"),
         List("--github-app-key-file", "example_app_key"),
-        List("--refresh-backoff-period", "1 day"),
-        List("--validate-repo-config", "config.conf")
+        List("--refresh-backoff-period", "1 day")
       ).flatten
     )
 
@@ -62,11 +62,10 @@ class CliTest extends FunSuite {
     )
     assertEquals(obtained.githubApp, Some(GitHubApp(12345678L, File("example_app_key"))))
     assertEquals(obtained.refreshBackoffPeriod, 1.day)
-    assertEquals(obtained.validateRepoConfig, Some(File("config.conf")))
   }
 
   test("parseArgs: minimal example") {
-    val Success(obtained) = Cli.parseArgs(
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -85,7 +84,7 @@ class CliTest extends FunSuite {
   }
 
   test("parseArgs: enable sandbox") {
-    val Success(obtained) = Cli.parseArgs(
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -116,7 +115,7 @@ class CliTest extends FunSuite {
   }
 
   test("parseArgs: disable sandbox") {
-    val Success(obtained) = Cli.parseArgs(
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -144,6 +144,16 @@ class CliTest extends FunSuite {
     assert(clue(obtained).startsWith("Usage"))
   }
 
+  test("parseArgs: validate-repo-config") {
+    val Success(StewardUsage.ValidateRepoConfig(file)) = Cli.parseArgs(
+      List(
+        List("validate-repo-config", "file.conf")
+      ).flatten
+    )
+
+    assertEquals(file, File("file.conf"))
+  }
+
   test("envVarArgument: env-var without equals sign") {
     assert(clue(Cli.envVarArgument.read("SBT_OPTS")).isInvalid)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -32,7 +32,8 @@ class CliTest extends FunSuite {
         List("--repo-config", "/opt/scala-steward/scala-steward.conf"),
         List("--github-app-id", "12345678"),
         List("--github-app-key-file", "example_app_key"),
-        List("--refresh-backoff-period", "1 day")
+        List("--refresh-backoff-period", "1 day"),
+        List("--validate-repo-config", "config.conf")
       ).flatten
     )
 
@@ -61,6 +62,7 @@ class CliTest extends FunSuite {
     )
     assertEquals(obtained.githubApp, Some(GitHubApp(12345678L, File("example_app_key"))))
     assertEquals(obtained.refreshBackoffPeriod, 1.day)
+    assertEquals(obtained.validateRepoConfig, Some(File("config.conf")))
   }
 
   test("parseArgs: minimal example") {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -21,7 +21,7 @@ object MockConfig {
     "--cache-ttl=1hour",
     "--refresh-backoff-period=1hour"
   )
-  val Success(config: Config) = Cli.parseArgs(args)
+  val Success(Config.StewardUsage.Regular(config)) = Cli.parseArgs(args)
   val envVars = List(s"GIT_ASKPASS=${config.gitCfg.gitAskPass}", "VAR1=val1", "VAR2=val2")
   def gitCmd(repoDir: File): List[String] =
     envVars ++ (repoDir.toString :: FileGitAlg.gitCmd.toList)

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,9 +1,11 @@
 package org.scalasteward.core.mock
 
+import better.files.File
 import cats.effect.unsafe.implicits.global
 import org.http4s.HttpApp
 import org.http4s.client.Client
 import org.scalasteward.core.application.Context
+import org.scalasteward.core.application.Context.StewardContext
 import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.io._
@@ -31,4 +33,6 @@ object MockContext {
   )
 
   val context: Context[MockEff] = mockState.toRef.flatMap(Context.step1(config).run).unsafeRunSync()
+  def validateRepoConfigContext(file: File): StewardContext.ValidateRepoConfig[MockEff] =
+    Context.initValidateRepoConfig(file)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -11,7 +11,7 @@ import java.nio.file.Files
 class ValidateRepoConfigAlgTest extends munit.FunSuite {
 
   def configFile(content: String) = FunFixture[(File, ConfigValidationResult)](
-    setup = _ => {
+    setup = { _ =>
       val tmpFile =
         File(
           Files.write(
@@ -20,7 +20,9 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
           )
         )
 
-      val obtained = MockContext.context.validateRepoConfigAlg
+      val obtained = MockContext
+        .validateRepoConfigContext(tmpFile)
+        .validateRepoConfigAlg
         .validateConfigFile(tmpFile)
         .runA(MockState.empty)
         .unsafeRunSync()
@@ -63,9 +65,11 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
     }
 
   test("rejects non-existent config file") {
-    // I am pretty sure this fails in Windows
-    val obtained = MockContext.context.validateRepoConfigAlg
-      .validateConfigFile(File("/", "scripts", "script"))
+    val nonExistentFile = File("/", "scripts", "script")
+    val obtained = MockContext
+      .validateRepoConfigContext(nonExistentFile)
+      .validateRepoConfigAlg
+      .validateConfigFile(nonExistentFile)
       .runA(MockState.empty)
       .unsafeRunSync()
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -2,8 +2,7 @@ package org.scalasteward.core.repoconfig
 
 import better.files.File
 import cats.effect.unsafe.implicits.global
-import org.scalasteward.core.mock.MockContext
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockContext, MockState}
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
 import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -3,9 +3,10 @@ package org.scalasteward.core.repoconfig
 import better.files.File
 import cats.effect.unsafe.implicits.global
 import org.scalasteward.core.mock.{MockContext, MockState}
-import java.nio.file.Files
-import java.nio.charset.StandardCharsets
 import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 class ValidateRepoConfigAlgTest extends munit.FunSuite {
 
@@ -32,45 +33,45 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
   )
 
   configFile(
-    """|updates.pin  =? [
-       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
-       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
-       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." },
-       |]""".stripMargin
-  )
-    .test("rejects invalid config") { case (_, obtained) =>
-      obtained match {
-        case ConfigValidationResult.ConfigIsInvalid(_) => assert(true)
-        case other => fail(s"Invalid config was accepted with: $other")
-      }
-
-    }
-
-  configFile(
     """|updates.pin = [
        |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
        |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
        |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
        |]""".stripMargin
   )
-    .test("accepts valid config") { case (_, obtained) =>
-      obtained match {
-        case ConfigValidationResult.Ok => assert(true)
-        case other =>
-          fail(s"Valid config was rejected with: $other")
-      }
+    .test("accepts valid config") { case (file, obtained) =>
+      assertEquals(
+        ValidateRepoConfigAlg.presentValidationResult(file)(obtained),
+        Right(s"Configuration file at $file is valid.")
+      )
+    }
+
+  configFile(
+    """|updates.pin  =? [
+       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." },
+       |]""".stripMargin
+  )
+    .test("rejects invalid config") { case (file, obtained) =>
+      val ConfigValidationResult.ConfigIsInvalid(err) = obtained
+      assertEquals(
+        ValidateRepoConfigAlg.presentValidationResult(file)(obtained),
+        Left(s"Configuration file at $file contains errors:\n  $err")
+      )
+
     }
 
   test("rejects non-existent config file") {
+    // I am pretty sure this fails in Windows
     val obtained = MockContext.context.validateRepoConfigAlg
-      .validateConfigFile(File("scripts", "script"))
+      .validateConfigFile(File("/", "scripts", "script"))
       .runA(MockState.empty)
       .unsafeRunSync()
 
-    obtained match {
-      case ConfigValidationResult.FileDoesNotExist => assert(true)
-      case other => fail(s"Non existent file was accepted with: $other")
-    }
-
+    assertEquals(
+      ValidateRepoConfigAlg.presentValidationResult(File("/", "scripts", "script"))(obtained),
+      Left(s"Configuration file at /scripts/script does not exist!")
+    )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala.scala
@@ -1,0 +1,77 @@
+package org.scalasteward.core.repoconfig
+
+import better.files.File
+import cats.effect.unsafe.implicits.global
+import org.scalasteward.core.mock.MockContext
+import org.scalasteward.core.mock.MockState
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg.ConfigValidationResult
+
+class ValidateRepoConfigAlgTest extends munit.FunSuite {
+
+  def configFile(content: String) = FunFixture[(File, ConfigValidationResult)](
+    setup = _ => {
+      val tmpFile =
+        File(
+          Files.write(
+            Files.createTempFile(".scala-steward", ".conf"),
+            content.getBytes(StandardCharsets.UTF_8)
+          )
+        )
+
+      val obtained = MockContext.context.validateRepoConfigAlg
+        .validateConfigFile(tmpFile)
+        .runA(MockState.empty)
+        .unsafeRunSync()
+
+      (tmpFile, obtained)
+    },
+    teardown = { case (file, _) =>
+      file.delete()
+    }
+  )
+
+  configFile(
+    """|updates.pin  =? [
+       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." },
+       |]""".stripMargin
+  )
+    .test("rejects invalid config") { case (_, obtained) =>
+      obtained match {
+        case ConfigValidationResult.ConfigIsInvalid(_) => assert(true)
+        case other => fail(s"Invalid config was accepted with: $other")
+      }
+
+    }
+
+  configFile(
+    """|updates.pin = [
+       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
+       |]""".stripMargin
+  )
+    .test("accepts valid config") { case (_, obtained) =>
+      obtained match {
+        case ConfigValidationResult.Ok => assert(true)
+        case other =>
+          fail(s"Valid config was rejected with: $other")
+      }
+    }
+
+  test("rejects non-existent config file") {
+    val obtained = MockContext.context.validateRepoConfigAlg
+      .validateConfigFile(File("scripts", "script"))
+      .runA(MockState.empty)
+      .unsafeRunSync()
+
+    obtained match {
+      case ConfigValidationResult.FileDoesNotExist => assert(true)
+      case other => fail(s"Non existent file was accepted with: $other")
+    }
+
+  }
+}


### PR DESCRIPTION
Attempt to solve #2638. Can be invoked like this (as a subcommand):
```
java -jar scala-steward-assembly-VERSION.jar validate-repo-config .scala-steward.conf
```
Sample input (with error):
`.scala-steward.conf`:
```ini
updatePullRequests = 123
```

Output:
```python
2022-07-12 11:17:08,589 ERROR Configuration file at /home/nikololiahim/scala/scala-steward/.scala-steward.conf contains errors:
  Decoding failed with:
    Got value '123' with wrong type, expecting string:
      updatePullRequests
```