### PR TITLE
Advertize VirtusLab's public Scala Steward instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ See also the announcement blog post:
 
 ## Quick start guide
 
-Open a pull request that adds the GitHub, GitLab, or Bitbucket repository of your Scala project
-to [repos-github.md](https://github.com/scala-steward-org/repos/blob/main/repos-github.md)
-([edit](https://github.com/scala-steward-org/repos/edit/main/repos-github.md)).
-Once that PR is merged, [**@scala-steward**][@scala-steward] will check
-periodically for version number updates in your project and will
-open pull requests for updates it found.
+Open a pull request that adds the GitHub repository of your project to [repos-github.md](https://github.com/VirtusLab/scala-steward-repos/blob/main/repos-github.md) ([edit](https://github.com/VirtusLab/scala-steward-repos/edit/main/repos-github.md)).
+Once that PR is merged, [**@scala-steward**][@scala-steward] will check periodically for version updates in your project and will open pull requests for updates it found.
+
+Many thanks to [VirtusLab][VirtusLab] for hosting and managing this public Scala Steward instance!
 
 ## Show us the pull requests!
 
@@ -214,3 +212,4 @@ Scala Steward is licensed under the
 [CoC]: https://github.com/scala-steward-org/scala-steward/blob/master/CODE_OF_CONDUCT.md
 [@scala-steward]: https://github.com/scala-steward
 [sbt-updates]: https://github.com/rtimush/sbt-updates
+[VirtusLab]: https://www.virtuslab.com

--- a/repos.md
+++ b/repos.md
@@ -1,4 +1,7 @@
-List the repositories here you want Scala Steward to keep up-to-date.
+The repos.md file for the public Scala Steward instance hosted by [VirtusLab](https://www.virtuslab.com/) is at <https://github.com/VirtusLab/scala-steward-repos/blob/main/repos-github.md>.
+If you want [@scala-steward](https://github.com/scala-steward) to keep your project up-to-date, please add it there.
+
+List the repositories here you want your own Scala Steward to keep up-to-date.
 The format is "- $owner/$repo".
 If you want Scala Steward to keep a non-default branch up-to-date, use "- $owner/$repo:$branch".
 All lines that do not start with a hyphen and space are ignored.


### PR DESCRIPTION
This points users to https://github.com/VirtusLab/scala-steward-repos
instead of the now archived https://github.com/scala-steward-org/repos.

Many thanks again to VirtusLab for hosting the public instance!

/cc @romanowski @Kordyjan @pikinier20