### PR TITLE
Scalafix rewrites via dependency when target="build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Consider creating PR to add your company to the list and join the community.
 * [Teads](https://medium.com/teads-engineering)
 * [Tegonal GmbH](https://tegonal.com)
 * [Tupl](https://www.tupl.com)
+* [VirtusLab](https://virtuslab.com/)
 * [wehkamp](https://www.wehkamp.nl/)
 * [Zalando](https://en.zalando.de/)
 


### PR DESCRIPTION
All our Scalafix migrations are in private repos. By using the "dependency:" prefix in rewrite rule definitions, Scala Steward leverages Coursier to resolve these from our private artifactory. But this only seems to work when the `target="sources"` (default). 

I'm attempting to create a new rewrite for SBT files by using `target="build"` and I am unable to fetch these rules from our artifactory. It appears the issue is that, where `"sources"` uses the Scalafix SBT plugin, `"build"` uses the Scalafix CLI, and the CLI does not support the "dependency:" prefix for rules. The [Scalafix docs](https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#publish-the-rule-to-maven-central) indicate that "Users of the Scalafix command-line interface can use the `--tool-classpath` flag" to use published artifacts.

If there is a better way to achieve this through configuration, environment variables, etc., that would be amazing. But I haven't been able to work out how to do that, and without it, I'm thinking a change like this might solve the problem. Looking for feedback and guidance on this approach. Basically it would keep existing `target="build"` rules using `https`, `github`, `file`, etc. unchanged, but would reinterpret rules specified in the form `dependency:ruleName@repo::artifact:version` to be `ruleName --tool-classpath $(cs fetch repo::artifact:version -p)`, consistent with the Scalafix documentation linked above.

If I'm on the right track here, I'd be happy to update documentation and write a couple tests.