### PR TITLE
Add sbt-typelevel-github-actions to sbtGitHubWorkflowGenerateModules

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -105,6 +105,7 @@ object HookExecutor {
     (GroupId("io.chrisdavenport"), ArtifactId("sbt-davenverse")),
     (GroupId("io.github.nafg.mergify"), ArtifactId("sbt-mergify-github-actions")),
     (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-ci-release")),
+    (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-github-actions")),
     (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-mergify"))
   )
 


### PR DESCRIPTION
If the `sbt-typelevel-github-actions` plugin is used directly, we want pull requests to run `githubWorkflowGenerate`.