### PR TITLE
feat: add ability to detect Mill plugins

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -55,7 +55,11 @@ final class MillAlg[F[_]](implicit
       millBuildDeps = millBuildVersion.toSeq.map(version =>
         Scope(List(millMainArtifact(version)), List(millMainResolver))
       )
-    } yield dependencies ++ millBuildDeps
+      millPluginDeps <- millBuildVersion match {
+        case None        => F.pure(Seq.empty[Scope[List[Dependency]]])
+        case Some(value) => getMillPluginDeps(value, buildRootDir)
+      }
+    } yield dependencies ++ millBuildDeps ++ millPluginDeps
 
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     F.unit
@@ -65,6 +69,17 @@ final class MillAlg[F[_]](implicit
       millVersionFileContent <- fileAlg.readFile(buildRootDir / ".mill-version")
       version = millVersionFileContent.flatMap(parser.parseMillVersion)
     } yield version
+
+  private def getMillPluginDeps(
+      millVersion: Version,
+      buildRootDir: File
+  ): F[Seq[Scope[List[Dependency]]]] =
+    for {
+      buildConent <- fileAlg.readFile(buildRootDir / "build.sc")
+      deps = buildConent.toList.map(content =>
+        Scope(parser.parseMillPluginDeps(content, millVersion), List(millMainResolver))
+      )
+    } yield deps
 }
 
 object MillAlg {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
@@ -19,6 +19,11 @@ package org.scalasteward.core.buildtool.mill
 import cats.syntax.all._
 import io.circe.{Decoder, DecodingFailure}
 import org.scalasteward.core.data.{Dependency, Resolver, Version}
+import cats.parse.Parser
+import cats.parse.Rfc5234.sp
+import org.scalasteward.core.data.GroupId
+import org.scalasteward.core.data.ArtifactId
+import scala.util.Try
 
 object parser {
   sealed trait ParseError extends RuntimeException {
@@ -43,6 +48,67 @@ object parser {
   def parseMillVersion(s: String): Option[Version] =
     Option(s.trim).filter(_.nonEmpty).map(Version.apply)
 
+  /**
+    * Used to correctly format the Mill plugin artifacts will when included look like:
+    * - import $ivy.`com.goyeau::mill-scalafix::0.2.10`
+    * However for the actual artifact if the user is on 0.10.x will look like:
+    * - mill-scalafix_mill0.10_.2.13
+    *
+    * @param artifactName name of the artifact parsed from the build file
+    * @param millVerion the current Mill version being used
+    * @return the newly put together ArtifactId
+    */
+  private def millPluginArtifact(artifactName: String, millVersion: Version): ArtifactId = {
+    def format(major: String, minor: String) = s"${major}.${minor}_2.13"
+    val millSuffix = millVersion.value.split('.') match {
+      // Basically for right now we only accept "0.9.12", which is when this syntax for Mill plugins
+      // was introduced, and all other pre v1 versions. Once it's for sure verified that v1 will also
+      // follow this pattern we can include that.
+      case Array(major, minor, patch) if major == "0" && minor == "9" && patch == "12" =>
+        format(major, minor)
+      case Array(major, minor, _) if major == "0" && Try(minor.toInt).map(_ > 9).getOrElse(false) =>
+        format(major, minor)
+      case _ => ""
+    }
+
+    ArtifactId(artifactName, Some(s"${artifactName}_mill${millSuffix}"))
+  }
+
+  def parseMillPluginDeps(s: String, millVersion: Version): List[Dependency] = {
+
+    val importParser = Parser.string("import")
+    val ivyParser = Parser.string("$ivy")
+    val backtickParser = Parser.char('`')
+    val doubleColonParser = Parser.string("::")
+    val dotParser = Parser.char('.')
+    val grabUntilColonParser = Parser.until(doubleColonParser)
+    val grabntilBacktickParser = Parser.until(backtickParser)
+
+    val parser =
+      (importParser ~
+        sp.rep ~
+        ivyParser ~
+        dotParser ~
+        backtickParser) *>
+        (grabUntilColonParser.string <*
+          doubleColonParser) ~
+        grabUntilColonParser.string ~
+        (doubleColonParser *>
+          grabntilBacktickParser.string <*
+          backtickParser)
+
+    val pluginDependencies = s
+      .split("\n")
+      .toList
+      .map { line =>
+        parser.parse(line)
+      }
+      .collect { case Right((_, ((org, artifact), version))) =>
+        Dependency(GroupId(org), millPluginArtifact(artifact, millVersion), Version(version))
+      }
+
+    pluginDependencies
+  }
 }
 
 case class Modules(modules: List[MillModule])

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillPluginParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillPluginParserTest.scala
@@ -1,0 +1,38 @@
+package org.scalasteward.core.buildtool.mill
+
+import munit.FunSuite
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
+
+class MillPluginParserTest extends FunSuite {
+
+  val supportedVersionExamples = Map("0.9" -> "0.9.12", "0.10" -> "0.10.7")
+
+  supportedVersionExamples.foreach { case (versionSuffix, millVersion) =>
+    test(s"basic-${versionSuffix}") {
+      val fileContent =
+        """|import $ivy.`com.goyeau::mill-scalafix::0.2.10`
+           |import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.6.1`""".stripMargin
+
+      val expected = List(
+        Dependency(
+          GroupId("com.goyeau"),
+          ArtifactId("mill-scalafix", s"mill-scalafix_mill${versionSuffix}_2.13"),
+          Version("0.2.10")
+        ),
+        Dependency(
+          GroupId("de.tototec"),
+          ArtifactId(
+            "de.tobiasroeser.mill.integrationtest",
+            s"de.tobiasroeser.mill.integrationtest_mill${versionSuffix}_2.13"
+          ),
+          Version("0.6.1")
+        )
+      )
+
+      val parsed = parser.parseMillPluginDeps(fileContent, Version(millVersion))
+
+      assertEquals(parsed, expected)
+    }
+  }
+
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -533,6 +533,33 @@ class UpdateHeuristicTest extends FunSuite {
     val update = ("org.typelevel".g % "cats-core".a % "2.4.1" %> "2.4.2").single
     assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
   }
+
+  test("basic mill") {
+    val original = """ivy"com.lihaoyi::requests:0.7.0"""".stripMargin
+    val expected = """ivy"com.lihaoyi::requests:0.7.1"""".stripMargin
+    val update = ("com.lihaoyi".g % "requests".a % "0.7.0" %> "0.7.1").single
+    assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
+  }
+
+  test("mill with variable") {
+    val original = """val requests = "0.7.0"
+                     |ivy"com.lihaoyi::requests:$requests"
+                     |""".stripMargin
+    val expected = """val requests = "0.7.1"
+                     |ivy"com.lihaoyi::requests:$requests"
+                     |""".stripMargin
+    val update = ("com.lihaoyi".g % "requests".a % "0.7.0" %> "0.7.1").single
+    assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.original.name)
+  }
+
+  test("mill with cross") {
+    val original = """import $ivy.`com.goyeau::mill-scalafix::0.2.9`
+                     |""".stripMargin
+    val expected = """import $ivy.`com.goyeau::mill-scalafix::0.2.10`
+                     |""".stripMargin
+    val update = ("com.goyeau".g % "mill-scalafix".a % "0.2.9" %> "0.2.10").single
+    assertEquals(update.replaceVersionIn(original), Some(expected) -> UpdateHeuristic.moduleId.name)
+  }
 }
 
 object UpdateHeuristicTest {


### PR DESCRIPTION
This pr adds in the ability to detect Mill plugins that are defined in
the following way, which is new as of 0.10.x of Mill.

```
import $ivy.`com.goyeau::mill-scalafix::0.2.10`
```

The artifact for this will end up being:

```
mill-scalafix_mill0.10_2.13
```
There is no API currently for Mill to give you the plugins being used in
the build file, so instead of this logic being in the actual Mill plugin
we parse the build file.

Closes #2694 