### PR TITLE
Ignore common prefix weight for snapshots ordering

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -40,11 +40,15 @@ final case class Version(value: String) {
   def selectNext(versions: List[Version], allowPreReleases: Boolean = false): Option[Version] = {
     val cutoff = alnumComponentsWithoutPreRelease.length - 1
     val newerVersionsByCommonPrefix =
-      versions
-        .filter(_ > this)
-        .groupBy(_.alnumComponents.zip(alnumComponents).take(cutoff).takeWhile { case (c1, c2) =>
-          c1 === c2
-        })
+      if (this.isPreRelease && allowPreReleases) {
+        versions.groupBy(_ => List.empty)
+      } else {
+        versions
+          .filter(_ > this)
+          .groupBy(_.alnumComponents.zip(alnumComponents).take(cutoff).takeWhile { case (c1, c2) =>
+            c1 === c2
+          })
+      }
 
     newerVersionsByCommonPrefix.toList
       .sortBy { case (commonPrefix, _) => commonPrefix.length }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -253,6 +253,16 @@ class VersionTest extends DisciplineSuite {
         List("0.22.0+99-a0087dd-SNAPSHOT"),
         Some("0.22.0+99-a0087dd-SNAPSHOT")
       ),
+      (
+        "0.21.6+75-6ad94f6f-SNAPSHOT",
+        List("0.21.6+78-a0457da-SNAPSHOT", "0.21.7+81-a0ff7dd-SNAPSHOT"),
+        Some("0.21.7+81-a0ff7dd-SNAPSHOT")
+      ),
+      (
+        "0.21.6+75-6ad94f6f-SNAPSHOT",
+        List("0.21.7+81-a0ff7dd-SNAPSHOT", "0.22.0+99-a0087dd-SNAPSHOT"),
+        Some("0.22.0+99-a0087dd-SNAPSHOT")
+      ),
       ("0.1.1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-RC1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-ALPHA", List("0.2.1-SNAPSHOT"), None),


### PR DESCRIPTION
This is a bug fix to match the documented behavior in #2635 

> This also implies, that it will be allowed for snapshot versions to be updated to snapshots of different series.

For this to work reliably we need to eliminate weight of common prefix in allowPrereleases mode upgrading from Snapshot to Snapshot.

This is crucial, because in many projects (which publishes only snapshots for some reasons like continuous builds) there is no point to merge snapshots one by one sequentially.

Tests for these cases added.