### PR TITLE
chore: Exclude Akka artifacts due to change of license

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -134,5 +134,14 @@ updates.ignore = [
   { groupId = "org.http4s", version = "0.19.0" },
 
   // https://github.com/scala-js/scala-js/issues/3865
-  { groupId = "org.scala-js", version = "0.6.30" }
+  { groupId = "org.scala-js", version = "0.6.30" },
+  
+  // https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka
+  // https://github.com/scala-steward-org/scala-steward/issues/2708
+  { groupId = "com.typesafe.akka"},
+  { groupId = "com.lightbend.akka" },
+  { groupId = "com.lightbend.akka.grpc" },
+  { groupId = "com.lightbend.akka.management" },
+  { groupId = "com.lightbend.akka.discovery" },
+  
 ]


### PR DESCRIPTION
Akka starting from version 2.7.0 will use the BSL license, which will require from large companies to pay for license. Due to that any library that uses Akka and is included in a project would also need to pay for licenses.

To avoid unexpected costs for companies, let's add Akka 2.7.0 as ignored for Scala Steward, so that users will need to update it manually and consiously accept the new license.

Not sure how to properly allow for the updates if the user wants it, but if it proves to be difficult we can add some additional settings. I was thinking about maybe `allowedLicenses` that could get overriden in a local repo.

Let me know what everyone thinks about this change.