### PR TITLE
Add support for grouping dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import scala.util.Properties
+import scala.reflect.io.Path
 import com.typesafe.sbt.packager.docker._
 import sbtcrossproject.{CrossProject, CrossType, Platform}
 import sbtghactions.JavaSpec.Distribution.Adopt
@@ -191,6 +193,8 @@ lazy val core = myCrossProject("core")
     }.taskValue,
     run / fork := true,
     Test / fork := true,
+    Test / testOptions +=
+      Tests.Cleanup(() => Path(file(Properties.tmpDir) / "scala-steward").deleteRecursively()),
     Compile / unmanagedResourceDirectories ++= (`sbt-plugin`.jvm / Compile / unmanagedSourceDirectories).value
   )
 

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -32,6 +32,41 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 #pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
 pullRequests.frequency = "7 days"
 
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+# 
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know 
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#   
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+# 
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update togeher a filter like {group = "*"} can be # provided.
+#
+# Default: []
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
+  { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
+  { name = "typelevel", "title" = "Typelevel updates", "filter" = [{"group" = "org.typelevel"}, {"group" = "org.http4s"}] },
+  { name = "my_libraries", "filter" = [{"artifact" = "my-library"}, {"artifact" = "my-other-library", "group" = "my-org"}] },
+  { name = "all", title = "Dependency updates", "filter" = [{"group" = "*"}] }
+]
+
 # pullRequests.includeMatchedLabels allows to control which labels are added to PRs 
 # via a regex check each label is checked against.
 # Defaults to no regex (all labels are added) which is equivalent to ".*".

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -53,6 +53,8 @@ pullRequests.frequency = "7 days"
 #       group = "{group}",
 #       artifact = "{artifact}"
 #    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
 # 
 # Every field in a `filter` is optional but at least one must be provided.
 #

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -20,10 +20,32 @@ import cats.Order
 import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.semiauto._
-import org.scalasteward.core.data.Update.{Group, Single}
+import org.scalasteward.core.data.Update.Group
+import org.scalasteward.core.data.Update.Single
+import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.string.MinLengthString
+
+import scala.annotation.nowarn
+
+final case class GroupedUpdate(name: String, title: Option[String], updates: List[Update])
+
+object GroupedUpdate {
+
+  /**
+    * Processes the provided updates using the group configuration. Each update will only be present in the
+    * first group it falls into.
+    *
+    * Updates that do not fall into any group will be returned back in the second return parameter.
+    */
+  @nowarn
+  def from(
+      groups: List[PullRequestGroup],
+      updates: List[Update.Single]
+  ): (List[GroupedUpdate], List[Update.Single]) = (Nil, updates)
+
+}
 
 sealed trait Update extends Product with Serializable {
   def crossDependencies: Nel[CrossDependency]

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.data
 import cats.Order
 import cats.implicits._
 import io.circe.Codec
+import io.circe.syntax._
 import io.circe.generic.semiauto._
 import org.scalasteward.core.data.Update.Group
 import org.scalasteward.core.data.Update.Single
@@ -26,6 +27,7 @@ import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.string.MinLengthString
+import io.circe.Decoder
 
 sealed trait AnUpdate {
 
@@ -35,6 +37,15 @@ sealed trait AnUpdate {
   }
 
   def show: String
+
+}
+
+object AnUpdate {
+
+  implicit val AnUpdateCodec: Codec[AnUpdate] = Codec.from(
+    Decoder[GroupedUpdate].widen[AnUpdate].or(Decoder[Update].widen[AnUpdate]),
+    _.on(_.asJson, _.asJson)
+  )
 
 }
 
@@ -69,6 +80,8 @@ object GroupedUpdate {
         case (matched, rest) => (grouped :+ GroupedUpdate(group.name, group.title, matched), rest)
       }
     }
+
+  implicit val GroupedUpdateCodec: Codec[GroupedUpdate] = deriveCodec
 
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -29,7 +29,19 @@ import org.scalasteward.core.util.string.MinLengthString
 
 import scala.annotation.nowarn
 
+sealed trait AnUpdate {
+
+
+  def show: String
+
+}
+
 final case class GroupedUpdate(name: String, title: Option[String], updates: List[Update])
+    extends AnUpdate {
+
+  override def show: String = name
+
+}
 
 object GroupedUpdate {
 
@@ -47,7 +59,7 @@ object GroupedUpdate {
 
 }
 
-sealed trait Update extends Product with Serializable {
+sealed trait Update extends Product with Serializable with AnUpdate {
   def crossDependencies: Nel[CrossDependency]
   def dependencies: Nel[Dependency]
   def groupId: GroupId
@@ -62,7 +74,7 @@ sealed trait Update extends Product with Serializable {
   final def nextVersion: Version =
     newerVersions.head
 
-  final def show: String = {
+  final override def show: String = {
     val artifacts = this match {
       case s: Single => s.crossDependency.showArtifactNames
       case g: Group  => g.crossDependencies.map(_.showArtifactNames).mkString_("{", ", ", "}")

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -29,6 +29,10 @@ import org.scalasteward.core.util.string.MinLengthString
 
 sealed trait AnUpdate {
 
+  def on[A](update: Update => A, grouped: GroupedUpdate => A): A = this match {
+    case g: GroupedUpdate => grouped(g)
+    case u: Update        => update(u)
+  }
 
   def show: String
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -23,7 +23,6 @@ import org.scalasteward.core.vcs.data.Repo
 final case class UpdateData(
     repoData: RepoData,
     fork: Repo,
-    oldUpdate: Update,
     update: AnUpdate,
     baseBranch: Branch,
     baseSha1: Sha1,

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -23,7 +23,8 @@ import org.scalasteward.core.vcs.data.Repo
 final case class UpdateData(
     repoData: RepoData,
     fork: Repo,
-    update: Update,
+    oldUpdate: Update,
+    update: AnUpdate,
     baseBranch: Branch,
     baseSha1: Sha1,
     updateBranch: Branch

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core
 
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{AnUpdate, GroupedUpdate, Update}
 import org.scalasteward.core.repoconfig.CommitsConfig
 import org.scalasteward.core.vcs.data.Repo
 
@@ -27,9 +27,12 @@ package object git {
 
   val updateBranchPrefix = "update"
 
-  def branchFor(update: Update, baseBranch: Option[Branch]): Branch = {
+  def branchFor(update: AnUpdate, baseBranch: Option[Branch]): Branch = {
     val base = baseBranch.fold("")(branch => s"${branch.name}/")
-    Branch(s"$updateBranchPrefix/$base${update.name}-${update.nextVersion}")
+    update match {
+      case g: GroupedUpdate => Branch(s"$updateBranchPrefix/$base${g.name}")
+      case u: Update        => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}")
+    }
   }
 
   def commitMsgFor(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -105,7 +105,7 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
         val prData = PullRequestData[Id](
           pr.html_url,
           data.baseSha1,
-          data.oldUpdate,
+          data.update,
           pr.state,
           pr.number,
           data.updateBranch
@@ -207,7 +207,7 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
       prData = PullRequestData[Id](
         pr.html_url,
         data.baseSha1,
-        data.oldUpdate,
+        data.update,
         pr.state,
         pr.number,
         data.updateBranch

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -72,8 +72,7 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
         .emits(updates)
         .evalMap { update =>
           val updateBranch = git.branchFor(update, data.repo.branch)
-          val updateData =
-            UpdateData(data, fork, update, update, baseBranch, baseSha1, updateBranch)
+          val updateData = UpdateData(data, fork, update, baseBranch, baseSha1, updateBranch)
           processUpdate(updateData)
         }
         .through(util.takeUntilMaybe(0, data.config.updates.limit.map(_.value)) {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -195,7 +195,9 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
       releaseRelatedUrls <-
         existingArtifactUrlsList
           .traverse { case (id, uri) =>
-            vcsExtraAlg.getReleaseRelatedUrls(uri, data.oldUpdate).tupleLeft(id)
+            vcsExtraAlg
+              .getReleaseRelatedUrls(uri, data.oldUpdate.currentVersion, data.oldUpdate.nextVersion)
+              .tupleLeft(id)
           }
           .map(_.toMap)
       filesWithOldVersion <-

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -198,10 +198,11 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
             vcsExtraAlg.getReleaseRelatedUrls(uri, data.oldUpdate).tupleLeft(id)
           }
           .map(_.toMap)
-      filesWithOldVersion <- gitAlg.findFilesContaining(
-        data.repo,
-        data.oldUpdate.currentVersion.value
-      )
+      filesWithOldVersion <-
+        data.update
+          .on(u => List(u.currentVersion.value), _.updates.map(_.currentVersion.value))
+          .flatTraverse(gitAlg.findFilesContaining(data.repo, _))
+          .map(_.distinct)
       branchName = vcs.createBranch(config.tpe, data.fork, data.updateBranch)
       requestData = NewPullRequestData.from(
         data,

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.nurture
 
 import org.http4s.Uri
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.AnUpdate
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState}
 
 final case class PullRequestData[F[_]](
     url: Uri,
     baseSha1: Sha1,
-    update: Update,
+    update: AnUpdate,
     state: PullRequestState,
     number: F[PullRequestNumber],
     updateBranch: F[Branch]

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -21,7 +21,7 @@ import cats.{Id, Monad}
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.http4s.Uri
-import org.scalasteward.core.data.{CrossDependency, GroupId, Update, Version}
+import org.scalasteward.core.data.{AnUpdate, CrossDependency, GroupId, Update, Version}
 import org.scalasteward.core.git
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.nurture.PullRequestRepository.Entry
@@ -69,21 +69,14 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
   def getObsoleteOpenPullRequests(repo: Repo, update: Update): F[List[PullRequestData[Id]]] =
     kvStore.getOrElse(repo, Map.empty).map {
       _.collect {
-        case (url, entry)
-            if entry.state === PullRequestState.Open &&
-              entry.update.withNewerVersions(update.newerVersions) === update &&
-              entry.update.nextVersion < update.nextVersion =>
+        case (url, Entry(baseSha1, u: Update, state, _, number, updateBranch))
+            if state === PullRequestState.Open &&
+              u.withNewerVersions(update.newerVersions) === update &&
+              u.nextVersion < update.nextVersion =>
           for {
-            number <- entry.number
-            updateBranch = entry.updateBranch.getOrElse(git.branchFor(entry.update, repo.branch))
-          } yield PullRequestData[Id](
-            url,
-            entry.baseSha1,
-            entry.update,
-            entry.state,
-            number,
-            updateBranch
-          )
+            number <- number
+            branch = updateBranch.getOrElse(git.branchFor(u, repo.branch))
+          } yield PullRequestData[Id](url, baseSha1, u, state, number, branch)
       }.flatten.toList.sortBy(_.number.value)
     }
 
@@ -93,9 +86,10 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
       newVersion: Version
   ): F[Option[PullRequestData[Option]]] =
     kvStore.getOrElse(repo, Map.empty).map {
-      _.filter { case (_, entry) =>
-        UpdateAlg.isUpdateFor(entry.update, crossDependency) &&
-        entry.update.nextVersion === newVersion
+      _.filter {
+        case (_, Entry(_, u: Update, _, _, _, _)) =>
+          UpdateAlg.isUpdateFor(u, crossDependency) && u.nextVersion === newVersion
+        case _ => false
       }
         .maxByOption { case (_, entry) => entry.entryCreatedAt.millis }
         .map { case (url, entry) =>
@@ -118,9 +112,12 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
       case None => Map.empty
       case Some(pullRequests) =>
         pullRequests.values
-          .groupBy(entry => (entry.update.groupId, entry.update.mainArtifactId))
+          .collect { case Entry(_, u: Update, _, entryCreatedAt, _, _) =>
+            (u.groupId, u.mainArtifactId, entryCreatedAt)
+          }
+          .groupBy { case (groupId, mainArtifactId, _) => (groupId, mainArtifactId) }
           .view
-          .mapValues(_.map(_.entryCreatedAt).max)
+          .mapValues(_.map { case (_, _, createdAt) => createdAt }.max)
           .toMap
     }
 }
@@ -128,7 +125,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
 object PullRequestRepository {
   final case class Entry(
       baseSha1: Sha1,
-      update: Update,
+      update: AnUpdate,
       state: PullRequestState,
       entryCreatedAt: Timestamp,
       number: Option[PullRequestNumber],

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -20,12 +20,20 @@ import cats.Eq
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import cats.data.NonEmptyList
+import org.scalasteward.core.data.Update
 
 case class PullRequestGroup(
     name: String,
     title: Option[String] = None,
     filter: NonEmptyList[PullRequestUpdateFilter]
-)
+) {
+
+  /**
+    * Returns `true` if an update falls into this group; returns `false` otherwise.
+    */
+  def matches(update: Update): Boolean = ???
+
+}
 
 object PullRequestGroup {
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -31,7 +31,7 @@ case class PullRequestGroup(
   /**
     * Returns `true` if an update falls into this group; returns `false` otherwise.
     */
-  def matches(update: Update): Boolean = ???
+  def matches(update: Update.Single): Boolean = filter.exists(_.matches(update))
 
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.Eq
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
+import cats.data.NonEmptyList
+
+case class PullRequestGroup(
+    name: String,
+    title: Option[String] = None,
+    filter: NonEmptyList[PullRequestUpdateFilter]
+)
+
+object PullRequestGroup {
+
+  implicit val pullRequestGroupEq: Eq[PullRequestGroup] =
+    Eq.fromUniversalEquals
+
+  implicit val pullRequestGroupDecoder: Decoder[PullRequestGroup] =
+    deriveDecoder
+
+  implicit val pullRequestGroupEncoder: Encoder[PullRequestGroup] =
+    deriveEncoder
+
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.Eq
+import cats.syntax.all._
+import io.circe._
+import io.circe.syntax._
+import org.scalasteward.core.data.SemVer
+
+final case class PullRequestUpdateFilter private (
+    group: Option[String] = None,
+    artifact: Option[String] = None,
+    version: Option[SemVer.Change] = None
+)
+
+object PullRequestUpdateFilter {
+  def apply(
+      group: Option[String] = None,
+      artifact: Option[String] = None,
+      version: Option[SemVer.Change] = None
+  ): Either[String, PullRequestUpdateFilter] =
+    if (group.isEmpty && artifact.isEmpty && version.isEmpty)
+      Left("At least one predicate should be added to the filter")
+    else Right(new PullRequestUpdateFilter(group, artifact, version))
+
+  implicit val pullRequestUpdateDecoder: Decoder[PullRequestUpdateFilter] = { cursor =>
+    for {
+      group <- cursor.get[Option[String]]("group")
+      artifact <- cursor.get[Option[String]]("artifact")
+      version <- cursor.get[Option[SemVer.Change]]("version")
+      filter <- apply(group, artifact, version).leftMap(DecodingFailure(_, Nil))
+    } yield filter
+  }
+
+  implicit val pullRequestUpdateFilterEq: Eq[PullRequestUpdateFilter] =
+    Eq.fromUniversalEquals
+
+  implicit val pullRequestUpdateFilterEncoder: Encoder[PullRequestUpdateFilter] = filter =>
+    Json.obj(
+      "group" := filter.group,
+      "artifact" := filter.artifact,
+      "version" := filter.version
+    )
+
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -27,6 +27,7 @@ import scala.util.matching.Regex
 
 final case class PullRequestsConfig(
     frequency: Option[PullRequestFrequency] = None,
+    grouping: List[PullRequestGroup] = Nil,
     includeMatchedLabels: Option[Regex] = None
 ) {
   def frequencyOrDefault: PullRequestFrequency =

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -17,8 +17,10 @@
 package org.scalasteward.core.util
 
 import cats.syntax.all._
-import cats.{Foldable, Functor, Monad, MonadThrow}
+import cats.{Monad, MonadThrow}
+import org.scalasteward.core.data.GroupedUpdate
 import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.AnUpdate
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration.FiniteDuration
 
@@ -66,8 +68,13 @@ object logger {
     }
   }
 
-  def showUpdates[F[_]: Foldable: Functor](updates: F[Update]): String = {
-    val list = string.indentLines(updates.map(_.show))
+  def showUpdates(allUpdates: List[AnUpdate]): String = {
+    val updates = allUpdates.flatMap {
+      case g: GroupedUpdate => g.updates.map(_.show)
+      case u: Update        => List(u.show)
+    }
+
+    val list = string.indentLines(updates)
     updates.size match {
       case 0 => s"Found 0 updates"
       case 1 => s"Found 1 update:\n$list"

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -20,12 +20,16 @@ import cats.Monad
 import cats.syntax.all._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.VCSCfg
-import org.scalasteward.core.data.{ReleaseRelatedUrl, Update}
+import org.scalasteward.core.data.{ReleaseRelatedUrl, Version}
 import org.scalasteward.core.util.UrlChecker
 import org.scalasteward.core.vcs
 
 trait VCSExtraAlg[F[_]] {
-  def getReleaseRelatedUrls(repoUrl: Uri, update: Update): F[List[ReleaseRelatedUrl]]
+  def getReleaseRelatedUrls(
+      repoUrl: Uri,
+      currentVersion: Version,
+      nextVersion: Version
+  ): F[List[ReleaseRelatedUrl]]
 }
 
 object VCSExtraAlg {
@@ -34,9 +38,19 @@ object VCSExtraAlg {
       F: Monad[F]
   ): VCSExtraAlg[F] =
     new VCSExtraAlg[F] {
-      override def getReleaseRelatedUrls(repoUrl: Uri, update: Update): F[List[ReleaseRelatedUrl]] =
+      override def getReleaseRelatedUrls(
+          repoUrl: Uri,
+          currentVersion: Version,
+          nextVersion: Version
+      ): F[List[ReleaseRelatedUrl]] =
         vcs
-          .possibleReleaseRelatedUrls(config.tpe, config.apiHost, repoUrl, update)
+          .possibleReleaseRelatedUrls(
+            config.tpe,
+            config.apiHost,
+            repoUrl,
+            currentVersion,
+            nextVersion
+          )
           .filterA(releaseRelatedUrl => urlChecker.exists(releaseRelatedUrl.url))
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -186,16 +186,16 @@ object NewPullRequestData {
       filesWithOldVersion: List[String] = List.empty,
       includeMatchedLabels: Option[Regex] = None
   ): NewPullRequestData = {
-    val labels = labelsFor(data.update, edits, filesWithOldVersion, includeMatchedLabels)
+    val labels = labelsFor(data.oldUpdate, edits, filesWithOldVersion, includeMatchedLabels)
     NewPullRequestData(
       title = CommitMsg
         .replaceVariables(data.repoConfig.commits.messageOrDefault)(
-          data.update,
+          data.oldUpdate,
           data.repoData.repo.branch
         )
         .title,
       body = bodyFor(
-        data.update,
+        data.oldUpdate,
         edits,
         artifactIdToUrl,
         releaseRelatedUrls,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -234,7 +234,7 @@ object NewPullRequestData {
     NewPullRequestData(
       title = CommitMsg
         .replaceVariables(data.repoConfig.commits.messageOrDefault)(
-          data.oldUpdate,
+          data.update,
           data.repoData.repo.branch
         )
         .title,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -120,11 +120,16 @@ object NewPullRequestData {
       case None      => s"$groupId:$artifactId"
     }
 
-  def oldVersionNote(files: List[String], update: Update): Option[Details] =
+  def oldVersionNote(files: List[String], update: AnUpdate): Option[Details] =
     Option.when(files.nonEmpty) {
+      val (number, numberWithVersion) = update.on(
+        update = u => ("number", s"number (${u.currentVersion})"),
+        grouped = _ => ("numbers", "numbers")
+      )
+
       Details(
-        "Files still referring to the old version number",
-        s"""The following files still refer to the old version number (${update.currentVersion}).
+        s"Files still referring to the old version $number",
+        s"""The following files still refer to the old version $numberWithVersion.
            |You might want to review and update them manually.
            |```
            |${files.mkString("\n")}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -138,19 +138,31 @@ object NewPullRequestData {
       )
     }
 
-  def adjustFutureUpdates(update: Update): Details =
-    Details(
-      "Adjust future updates",
-      s"""|Add this to your `${RepoConfigAlg.repoConfigBasename}` file to ignore future updates of this dependency:
-          |```
-          |${RepoConfigAlg.configToIgnoreFurtherUpdates(update)}
-          |```
-          |Or, add this to slow down future updates of this dependency:
-          |```
-          |${GroupRepoConfig.configToSlowDownUpdatesFrequency(update)}
-          |```
-          |""".stripMargin.trim
+  def adjustFutureUpdates(update: AnUpdate): Details = Details(
+    "Adjust future updates",
+    update.on(
+      update = u =>
+        s"""|Add this to your `${RepoConfigAlg.repoConfigBasename}` file to ignore future updates of this dependency:
+            |```
+            |${RepoConfigAlg.configToIgnoreFurtherUpdates(u)}
+            |```
+            |Or, add this to slow down future updates of this dependency:
+            |```
+            |${GroupRepoConfig.configToSlowDownUpdatesFrequency(u)}
+            |```
+            |""".stripMargin.trim,
+      grouped = g =>
+        s"""|Add these to your `${RepoConfigAlg.repoConfigBasename}` file to ignore future updates of these dependencies:
+            |```
+            |${RepoConfigAlg.configToIgnoreFurtherUpdates(g)}
+            |```
+            |Or, add these to slow down future updates of these dependencies:
+            |```
+            |${GroupRepoConfig.configToSlowDownUpdatesFrequency(g)}
+            |```
+            |""".stripMargin.trim
     )
+  )
 
   def configParsingErrorDetails(error: String): Details =
     Details(

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -1,0 +1,565 @@
+package org.scalasteward.core.data
+
+import cats.data.NonEmptyList
+import cats.implicits.catsSyntaxOptionId
+import org.scalasteward.core.TestSyntax._
+import munit.FunSuite
+import org.scalasteward.core.repoconfig.{PullRequestGroup, PullRequestUpdateFilter}
+
+class GroupedUpdateTest extends FunSuite {
+  val updateSingleSpecs2Core: Update.Single =
+    ("org.specs2".g % "specs2-core".a % "3.9.3" %> "3.9.5").single
+
+  val updateSingleSpecs2Scalacheck: Update.Single =
+    ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single
+
+  val updateSingleTypelevelAlgebra: Update.Single =
+    ("org.typelevel".g % "algebra".a % "3.9.4" %> "3.9.5").single
+
+  val updateSingleCirceCore: Update.Single =
+    ("circe".g % "core".a % "1.4.2" %> "1.5.0").single
+
+  test(
+    "GroupedUpdate.from: Do not group a Update.Single if the groupId does not match the filter"
+  ) {
+    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(List(pullRequestGroupSpecs2), List(updateSingleTypelevelAlgebra))
+    assertEquals(grouped, List.empty)
+    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
+  }
+
+  test(
+    "GroupedUpdate.from: Do not group multiple Update.Single if the groupId does not match the filter"
+  ) {
+    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+      "typelevel",
+      Some("update typelevel"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+      )
+    )
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestGroupTypeLevel),
+        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+      )
+    assertEquals(grouped, List.empty)
+    assertEquals(notGrouped, List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck))
+  }
+
+  test("GroupedUpdate.from: Group a Update.Single for a single GroupId filter") {
+    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+      "typelevel",
+      Some("update typelevel"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestGroupTypeLevel),
+        List(updateSingleTypelevelAlgebra)
+      )
+
+    assertEquals(
+      grouped,
+      List(GroupedUpdate("typelevel", Some("update typelevel"), List(updateSingleTypelevelAlgebra)))
+    )
+    assertEquals(notGrouped, List.empty)
+  }
+
+  test("GroupedUpdate.from: Group multiple Update.Single for a single GroupId filter") {
+    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestGroupSpecs2),
+        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2",
+          Some("update specs2"),
+          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+        )
+      )
+    )
+    assertEquals(notGrouped, List.empty)
+  }
+
+  test("GroupedUpdate.from: Group multiple Updates for multiple GroupId filters") {
+    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+      "typelevel",
+      Some("update typelevel"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val updates = List(
+      updateSingleSpecs2Core,
+      updateSingleSpecs2Scalacheck,
+      updateSingleTypelevelAlgebra,
+      updateSingleCirceCore
+    )
+    val pullRequestGroups = List(pullRequestGroupSpecs2, pullRequestGroupTypeLevel)
+
+    val (grouped, notGrouped) = GroupedUpdate.from(pullRequestGroups, updates)
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2",
+          Some("update specs2"),
+          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+        ),
+        GroupedUpdate("typelevel", Some("update typelevel"), List(updateSingleTypelevelAlgebra))
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleCirceCore))
+  }
+
+  val pullRequestGroupOrgWildcard: PullRequestGroup = PullRequestGroup(
+    "org",
+    Some("update org"),
+    NonEmptyList.one(PullRequestUpdateFilter("org.*".some).getOrElse(fail("Should not be called")))
+  )
+
+  test("GroupedUpdate.from: Group multiple Updates for a GroupId filter with a wildcard") {
+    val updates = List(
+      updateSingleSpecs2Core,
+      updateSingleSpecs2Scalacheck,
+      updateSingleTypelevelAlgebra,
+      updateSingleCirceCore
+    )
+    val pullRequestGroups = List(pullRequestGroupOrgWildcard)
+
+    val (grouped, notGrouped) = GroupedUpdate.from(pullRequestGroups, updates)
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "org",
+          Some("update org"),
+          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck, updateSingleTypelevelAlgebra)
+        )
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleCirceCore))
+  }
+
+  test("GroupedUpdate.from: Group everything when using * for OrganisationId") {
+    val pullRequestGroupWildcardAll: PullRequestGroup = PullRequestGroup(
+      "all wildcard",
+      Some("update all wildcard"),
+      NonEmptyList.one(PullRequestUpdateFilter("*".some).getOrElse(fail("Should not be called")))
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestGroupWildcardAll),
+        List(
+          updateSingleTypelevelAlgebra,
+          updateSingleSpecs2Core,
+          updateSingleSpecs2Scalacheck
+        )
+      )
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "all wildcard",
+          Some("update all wildcard"),
+          List(
+            updateSingleTypelevelAlgebra,
+            updateSingleSpecs2Core,
+            updateSingleSpecs2Scalacheck
+          )
+        )
+      )
+    )
+    assertEquals(notGrouped, List.empty)
+  }
+
+  test("GroupedUpdate.from: Group Update.Group for an ArtifactId filter without a group") {
+    val pullRequestArtifactSpecs2CoreWithoutGroup: PullRequestGroup = PullRequestGroup(
+      "specs2 core",
+      Some("update specs2 core"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter(None, "specs2-core".some).getOrElse(fail("Should not be called"))
+      )
+    )
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2CoreWithoutGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+      )
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2 core",
+          Some("update specs2 core"),
+          List(updateSingleSpecs2Core)
+        )
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
+  }
+
+  val pullRequestArtifactSpecs2CoreWithGroup: PullRequestGroup = PullRequestGroup(
+    "specs2 core",
+    Some("update specs2 core"),
+    NonEmptyList.one(
+      PullRequestUpdateFilter("org.specs2".some, "specs2-core".some).getOrElse(
+        fail("Should not be called")
+      )
+    )
+  )
+
+  test("GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a group") {
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2CoreWithGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+      )
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2 core",
+          Some("update specs2 core"),
+          List(updateSingleSpecs2Core)
+        )
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
+  }
+
+  test(
+    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with an invalid group"
+  ) {
+    val pullRequestArtifactSpecs2CoreWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "specs2 core",
+      Some("update specs2 core"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.invalid".some, "specs2-core".some).getOrElse(
+          fail("Should not be called")
+        )
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2CoreWithInvalidGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+      )
+
+    assertEquals(grouped, List.empty)
+    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core))
+  }
+
+  test(
+    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithoutGroup: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter(None, "specs2-*".some).getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithoutGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2",
+          Some("update specs2"),
+          List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+        )
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
+  }
+
+  test(
+    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard and a group"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithGroup: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.specs2".some, "specs2-*".some).getOrElse(
+          fail("Should not be called")
+        )
+      )
+    )
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+      )
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate(
+          "specs2",
+          Some("update specs2"),
+          List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+        )
+      )
+    )
+    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
+  }
+
+  test(
+    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with a wildcard an invalid group"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "specs2",
+      Some("update specs2"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter("org.invalid".some, "specs2-*".some).getOrElse(
+          fail("Should not be called")
+        )
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+      )
+
+    assertEquals(grouped, List.empty)
+    assertEquals(
+      notGrouped,
+      List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+    )
+  }
+
+  val majorUpdate: Update.Single = ("org.major".g % "major".a % "3.1.2" %> "4.0.0").single
+  val minorUpdate: Update.Single = ("org.minor".g % "minor".a % "3.1.2" %> "3.2.0").single
+  val patchUpdate: Update.Single = ("org.patch".g % "patch".a % "3.1.2" %> "3.1.3").single
+
+  test(
+    "GroupedUpdate.from: Group major updates"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "major",
+      Some("update major"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("major", Some("update major"), List(majorUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(minorUpdate, patchUpdate))
+  }
+
+  test(
+    "GroupedUpdate.from: Group minor updates"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "minor",
+      Some("update minor"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("minor", Some("update minor"), List(minorUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(majorUpdate, patchUpdate))
+  }
+
+  test(
+    "GroupedUpdate.from: Group patch updates"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "patch",
+      Some("update patch"),
+      NonEmptyList.one(
+        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("patch", Some("update patch"), List(patchUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
+  }
+
+  test(
+    "GroupedUpdate.from: Group minor & patch updates"
+  ) {
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "patch & minor",
+      Some("update patch & minor"),
+      NonEmptyList.of(
+        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+          .getOrElse(fail("Should not be called")),
+        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("patch & minor", Some("update patch & minor"), List(minorUpdate, patchUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(majorUpdate))
+  }
+
+  test(
+    "GroupedUpdate.from: Group major & minor updates with version numbers containing a date and commit hash"
+  ) {
+    val majorUpdate: Update.Single =
+      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single
+    val minorUpdate: Update.Single =
+      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single
+    val patchUpdate: Update.Single =
+      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220922-180024-dd318047").single
+
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "major & minor",
+      Some("update major & minor"),
+      NonEmptyList.of(
+        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
+          .getOrElse(fail("Should not be called")),
+        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("major & minor", Some("update major & minor"), List(majorUpdate, minorUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(patchUpdate))
+  }
+
+  test(
+    "GroupedUpdate.from: Group patch updates with version numbers containing a date and commit hash"
+  ) {
+    val majorUpdate: Update.Single =
+      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single
+    val minorUpdate: Update.Single =
+      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single
+    val patchUpdate: Update.Single =
+      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220920-180024-dd318047").single
+
+    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+      "patch",
+      Some("update patch"),
+      NonEmptyList.of(
+        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+          .getOrElse(fail("Should not be called"))
+      )
+    )
+
+    val (grouped, notGrouped) =
+      GroupedUpdate.from(
+        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+        List(majorUpdate, minorUpdate, patchUpdate)
+      )
+
+    assertEquals(
+      grouped,
+      List(
+        GroupedUpdate("patch", Some("update patch"), List(patchUpdate))
+      )
+    )
+
+    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -205,7 +205,7 @@ object FileGitAlgTest {
       for {
         _ <- gitAlg.removeClone(repo)
         _ <- fileAlg.ensureExists(repo)
-        _ <- git("init", ".")(repo)
+        _ <- git("init", ".", "--initial-branch", "master")(repo)
         _ <- gitAlg.setAuthor(repo, config.gitCfg.gitAuthor)
         _ <- git("commit", "--allow-empty", "-m", "Initial commit")(repo)
       } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.data.GroupedUpdate
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
@@ -137,4 +138,58 @@ class PullRequestRepositoryTest extends FunSuite {
       )
     )
   }
+
+  test("findLatestPullRequest ignores grouped updates") {
+    val repo = Repo("pr-repo-test", "repo5")
+    val update = portableScala
+    val grouped = GroupedUpdate("group", None, List(update))
+    val data = PullRequestData[Id](url, sha1, grouped, Open, number, branch)
+
+    val p = for {
+      _ <- pullRequestRepository.createOrUpdate(repo, data)
+      result <- pullRequestRepository.findLatestPullRequest(repo, update.crossDependency, "1.0.0".v)
+    } yield result
+
+    val (state, result) = p.runSA(MockState.empty).unsafeRunSync()
+
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
+    assert(result.isEmpty)
+
+    checkTrace(
+      state,
+      Vector(
+        Cmd("read", store.toString),
+        Cmd("write", store.toString)
+      )
+    )
+  }
+
+  test("lastPullRequestCreatedAt returns timestamp for grouped updates") {
+    val repo = Repo("pr-repo-test", "repo7")
+    val update = catsCore
+    val grouped = GroupedUpdate("group", None, List(update))
+    val data = PullRequestData[Id](url, sha1, grouped, Open, number, branch)
+
+    val p = for {
+      emptyCreatedAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
+      _ <- pullRequestRepository.createOrUpdate(repo, data)
+      createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
+    } yield (emptyCreatedAt, createdAt)
+    val (state, (emptyCreatedAt, createdAt)) = p.runSA(MockState.empty).unsafeRunSync()
+
+    val store =
+      config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
+    assert(emptyCreatedAt.isEmpty)
+    assert(createdAt.isDefined)
+
+    checkTrace(
+      state,
+      Vector(
+        Cmd("read", store.toString),
+        Cmd("write", store.toString)
+      )
+    )
+  }
+
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -36,14 +36,22 @@ class VCSExtraAlgTest extends FunSuite {
 
     assertEquals(
       vcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.com/foo/foo", updateFoo)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.com/foo/foo",
+          currentVersion = updateFoo.currentVersion,
+          nextVersion = updateFoo.nextVersion
+        )
         .unsafeRunSync(),
       List.empty
     )
 
     assertEquals(
       vcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.com/foo/bar", updateBar)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.com/foo/bar",
+          currentVersion = updateBar.currentVersion,
+          nextVersion = updateBar.nextVersion
+        )
         .unsafeRunSync(),
       List(
         ReleaseRelatedUrl.VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
@@ -52,7 +60,11 @@ class VCSExtraAlgTest extends FunSuite {
 
     assertEquals(
       vcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.com/foo/buz", updateBuz)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.com/foo/buz",
+          currentVersion = updateBuz.currentVersion,
+          nextVersion = updateBuz.nextVersion
+        )
         .unsafeRunSync(),
       List.empty
     )
@@ -70,14 +82,22 @@ class VCSExtraAlgTest extends FunSuite {
 
     assertEquals(
       githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/foo", updateFoo)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.on-prem.com/foo/foo",
+          currentVersion = updateFoo.currentVersion,
+          nextVersion = updateFoo.nextVersion
+        )
         .unsafeRunSync(),
       List.empty
     )
 
     assertEquals(
       githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/bar", updateBar)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.on-prem.com/foo/bar",
+          currentVersion = updateBar.currentVersion,
+          nextVersion = updateBar.nextVersion
+        )
         .unsafeRunSync(),
       List(
         ReleaseRelatedUrl.VersionDiff(
@@ -88,7 +108,11 @@ class VCSExtraAlgTest extends FunSuite {
 
     assertEquals(
       githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/buz", updateFoo)
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.on-prem.com/foo/buz",
+          currentVersion = updateFoo.currentVersion,
+          nextVersion = updateFoo.nextVersion
+        )
         .unsafeRunSync(),
       List.empty
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -37,7 +37,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           uri"https://github.com/foo/bar",
-          update
+          update.currentVersion,
+          update.nextVersion
         ).map(_.url.renderString),
         List(
           "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
@@ -52,7 +53,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           uri"https://github.com/foo/bar/",
-          update
+          update.currentVersion,
+          update.nextVersion
         ).map(_.url.renderString),
         List(
           "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
@@ -66,7 +68,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           uri"https://gitlab.com/foo/bar",
-          update
+          update.currentVersion,
+          update.nextVersion
         ).map(_.url.renderString),
         List(
           "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
@@ -80,7 +83,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           uri"https://bitbucket.org/foo/bar",
-          update
+          update.currentVersion,
+          update.nextVersion
         ).map(_.url.renderString),
         List(
           "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
@@ -94,7 +98,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           uri"https://scalacenter.github.io/scalafix/",
-          update
+          update.currentVersion,
+          update.nextVersion
         ),
         List.empty
       )
@@ -104,7 +109,8 @@ class VCSPackageTest extends FunSuite {
           GitHub,
           onPremVCSUri,
           onPremVCSUri.addPath("foo/bar"),
-          update
+          update.currentVersion,
+          update.nextVersion
         ).map(_.url.renderString),
         List(
           s"${onPremVCS}foo/bar/compare/v1.2.0...v1.2.3",
@@ -119,7 +125,8 @@ class VCSPackageTest extends FunSuite {
         GitHub,
         uri"https://github.com",
         uri"https://github.com/foo/bar",
-        update
+        update.currentVersion,
+        update.nextVersion
       ).map(_.url.renderString)
       val expected = List(
         "https://github.com/foo/bar/releases/tag/v1.2.3",
@@ -161,7 +168,8 @@ class VCSPackageTest extends FunSuite {
         GitHub,
         uri"https://github.com",
         uri"https://gitlab.com/foo/bar",
-        update
+        update.currentVersion,
+        update.nextVersion
       ).map(_.url.renderString)
       val expected =
         possibleReleaseNotesFilenames.map(name =>
@@ -181,7 +189,8 @@ class VCSPackageTest extends FunSuite {
         GitLab,
         uri"https://gitlab.on-prem.net",
         uri"https://gitlab.on-prem.net/foo/bar",
-        update
+        update.currentVersion,
+        update.nextVersion
       ).map(_.url.renderString)
       val expected = possibleReleaseNotesFilenames.map(name =>
         s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
@@ -200,7 +209,8 @@ class VCSPackageTest extends FunSuite {
         GitHub,
         uri"https://github.com",
         uri"https://bitbucket.org/foo/bar",
-        update
+        update.currentVersion,
+        update.nextVersion
       ).map(_.url.renderString)
       val expected =
         possibleReleaseNotesFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name") ++
@@ -218,7 +228,8 @@ class VCSPackageTest extends FunSuite {
         GitHub,
         uri"https://github.com",
         uri"https://scalacenter.github.io/scalafix/",
-        update
+        update.currentVersion,
+        update.nextVersion
       ).map(_.url.renderString)
       assertEquals(obtained, List.empty)
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -5,213 +5,248 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.git
 import org.scalasteward.core.vcs.VCSType.{GitHub, GitLab}
+import org.scalasteward.core.data.GroupedUpdate
 import org.scalasteward.core.vcs.data.Repo
 
 class VCSPackageTest extends FunSuite {
   private val repo = Repo("foo", "bar")
-  private val update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
-  private val updateBranch = git.branchFor(update, None)
 
-  test("listingBranch") {
-    assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:${updateBranch.name}")
-    assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
-  }
+  // Single updates
 
-  test("createBranch") {
-    assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:${updateBranch.name}")
-    assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
-  }
+  {
 
-  test("possibleCompareUrls") {
-    val onPremVCS = "https://github.onprem.io/"
-    val onPremVCSUri = uri"https://github.onprem.io/"
+    val update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
+    val updateBranch = git.branchFor(update, None)
 
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        uri"https://github.com/foo/bar",
-        update
-      ).map(_.url.renderString),
-      List(
-        "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
-        "https://github.com/foo/bar/compare/1.2.0...1.2.3",
-        "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+    test("listingBranch (single)") {
+      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:${updateBranch.name}")
+      assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+
+    test("createBranch (single)") {
+      assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:${updateBranch.name}")
+      assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+
+    test("possibleCompareUrls") {
+      val onPremVCS = "https://github.onprem.io/"
+      val onPremVCSUri = uri"https://github.onprem.io/"
+
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          uri"https://github.com/foo/bar",
+          update
+        ).map(_.url.renderString),
+        List(
+          "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
+          "https://github.com/foo/bar/compare/1.2.0...1.2.3",
+          "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+        )
       )
-    )
 
-    // should canonicalize (drop last slash)
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        uri"https://github.com/foo/bar/",
-        update
-      ).map(_.url.renderString),
-      List(
-        "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
-        "https://github.com/foo/bar/compare/1.2.0...1.2.3",
-        "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+      // should canonicalize (drop last slash)
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          uri"https://github.com/foo/bar/",
+          update
+        ).map(_.url.renderString),
+        List(
+          "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
+          "https://github.com/foo/bar/compare/1.2.0...1.2.3",
+          "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+        )
       )
-    )
 
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        uri"https://gitlab.com/foo/bar",
-        update
-      ).map(_.url.renderString),
-      List(
-        "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
-        "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
-        "https://gitlab.com/foo/bar/compare/release-1.2.0...release-1.2.3"
-      )
-    )
-
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        uri"https://bitbucket.org/foo/bar",
-        update
-      ).map(_.url.renderString),
-      List(
-        "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
-        "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff",
-        "https://bitbucket.org/foo/bar/compare/release-1.2.3..release-1.2.0#diff"
-      )
-    )
-
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        uri"https://scalacenter.github.io/scalafix/",
-        update
-      ),
-      List.empty
-    )
-
-    assertEquals(
-      possibleCompareUrls(
-        GitHub,
-        onPremVCSUri,
-        onPremVCSUri.addPath("foo/bar"),
-        update
-      ).map(_.url.renderString),
-      List(
-        s"${onPremVCS}foo/bar/compare/v1.2.0...v1.2.3",
-        s"${onPremVCS}foo/bar/compare/1.2.0...1.2.3",
-        s"${onPremVCS}foo/bar/compare/release-1.2.0...release-1.2.3"
-      )
-    )
-  }
-
-  test("possibleChangelogUrls: github.com") {
-    val obtained = possibleReleaseRelatedUrls(
-      GitHub,
-      uri"https://github.com",
-      uri"https://github.com/foo/bar",
-      update
-    ).map(_.url.renderString)
-    val expected = List(
-      "https://github.com/foo/bar/releases/tag/v1.2.3",
-      "https://github.com/foo/bar/releases/tag/1.2.3",
-      "https://github.com/foo/bar/releases/tag/release-1.2.3",
-      "https://github.com/foo/bar/blob/master/ReleaseNotes.md",
-      "https://github.com/foo/bar/blob/master/ReleaseNotes.markdown",
-      "https://github.com/foo/bar/blob/master/ReleaseNotes.rst",
-      "https://github.com/foo/bar/blob/master/RELEASES.md",
-      "https://github.com/foo/bar/blob/master/RELEASES.markdown",
-      "https://github.com/foo/bar/blob/master/RELEASES.rst",
-      "https://github.com/foo/bar/blob/master/Releases.md",
-      "https://github.com/foo/bar/blob/master/Releases.markdown",
-      "https://github.com/foo/bar/blob/master/Releases.rst",
-      "https://github.com/foo/bar/blob/master/releases.md",
-      "https://github.com/foo/bar/blob/master/releases.markdown",
-      "https://github.com/foo/bar/blob/master/releases.rst",
-      "https://github.com/foo/bar/blob/master/CHANGELOG.md",
-      "https://github.com/foo/bar/blob/master/CHANGELOG.markdown",
-      "https://github.com/foo/bar/blob/master/CHANGELOG.rst",
-      "https://github.com/foo/bar/blob/master/Changelog.md",
-      "https://github.com/foo/bar/blob/master/Changelog.markdown",
-      "https://github.com/foo/bar/blob/master/Changelog.rst",
-      "https://github.com/foo/bar/blob/master/changelog.md",
-      "https://github.com/foo/bar/blob/master/changelog.markdown",
-      "https://github.com/foo/bar/blob/master/changelog.rst",
-      "https://github.com/foo/bar/blob/master/CHANGES.md",
-      "https://github.com/foo/bar/blob/master/CHANGES.markdown",
-      "https://github.com/foo/bar/blob/master/CHANGES.rst",
-      "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
-      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
-      "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
-    )
-    assertEquals(obtained, expected)
-  }
-
-  test("possibleChangelogUrls: gitlab.com") {
-    val obtained = possibleReleaseRelatedUrls(
-      GitHub,
-      uri"https://github.com",
-      uri"https://gitlab.com/foo/bar",
-      update
-    ).map(_.url.renderString)
-    val expected =
-      possibleReleaseNotesFilenames.map(name => s"https://gitlab.com/foo/bar/blob/master/$name") ++
-        possibleChangelogFilenames.map(name => s"https://gitlab.com/foo/bar/blob/master/$name") ++
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          uri"https://gitlab.com/foo/bar",
+          update
+        ).map(_.url.renderString),
         List(
           "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
           "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
           "https://gitlab.com/foo/bar/compare/release-1.2.0...release-1.2.3"
         )
-    assertEquals(obtained, expected)
-  }
+      )
 
-  test("possibleChangelogUrls: on-prem gitlab") {
-    val obtained = possibleReleaseRelatedUrls(
-      GitLab,
-      uri"https://gitlab.on-prem.net",
-      uri"https://gitlab.on-prem.net/foo/bar",
-      update
-    ).map(_.url.renderString)
-    val expected = possibleReleaseNotesFilenames.map(name =>
-      s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
-    ) ++ possibleChangelogFilenames.map(name =>
-      s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
-    ) ++ List(
-      "https://gitlab.on-prem.net/foo/bar/compare/v1.2.0...v1.2.3",
-      "https://gitlab.on-prem.net/foo/bar/compare/1.2.0...1.2.3",
-      "https://gitlab.on-prem.net/foo/bar/compare/release-1.2.0...release-1.2.3"
-    )
-    assertEquals(obtained, expected)
-  }
-
-  test("possibleChangelogUrls: bitbucket.org") {
-    val obtained = possibleReleaseRelatedUrls(
-      GitHub,
-      uri"https://github.com",
-      uri"https://bitbucket.org/foo/bar",
-      update
-    ).map(_.url.renderString)
-    val expected =
-      possibleReleaseNotesFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name") ++
-        possibleChangelogFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name") ++
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          uri"https://bitbucket.org/foo/bar",
+          update
+        ).map(_.url.renderString),
         List(
           "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
           "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff",
           "https://bitbucket.org/foo/bar/compare/release-1.2.3..release-1.2.0#diff"
         )
-    assertEquals(obtained, expected)
+      )
+
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          uri"https://scalacenter.github.io/scalafix/",
+          update
+        ),
+        List.empty
+      )
+
+      assertEquals(
+        possibleCompareUrls(
+          GitHub,
+          onPremVCSUri,
+          onPremVCSUri.addPath("foo/bar"),
+          update
+        ).map(_.url.renderString),
+        List(
+          s"${onPremVCS}foo/bar/compare/v1.2.0...v1.2.3",
+          s"${onPremVCS}foo/bar/compare/1.2.0...1.2.3",
+          s"${onPremVCS}foo/bar/compare/release-1.2.0...release-1.2.3"
+        )
+      )
+    }
+
+    test("possibleChangelogUrls: github.com") {
+      val obtained = possibleReleaseRelatedUrls(
+        GitHub,
+        uri"https://github.com",
+        uri"https://github.com/foo/bar",
+        update
+      ).map(_.url.renderString)
+      val expected = List(
+        "https://github.com/foo/bar/releases/tag/v1.2.3",
+        "https://github.com/foo/bar/releases/tag/1.2.3",
+        "https://github.com/foo/bar/releases/tag/release-1.2.3",
+        "https://github.com/foo/bar/blob/master/ReleaseNotes.md",
+        "https://github.com/foo/bar/blob/master/ReleaseNotes.markdown",
+        "https://github.com/foo/bar/blob/master/ReleaseNotes.rst",
+        "https://github.com/foo/bar/blob/master/RELEASES.md",
+        "https://github.com/foo/bar/blob/master/RELEASES.markdown",
+        "https://github.com/foo/bar/blob/master/RELEASES.rst",
+        "https://github.com/foo/bar/blob/master/Releases.md",
+        "https://github.com/foo/bar/blob/master/Releases.markdown",
+        "https://github.com/foo/bar/blob/master/Releases.rst",
+        "https://github.com/foo/bar/blob/master/releases.md",
+        "https://github.com/foo/bar/blob/master/releases.markdown",
+        "https://github.com/foo/bar/blob/master/releases.rst",
+        "https://github.com/foo/bar/blob/master/CHANGELOG.md",
+        "https://github.com/foo/bar/blob/master/CHANGELOG.markdown",
+        "https://github.com/foo/bar/blob/master/CHANGELOG.rst",
+        "https://github.com/foo/bar/blob/master/Changelog.md",
+        "https://github.com/foo/bar/blob/master/Changelog.markdown",
+        "https://github.com/foo/bar/blob/master/Changelog.rst",
+        "https://github.com/foo/bar/blob/master/changelog.md",
+        "https://github.com/foo/bar/blob/master/changelog.markdown",
+        "https://github.com/foo/bar/blob/master/changelog.rst",
+        "https://github.com/foo/bar/blob/master/CHANGES.md",
+        "https://github.com/foo/bar/blob/master/CHANGES.markdown",
+        "https://github.com/foo/bar/blob/master/CHANGES.rst",
+        "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
+        "https://github.com/foo/bar/compare/1.2.0...1.2.3",
+        "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+      )
+      assertEquals(obtained, expected)
+    }
+
+    test("possibleChangelogUrls: gitlab.com") {
+      val obtained = possibleReleaseRelatedUrls(
+        GitHub,
+        uri"https://github.com",
+        uri"https://gitlab.com/foo/bar",
+        update
+      ).map(_.url.renderString)
+      val expected =
+        possibleReleaseNotesFilenames.map(name =>
+          s"https://gitlab.com/foo/bar/blob/master/$name"
+        ) ++
+          possibleChangelogFilenames.map(name => s"https://gitlab.com/foo/bar/blob/master/$name") ++
+          List(
+            "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
+            "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
+            "https://gitlab.com/foo/bar/compare/release-1.2.0...release-1.2.3"
+          )
+      assertEquals(obtained, expected)
+    }
+
+    test("possibleChangelogUrls: on-prem gitlab") {
+      val obtained = possibleReleaseRelatedUrls(
+        GitLab,
+        uri"https://gitlab.on-prem.net",
+        uri"https://gitlab.on-prem.net/foo/bar",
+        update
+      ).map(_.url.renderString)
+      val expected = possibleReleaseNotesFilenames.map(name =>
+        s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
+      ) ++ possibleChangelogFilenames.map(name =>
+        s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
+      ) ++ List(
+        "https://gitlab.on-prem.net/foo/bar/compare/v1.2.0...v1.2.3",
+        "https://gitlab.on-prem.net/foo/bar/compare/1.2.0...1.2.3",
+        "https://gitlab.on-prem.net/foo/bar/compare/release-1.2.0...release-1.2.3"
+      )
+      assertEquals(obtained, expected)
+    }
+
+    test("possibleChangelogUrls: bitbucket.org") {
+      val obtained = possibleReleaseRelatedUrls(
+        GitHub,
+        uri"https://github.com",
+        uri"https://bitbucket.org/foo/bar",
+        update
+      ).map(_.url.renderString)
+      val expected =
+        possibleReleaseNotesFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name") ++
+          possibleChangelogFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name") ++
+          List(
+            "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
+            "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff",
+            "https://bitbucket.org/foo/bar/compare/release-1.2.3..release-1.2.0#diff"
+          )
+      assertEquals(obtained, expected)
+    }
+
+    test("possibleChangelogUrls: homepage") {
+      val obtained = possibleReleaseRelatedUrls(
+        GitHub,
+        uri"https://github.com",
+        uri"https://scalacenter.github.io/scalafix/",
+        update
+      ).map(_.url.renderString)
+      assertEquals(obtained, List.empty)
+    }
+
   }
 
-  test("possibleChangelogUrls: homepage") {
-    val obtained = possibleReleaseRelatedUrls(
-      GitHub,
-      uri"https://github.com",
-      uri"https://scalacenter.github.io/scalafix/",
-      update
-    ).map(_.url.renderString)
-    assertEquals(obtained, List.empty)
+  // Grouped updates
+
+  {
+
+    val update = GroupedUpdate(
+      name = "my-group",
+      title = None,
+      updates = List(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
+    )
+
+    val updateBranch = git.branchFor(update, None)
+
+    test("listingBranch (grouped)") {
+      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group")
+      assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+
+    test("createBranch (grouped)") {
+      assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:update/my-group")
+      assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+
   }
+
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -339,4 +339,28 @@ class NewPullRequestDataTest extends FunSuite {
     assertEquals(labels, expected)
   }
 
+  test("oldVersionNote doesn't show version for grouped updates") {
+    val files = List("Readme.md", "travis.yml")
+    val update1 = ("a".g % "b".a % "1" -> "2").single
+    val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
+    val update = GroupedUpdate("my-group", None, List(update1, update2))
+
+    val note = oldVersionNote(files, update)
+
+    assertEquals(
+      note.fold("")(_.toHtml),
+      """<details>
+        |<summary>Files still referring to the old version numbers</summary>
+        |
+        |The following files still refer to the old version numbers.
+        |You might want to review and update them manually.
+        |```
+        |Readme.md
+        |travis.yml
+        |```
+        |</details>
+      """.stripMargin.trim
+    )
+  }
+
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -21,7 +21,6 @@ class NewPullRequestDataTest extends FunSuite {
       RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
-      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
       dummySha1,
       Branch("update/logback-classic-1.2.3")
@@ -52,7 +51,6 @@ class NewPullRequestDataTest extends FunSuite {
         RepoConfig.empty
       ),
       Repo("scala-steward", "bar"),
-      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
       dummySha1,
@@ -408,7 +406,6 @@ class NewPullRequestDataTest extends FunSuite {
     val data = UpdateData(
       RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),
-      null,
       update,
       Branch("master"),
       dummySha1,

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -20,6 +20,7 @@ class NewPullRequestDataTest extends FunSuite {
       RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
+      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
       dummySha1,
       Branch("update/logback-classic-1.2.3")
@@ -50,6 +51,7 @@ class NewPullRequestDataTest extends FunSuite {
         RepoConfig.empty
       ),
       Repo("scala-steward", "bar"),
+      ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
       Branch("master"),
       dummySha1,

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -363,4 +363,41 @@ class NewPullRequestDataTest extends FunSuite {
     )
   }
 
+  test("adjustFutureUpdates for grouped udpates shows settings for each update") {
+    val update1 = ("a".g % "b".a % "1" -> "2").single
+    val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
+    val update = GroupedUpdate("my-group", None, List(update1, update2))
+
+    val note = adjustFutureUpdates(update)
+
+    assertEquals(
+      note.toHtml,
+      """<details>
+        |<summary>Adjust future updates</summary>
+        |
+        |Add these to your `.scala-steward.conf` file to ignore future updates of these dependencies:
+        |```
+        |updates.ignore = [
+        |  { groupId = "a", artifactId = "b" },
+        |  { groupId = "c", artifactId = "d" }
+        |]
+        |```
+        |Or, add these to slow down future updates of these dependencies:
+        |```
+        |dependencyOverrides = [
+        |  {
+        |    pullRequests = { frequency = "@monthly" },
+        |    dependency = { groupId = "a", artifactId = "b" }
+        |  },
+        |  {
+        |    pullRequests = { frequency = "@monthly" },
+        |    dependency = { groupId = "c", artifactId = "d" }
+        |  }
+        |]
+        |```
+        |</details>
+      """.stripMargin.trim
+    )
+  }
+
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -86,6 +86,7 @@ class GitLabApiAlgTest extends FunSuite {
     RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
     Repo("scala-steward", "bar"),
     ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
+    ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
     Branch("master"),
     Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
     Branch("update/logback-classic-1.2.3")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -86,7 +86,6 @@ class GitLabApiAlgTest extends FunSuite {
     RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
     Repo("scala-steward", "bar"),
     ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
-    ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
     Branch("master"),
     Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
     Branch("update/logback-classic-1.2.3")


### PR DESCRIPTION
## 💻 How to review this PR?

This PR was created with the idea of being reviewed commit by commit.

Each commit contains an incremental change (and its tests, if applicable) that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## 🎯 What's the goal of this PR?

This PR adds support for a long-requested feature of Scala Steward, the ability to group pull-request updates.

## ❓ How this will be done?

A new configuration value (`pullRequests.grouping`) can be added to the `.scala-steward.conf` file. This config will represent the desired PR groups.

A group will be an object with:

- `name` (mandatory): the name of the group, can be used for things like naming the branch.
- `title` (optional): if provided it will be used as the title for the PR.
- `filter` (mandatory): a non-empty list containing the filters to use to know if an update falls into this group. Filters would have this format:
  + `{version = "major" | "minor" | "patch" | "pre-release" | "build-metadata"}, group = "{group}", artifact = "{artifact}"}`.

For filters every component is optional but at least one must be provided. For grouping every update a filter like `{group = "*"}` can be provided.

<details><summary><b>Examples</b></summary></br>

```conf
pullRequests.grouping = [
  { name = "patches", title = "Patch updates", filter = [{version = "patch"}] },
  { name = "minor_major", title = "Minor/major updates", filter = [{version = "minor"}, {version = "major"}] }
]
```

☝🏼 This configuration will group updates in two PRs: one titled "Patch updates" that will contain patch version updates and another one titled "Minor/major updates" with the rest of them.

```conf
pullRequests.grouping = [
  { name = "typelevel", title = "Typelevel updates", filter = [{group = "org.typelevel"}, {group = "org.http4s"}] }
]
```

☝🏼 This configuration will group Typelevel and Http4s updates into one PR.  Since there is no other group, any update not falling into this group will follow normal behavior.

```conf
pullRequests.grouping = [
  { name = "my_libraries", filter = [{"artifact" = "my-library-*"}, {"artifact" = "my-other-library", "group" = "my-org.*"}] },
  { name = "all", title = "Not my libraries, filter = [{group = "*"] }
]
```

☝🏼 This configuration will group updates whose artifact is named `my-library` or `my-org:my-other-library` in one PR titled `my_libraries` (no title provided, so it will use `name`) and any other update under one PR titled "Not my libraries"

</details>

### 🔖 Summary of changes made

- [x] Created class for representing configuration for grouping updates pull-requests
- [x] Add method for grouping `Update` objects based on configuration.
- [x] Fork the current method to process updates:
   + [x] Updates not falling into any group will follow normal update mechanism.
   + [x] A new mechanism will be created for creating pull-requests with grouped updates. This "grouped" pull requests should contain most features from the current mechanism (list of changes, scalafix migrations, hooks...) but there are some (closing a PR ignores the version) that won't be supported.
- [x] Adding tests for new paths in the code.
- [x] Update documentation for new configuration.