### PR TITLE
Update to scoverage to 2.0.5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.5")
 
 // A workaround until sbt ecosystem migrate to scala-xml 2.x https://github.com/sbt/sbt/issues/6997
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
This is a blocker to update Scala to 2.13.10