### PR TITLE
Update logback-classic only on 1.3.x series that supports JDK 8

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,2 +1,6 @@
 updatePullRequests = "always"
 
+updates.pin = [
+  # We may drop this when we drop JDK 8 since minimum JDK is 11 from logback-classic 1.4.0
+  { groupId = "ch.qos.logback", artifactId="logback-classic", version="1.3." }
+]


### PR DESCRIPTION
Supersedes #2719 

[logback-classic no longer supports JDK 8 starting from 1.4.0](https://logback.qos.ch/dependencies.html).
![image](https://user-images.githubusercontent.com/127635/196861865-73f3b8a2-2bc5-4fd3-a512-8b65623d27dc.png)


Let's pin it to 1.3.x series until we drop JDK 8 support.