### PR TITLE
Fix grouping feature

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -162,7 +162,7 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
       data.update
         .on(
           update = editAlg.applyUpdate(data.repoData, _, createBranch),
-          grouped = _.updates.flatTraverse(editAlg.applyUpdate(data.repoData, _, createBranch))
+          grouped = createBranch >> _.updates.flatTraverse(editAlg.applyUpdate(data.repoData, _))
         )
         .flatMap { edits =>
           val editCommits = edits.flatMap(_.commits)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -57,6 +57,7 @@ object PullRequestsConfig {
       (x, y) =>
         PullRequestsConfig(
           frequency = x.frequency.orElse(y.frequency),
+          grouping = x.grouping |+| y.grouping,
           includeMatchedLabels = x.includeMatchedLabels.orElse(y.includeMatchedLabels)
         )
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -69,9 +69,10 @@ object logger {
   }
 
   def showUpdates(allUpdates: List[AnUpdate]): String = {
-    val updates = allUpdates.flatMap {
-      case g: GroupedUpdate => g.updates.map(_.show)
-      case u: Update        => List(u.show)
+    val updates = allUpdates.map {
+      case g: GroupedUpdate =>
+        g.updates.map(_.show).mkString(s"${g.name} (group) {\n    ", "\n    ", "\n  }")
+      case u: Update => u.show
     }
 
     val list = string.indentLines(updates)

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -5,6 +5,9 @@ import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.util.logger.LoggerOps
+import org.scalasteward.core.util.logger.showUpdates
+import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.data.GroupedUpdate
 
 class loggerTest extends CatsEffectSuite {
   test("attemptError.label_") {
@@ -26,4 +29,37 @@ class loggerTest extends CatsEffectSuite {
       assertEquals(state.trace.size, 1)
     }
   }
+
+  test("showUpdates") {
+    val a = ("a".g % "a".a % "1.0.0" %> "1.0.1").single
+    val b = ("a".g % "b".a % "1.0.0" %> "1.1.0").single
+    val c = ("a".g % "c".a % "1.0.0" %> "2.0.0").single
+
+    val list = List(
+      GroupedUpdate("all", None, List(a, b, c)),
+      GroupedUpdate("some", None, List(a, b)),
+      a,
+      b,
+      c
+    )
+
+    val result = showUpdates(list)
+
+    val expected = """Found 5 updates:
+                     |  all (group) {
+                     |    a:a : 1.0.0 -> 1.0.1
+                     |    a:b : 1.0.0 -> 1.1.0
+                     |    a:c : 1.0.0 -> 2.0.0
+                     |  }
+                     |  some (group) {
+                     |    a:a : 1.0.0 -> 1.0.1
+                     |    a:b : 1.0.0 -> 1.1.0
+                     |  }
+                     |  a:a : 1.0.0 -> 1.0.1
+                     |  a:b : 1.0.0 -> 1.1.0
+                     |  a:c : 1.0.0 -> 2.0.0""".stripMargin
+
+    assertEquals(result, expected)
+  }
+
 }


### PR DESCRIPTION
## 🚀 What has been done in this PR?

- Fixes two bugs introduced on #2714:
   + `grouping` wasn't been joined properly when using the `Monoid` instance.
   + The update branch was trying to be created once per update in grouped updates.

It also rewords the log with the updates found so it better reflects which ones are grouped/single.

Example of PR with grouped update: https://github.com/alejandrohdezma/scala-steward-test/pull/3