### PR TITLE
Rename the `AnUpdate` hierarchy

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -33,7 +33,7 @@ class UpdatesConfigBenchmark {
     val newerVersions = Nel
       .of("2.0.0", "2.1.0", "2.1.1", "2.2.0", "3.0.0", "3.1.0", "3.2.1", "3.3.3", "4.0", "5.0")
       .map(Version.apply)
-    val update = Update.Single(dependency, newerVersions)
+    val update = Update.ForArtifactId(dependency, newerVersions)
 
     UpdatesConfig().keep(update)
     UpdatesConfig(allow = List(UpdatePattern(groupId, None, None))).keep(update)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -102,7 +102,7 @@ object MillAlg {
   private def millMainArtifact(version: Version): Dependency =
     Dependency(millMainGroupId, millMainArtifactId, version)
 
-  def isMillMainUpdate(update: Update): Boolean =
+  def isMillMainUpdate(update: Update.Single): Boolean =
     update.groupId === millMainGroupId && update.artifactIds.exists(
       _.name === millMainArtifactId.name
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -18,116 +18,77 @@ package org.scalasteward.core.data
 
 import cats.Order
 import cats.implicits._
-import io.circe.Codec
-import io.circe.syntax._
 import io.circe.generic.semiauto._
-import org.scalasteward.core.data.Update.Group
-import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.string.MinLengthString
 import io.circe.Decoder
+import io.circe.Encoder
 
-sealed trait AnUpdate {
+sealed trait Update {
 
-  def on[A](update: Update => A, grouped: GroupedUpdate => A): A = this match {
-    case g: GroupedUpdate => grouped(g)
-    case u: Update        => update(u)
+  def on[A](update: Update.Single => A, grouped: Update.Grouped => A): A = this match {
+    case g: Update.Grouped => grouped(g)
+    case u: Update.Single  => update(u)
   }
 
   def show: String
 
 }
 
-object AnUpdate {
-
-  implicit val AnUpdateCodec: Codec[AnUpdate] = Codec.from(
-    Decoder[GroupedUpdate].widen[AnUpdate].or(Decoder[Update].widen[AnUpdate]),
-    _.on(_.asJson, _.asJson)
-  )
-
-}
-
-final case class GroupedUpdate(name: String, title: Option[String], updates: List[Update])
-    extends AnUpdate {
-
-  override def show: String = name
-
-}
-
-object GroupedUpdate {
-
-  /**
-    * Processes the provided updates using the group configuration. Each update will only be present in the
-    * first group it falls into.
-    *
-    * Updates that do not fall into any group will be returned back in the second return parameter.
-    */
-  /**
-    * Processes the provided updates using the group configuration. Each update will only be present in the
-    * first group it falls into.
-    *
-    * Updates that do not fall into any group will be returned back in the second return parameter.
-    */
-  def from(
-      groups: List[PullRequestGroup],
-      updates: List[Update.Single]
-  ): (List[GroupedUpdate], List[Update.Single]) =
-    groups.foldLeft((List.empty[GroupedUpdate], updates)) { case ((grouped, notGrouped), group) =>
-      notGrouped.partition(group.matches) match {
-        case (Nil, rest)     => (grouped, rest)
-        case (matched, rest) => (grouped :+ GroupedUpdate(group.name, group.title, matched), rest)
-      }
-    }
-
-  implicit val GroupedUpdateCodec: Codec[GroupedUpdate] = deriveCodec
-
-}
-
-sealed trait Update extends Product with Serializable with AnUpdate {
-  def crossDependencies: Nel[CrossDependency]
-  def dependencies: Nel[Dependency]
-  def groupId: GroupId
-  def artifactIds: Nel[ArtifactId]
-  def mainArtifactId: String
-  def currentVersion: Version
-  def newerVersions: Nel[Version]
-
-  final def name: String =
-    Update.nameOf(groupId, mainArtifactId)
-
-  final def nextVersion: Version =
-    newerVersions.head
-
-  final override def show: String = {
-    val artifacts = this match {
-      case s: Single => s.crossDependency.showArtifactNames
-      case g: Group  => g.crossDependencies.map(_.showArtifactNames).mkString_("{", ", ", "}")
-    }
-    val versions = {
-      val vs0 = (currentVersion :: newerVersions).toList
-      val vs1 = if (vs0.size > 6) vs0.take(3) ++ ("..." :: vs0.takeRight(3)) else vs0
-      vs1.mkString("", " -> ", "")
-    }
-    s"$groupId:$artifacts : $versions"
-  }
-
-  def withNewerVersions(versions: Nel[Version]): Update = this match {
-    case s @ Single(_, _, _, _) =>
-      s.copy(newerVersions = versions)
-    case g @ Group(_, _) =>
-      g.copy(newerVersions = versions)
-  }
-}
-
 object Update {
-  final case class Single(
+
+  final case class Grouped(
+      name: String,
+      title: Option[String],
+      updates: List[Update.ForArtifactId]
+  ) extends Update {
+
+    override def show: String = name
+
+  }
+
+  sealed trait Single extends Product with Serializable with Update {
+    def crossDependencies: Nel[CrossDependency]
+    def dependencies: Nel[Dependency]
+    def groupId: GroupId
+    def artifactIds: Nel[ArtifactId]
+    def mainArtifactId: String
+    def currentVersion: Version
+    def newerVersions: Nel[Version]
+
+    final def name: String = Update.nameOf(groupId, mainArtifactId)
+
+    final def nextVersion: Version = newerVersions.head
+
+    final override def show: String = {
+      val artifacts = this match {
+        case s: ForArtifactId => s.crossDependency.showArtifactNames
+        case g: ForGroupId => g.crossDependencies.map(_.showArtifactNames).mkString_("{", ", ", "}")
+      }
+      val versions = {
+        val vs0 = (currentVersion :: newerVersions).toList
+        val vs1 = if (vs0.size > 6) vs0.take(3) ++ ("..." :: vs0.takeRight(3)) else vs0
+        vs1.mkString("", " -> ", "")
+      }
+      s"$groupId:$artifacts : $versions"
+    }
+
+    def withNewerVersions(versions: Nel[Version]): Update.Single = this match {
+      case s @ ForArtifactId(_, _, _, _) =>
+        s.copy(newerVersions = versions)
+      case g @ ForGroupId(_, _) =>
+        g.copy(newerVersions = versions)
+    }
+  }
+
+  final case class ForArtifactId(
       crossDependency: CrossDependency,
       newerVersions: Nel[Version],
       newerGroupId: Option[GroupId] = None,
       newerArtifactId: Option[String] = None
-  ) extends Update {
+  ) extends Single {
     override def crossDependencies: Nel[CrossDependency] =
       Nel.one(crossDependency)
 
@@ -150,10 +111,10 @@ object Update {
       crossDependency.head.artifactId
   }
 
-  final case class Group(
+  final case class ForGroupId(
       crossDependencies: Nel[CrossDependency],
       newerVersions: Nel[Version]
-  ) extends Update {
+  ) extends Single {
     override def dependencies: Nel[Dependency] =
       crossDependencies.flatMap(_.dependencies)
 
@@ -191,29 +152,79 @@ object Update {
     else
       artifactId
 
-  def groupByArtifactIdName(updates: List[Single]): List[Single] = {
+  def groupByArtifactIdName(updates: List[ForArtifactId]): List[ForArtifactId] = {
     val groups0 =
       updates.groupByNel(s => (s.groupId, s.artifactId.name, s.currentVersion, s.newerVersions))
     val groups1 = groups0.values.map { group =>
       val dependencies = group.flatMap(_.crossDependency.dependencies).distinct.sorted
       group.head.copy(crossDependency = CrossDependency(dependencies))
     }
-    groups1.toList.distinct.sortBy(u => u: Update)
+    groups1.toList.distinct.sortBy(u => u: Update.Single)
   }
 
-  def groupByGroupId(updates: List[Single]): List[Update] = {
+  def groupByGroupId(updates: List[ForArtifactId]): List[Single] = {
     val groups0 =
       updates.groupByNel(s => (s.groupId, s.currentVersion, s.newerVersions))
     val groups1 = groups0.values.map { group =>
       if (group.tail.isEmpty) group.head
-      else Group(group.map(_.crossDependency), group.head.newerVersions)
+      else ForGroupId(group.map(_.crossDependency), group.head.newerVersions)
     }
     groups1.toList.distinct.sorted
   }
 
-  implicit val updateCodec: Codec[Update] =
-    deriveCodec
+  /**
+    * Processes the provided updates using the group configuration. Each update will only be present in the
+    * first group it falls into.
+    *
+    * Updates that do not fall into any group will be returned back in the second return parameter.
+    */
+  def groupByPullRequestGroup(
+      groups: List[PullRequestGroup],
+      updates: List[Update.ForArtifactId]
+  ): (List[Grouped], List[Update.ForArtifactId]) =
+    groups.foldLeft((List.empty[Grouped], updates)) { case ((grouped, notGrouped), group) =>
+      notGrouped.partition(group.matches) match {
+        case (Nil, rest)     => (grouped, rest)
+        case (matched, rest) => (grouped :+ Grouped(group.name, group.title, matched), rest)
+      }
+    }
 
-  implicit val updateOrder: Order[Update] =
-    Order.by((u: Update) => (u.crossDependencies, u.newerVersions))
+  // TODO: Derive all instances of `Encoder`/`Decoder` here using `deriveCodec`
+  // Partially manually implemented so we don't fail reading old caches (those
+  // still using `Single`/`Group`)
+
+  implicit val ForArtifactIdEncoder: Encoder[ForArtifactId] = deriveEncoder
+
+  implicit val ForArtifactIdDecoder: Decoder[ForArtifactId] = {
+    val derived = deriveDecoder[ForArtifactId]
+    derived
+      .prepare(_.downField("ForArtifactId"))
+      .or(derived.prepare(_.downField("Single")))
+  }
+
+  implicit val ForGroupIdEncoder: Encoder[ForGroupId] = deriveEncoder
+
+  implicit val ForGroupIdDecoder: Decoder[ForGroupId] = {
+    val derived = deriveDecoder[ForGroupId]
+    derived
+      .prepare(_.downField("ForGroupId"))
+      .or(derived.prepare(_.downField("Group")))
+  }
+
+  implicit val GroupedEncoder: Encoder[Grouped] = deriveEncoder
+
+  implicit val GroupedDecoder: Decoder[Grouped] =
+    deriveDecoder[Grouped].prepare(_.downField("Grouped"))
+
+  implicit val SingleOrder: Order[Single] =
+    Order.by((u: Single) => (u.crossDependencies, u.newerVersions))
+
+  implicit val UpdateEncoder: Encoder[Update] = deriveEncoder
+
+  implicit val UpdateDecoder: Decoder[Update] =
+    ForArtifactIdDecoder
+      .widen[Update]
+      .or(ForGroupIdDecoder.widen[Update])
+      .or(Decoder[Grouped].widen[Update])
+
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.vcs.data.Repo
 final case class UpdateData(
     repoData: RepoData,
     fork: Repo,
-    update: AnUpdate,
+    update: Update,
     baseBranch: Branch,
     baseSha1: Sha1,
     updateBranch: Branch

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAttempt.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAttempt.scala
@@ -26,7 +26,7 @@ sealed trait EditAttempt extends Product with Serializable {
 }
 
 object EditAttempt {
-  final case class UpdateEdit(update: Update, commit: Commit) extends EditAttempt {
+  final case class UpdateEdit(update: Update.Single, commit: Commit) extends EditAttempt {
     override def commits: List[Commit] = List(commit)
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -45,7 +45,7 @@ final class HookExecutor[F[_]](implicit
     workspaceAlg: WorkspaceAlg[F],
     F: MonadThrow[F]
 ) {
-  def execPostUpdateHooks(data: RepoData, update: Update): F[List[EditAttempt]] =
+  def execPostUpdateHooks(data: RepoData, update: Update.Single): F[List[EditAttempt]] =
     (HookExecutor.postUpdateHooks ++ data.config.postUpdateHooksOrDefault)
       .filter { hook =>
         hook.groupId.forall(update.groupId === _) &&
@@ -56,7 +56,11 @@ final class HookExecutor[F[_]](implicit
       .distinctBy(_.command)
       .traverse(execPostUpdateHook(data.repo, update, _))
 
-  private def execPostUpdateHook(repo: Repo, update: Update, hook: PostUpdateHook): F[EditAttempt] =
+  private def execPostUpdateHook(
+      repo: Repo,
+      update: Update.Single,
+      hook: PostUpdateHook
+  ): F[EditAttempt] =
     for {
       _ <- logger.info(
         s"Executing post-update hook for ${update.groupId}:${update.mainArtifactId} with command ${hook.showCommand}"

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
@@ -28,7 +28,7 @@ final case class PostUpdateHook(
     artifactId: Option[ArtifactId],
     command: Nel[String],
     useSandbox: Boolean,
-    commitMessage: Update => CommitMsg,
+    commitMessage: Update.Single => CommitMsg,
     enabledByCache: RepoCache => Boolean,
     enabledByConfig: RepoConfig => Boolean,
     addToGitBlameIgnoreRevs: Boolean

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
@@ -21,7 +21,7 @@ import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.ExecutionOrder
 
 final class ScalafixMigrationsFinder(migrations: List[ScalafixMigration]) {
-  def findMigrations(update: Update): (List[ScalafixMigration], List[ScalafixMigration]) =
+  def findMigrations(update: Update.Single): (List[ScalafixMigration], List[ScalafixMigration]) =
     migrations
       .filter { migration =>
         update.groupId === migration.groupId &&

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.git
 
 import cats.syntax.all._
-import org.scalasteward.core.data.AnUpdate
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.update.show
 import org.scalasteward.core.util.Nel
 
@@ -39,7 +39,7 @@ final case class CommitMsg(
 }
 
 object CommitMsg {
-  def replaceVariables(s: String)(update: AnUpdate, baseBranch: Option[Branch]): CommitMsg =
+  def replaceVariables(s: String)(update: Update, baseBranch: Option[Branch]): CommitMsg =
     update.on(
       u => {
         val artifactNameValue = show.oneLiner(u)

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core
 
-import org.scalasteward.core.data.{AnUpdate, GroupedUpdate, Update}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.repoconfig.CommitsConfig
 import org.scalasteward.core.vcs.data.Repo
 
@@ -27,16 +27,16 @@ package object git {
 
   val updateBranchPrefix = "update"
 
-  def branchFor(update: AnUpdate, baseBranch: Option[Branch]): Branch = {
+  def branchFor(update: Update, baseBranch: Option[Branch]): Branch = {
     val base = baseBranch.fold("")(branch => s"${branch.name}/")
-    update match {
-      case g: GroupedUpdate => Branch(s"$updateBranchPrefix/$base${g.name}")
-      case u: Update        => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}")
-    }
+    update.on(
+      update = u => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}"),
+      grouped = g => Branch(s"$updateBranchPrefix/$base${g.name}")
+    )
   }
 
   def commitMsgFor(
-      update: Update,
+      update: Update.Single,
       commitsConfig: CommitsConfig,
       branch: Option[Branch]
   ): CommitMsg =

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -24,12 +24,12 @@ import org.scalasteward.core.data.Update
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtConfName, scalafmtGroupId}
 
 package object io {
-  def isSourceFile(update: Update, fileExtensions: Set[String])(file: File): Boolean = {
+  def isSourceFile(update: Update.Single, fileExtensions: Set[String])(file: File): Boolean = {
     val notInGitDir = !file.pathAsString.contains(".git/")
     notInGitDir && isSpecificOrGenericSourceFile(update, fileExtensions)(file)
   }
 
-  private def isSpecificOrGenericSourceFile(update: Update, fileExtensions: Set[String])(
+  private def isSpecificOrGenericSourceFile(update: Update.Single, fileExtensions: Set[String])(
       file: File
   ): Boolean =
     () match {
@@ -42,11 +42,11 @@ package object io {
   private def isGenericSourceFile(file: File, fileExtensions: Set[String]): Boolean =
     fileExtensions.exists(file.name.endsWith)
 
-  private def isSbtUpdate(update: Update): Boolean =
+  private def isSbtUpdate(update: Update.Single): Boolean =
     update.groupId === sbtGroupId &&
       update.artifactIds.exists(_.name === sbtArtifactId.name)
 
-  private def isScalafmtCoreUpdate(update: Update): Boolean =
+  private def isScalafmtCoreUpdate(update: Update.Single): Boolean =
     update.groupId === scalafmtGroupId &&
       update.artifactIds.exists(_.name === scalafmtArtifactId.name)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.nurture
 
 import org.http4s.Uri
-import org.scalasteward.core.data.AnUpdate
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState}
 
 final case class PullRequestData[F[_]](
     url: Uri,
     baseSha1: Sha1,
-    update: AnUpdate,
+    update: Update,
     state: PullRequestState,
     number: F[PullRequestNumber],
     updateBranch: F[Branch]

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repoconfig
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.semiauto.deriveCodec
-import org.scalasteward.core.data.{AnUpdate, Update}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.string.indentLines
 
 final case class GroupRepoConfig(
@@ -34,14 +34,14 @@ object GroupRepoConfig {
   implicit val groupPullConfigCodec: Codec[GroupRepoConfig] =
     deriveCodec
 
-  def configToSlowDownUpdatesFrequency(update: AnUpdate): String = {
-    val forUpdate: Update => String = {
-      case s: Update.Single =>
+  def configToSlowDownUpdatesFrequency(update: Update): String = {
+    val forUpdate: Update.Single => String = {
+      case s: Update.ForArtifactId =>
         s"""{
            |  pullRequests = { frequency = "@monthly" },
            |  dependency = { groupId = "${s.groupId}", artifactId = "${s.artifactId.name}" }
            |}""".stripMargin
-      case g: Update.Group =>
+      case g: Update.ForGroupId =>
         s"""{
            |  pullRequests = { frequency = "@monthly" },
            |  dependency = { groupId = "${g.groupId}" }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -31,7 +31,7 @@ case class PullRequestGroup(
   /**
     * Returns `true` if an update falls into this group; returns `false` otherwise.
     */
-  def matches(update: Update.Single): Boolean = filter.exists(_.matches(update))
+  def matches(update: Update.ForArtifactId): Boolean = filter.exists(_.matches(update))
 
 }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
@@ -33,7 +33,7 @@ final case class PullRequestUpdateFilter private (
   /**
     * Returns `true` if an update falls into this filter; returns `false` otherwise.
     */
-  def matches(update: Update.Single): Boolean =
+  def matches(update: Update.ForArtifactId): Boolean =
     groupRegex.forall(_.matches(update.groupId.value)) &&
       artifactRegex.forall(_.matches(update.mainArtifactId)) &&
       version.forall(isMatchedVersion(_, update))
@@ -46,7 +46,7 @@ final case class PullRequestUpdateFilter private (
     new Regex(pattern)
   }
 
-  private def isMatchedVersion(versionType: SemVer.Change, update: Update.Single): Boolean =
+  private def isMatchedVersion(versionType: SemVer.Change, update: Update.ForArtifactId): Boolean =
     (SemVer.parse(update.currentVersion.value), SemVer.parse(update.nextVersion.value)).tupled
       .flatMap { case (current, next) => SemVer.getChangeEarly(current, next) }
       .map(_.render === versionType.render)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -20,7 +20,7 @@ import better.files.File
 import cats.MonadThrow
 import cats.syntax.all._
 import io.circe.config.parser
-import org.scalasteward.core.data.{AnUpdate, Update}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfigAlg._
 import org.scalasteward.core.vcs.data.Repo
@@ -60,11 +60,11 @@ object RepoConfigAlg {
   def parseRepoConfig(input: String): Either[io.circe.Error, RepoConfig] =
     parser.decode[RepoConfig](input)
 
-  def configToIgnoreFurtherUpdates(update: AnUpdate): String = {
-    val forUpdate: Update => String = {
-      case s: Update.Single =>
+  def configToIgnoreFurtherUpdates(update: Update): String = {
+    val forUpdate: Update.Single => String = {
+      case s: Update.ForArtifactId =>
         s"""{ groupId = "${s.groupId}", artifactId = "${s.artifactId.name}" }""".stripMargin
-      case g: Update.Group =>
+      case g: Update.ForGroupId =>
         s"""{ groupId = "${g.groupId}" }""".stripMargin
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -37,7 +37,7 @@ object UpdatePattern {
 
   def findMatch(
       patterns: List[UpdatePattern],
-      update: Update.Single,
+      update: Update.ForArtifactId,
       include: Boolean
   ): MatchResult = {
     val byGroupId = patterns.filter(_.groupId === update.groupId)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -43,20 +43,20 @@ final case class UpdatesConfig(
   def fileExtensionsOrDefault: Set[String] =
     fileExtensions.fold(UpdatesConfig.defaultFileExtensions)(_.toSet)
 
-  def keep(update: Update.Single): FilterResult =
+  def keep(update: Update.ForArtifactId): FilterResult =
     isAllowed(update).flatMap(isPinned).flatMap(isIgnored)
 
-  def preRelease(update: Update.Single): FilterResult =
+  def preRelease(update: Update.ForArtifactId): FilterResult =
     isAllowedPreReleases(update)
 
-  private def isAllowedPreReleases(update: Update.Single): FilterResult = {
+  private def isAllowedPreReleases(update: Update.ForArtifactId): FilterResult = {
     val m = UpdatePattern.findMatch(allowPreReleases, update, include = true)
     if (m.filteredVersions.nonEmpty)
       Right(update)
     else Left(NotAllowedByConfig(update))
   }
 
-  private def isAllowed(update: Update.Single): FilterResult = {
+  private def isAllowed(update: Update.ForArtifactId): FilterResult = {
     val m = UpdatePattern.findMatch(allow, update, include = true)
     if (m.filteredVersions.nonEmpty)
       Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
@@ -65,7 +65,7 @@ final case class UpdatesConfig(
     else Left(NotAllowedByConfig(update))
   }
 
-  private def isPinned(update: Update.Single): FilterResult = {
+  private def isPinned(update: Update.ForArtifactId): FilterResult = {
     val m = UpdatePattern.findMatch(pin, update, include = true)
     if (m.filteredVersions.nonEmpty)
       Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
@@ -74,7 +74,7 @@ final case class UpdatesConfig(
     else Left(VersionPinnedByConfig(update))
   }
 
-  private def isIgnored(update: Update.Single): FilterResult = {
+  private def isIgnored(update: Update.ForArtifactId): FilterResult = {
     val m = UpdatePattern.findMatch(ignore, update, include = false)
     if (m.filteredVersions.nonEmpty)
       Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -32,7 +32,7 @@ package object scalafmt {
   val scalafmtModule: (GroupId, ArtifactId) =
     (scalafmtGroupId, scalafmtArtifactId)
 
-  def isScalafmtUpdate(update: Update.Single): Boolean =
+  def isScalafmtUpdate(update: Update.ForArtifactId): Boolean =
     update.groupId === scalafmtGroupId && update.artifactId.name === scalafmtArtifactId.name
 
   private def scalafmtGroupIdBy(version: Version): GroupId =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -30,11 +30,11 @@ final class FilterAlg[F[_]](implicit
 ) {
   def localFilterMany[G[_]: TraverseFilter](
       config: RepoConfig,
-      updates: G[Update.Single]
-  ): F[G[Update.Single]] =
+      updates: G[Update.ForArtifactId]
+  ): F[G[Update.ForArtifactId]] =
     updates.traverseFilter(update => logIfRejected(localFilter(update, config)))
 
-  private def logIfRejected(result: FilterResult): F[Option[Update.Single]] =
+  private def logIfRejected(result: FilterResult): F[Option[Update.ForArtifactId]] =
     result match {
       case Right(update) => F.pure(update.some)
       case Left(reason) =>
@@ -43,10 +43,10 @@ final class FilterAlg[F[_]](implicit
 }
 
 object FilterAlg {
-  type FilterResult = Either[RejectionReason, Update.Single]
+  type FilterResult = Either[RejectionReason, Update.ForArtifactId]
 
   sealed trait RejectionReason {
-    def update: Update.Single
+    def update: Update.ForArtifactId
     def show: String =
       this match {
         case IgnoredByConfig(_)         => "ignored by config"
@@ -57,16 +57,16 @@ object FilterAlg {
       }
   }
 
-  final case class IgnoredByConfig(update: Update.Single) extends RejectionReason
-  final case class VersionPinnedByConfig(update: Update.Single) extends RejectionReason
-  final case class NotAllowedByConfig(update: Update.Single) extends RejectionReason
-  final case class NoSuitableNextVersion(update: Update.Single) extends RejectionReason
-  final case class VersionOrderingConflict(update: Update.Single) extends RejectionReason
+  final case class IgnoredByConfig(update: Update.ForArtifactId) extends RejectionReason
+  final case class VersionPinnedByConfig(update: Update.ForArtifactId) extends RejectionReason
+  final case class NotAllowedByConfig(update: Update.ForArtifactId) extends RejectionReason
+  final case class NoSuitableNextVersion(update: Update.ForArtifactId) extends RejectionReason
+  final case class VersionOrderingConflict(update: Update.ForArtifactId) extends RejectionReason
 
-  def localFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
+  def localFilter(update: Update.ForArtifactId, repoConfig: RepoConfig): FilterResult =
     repoConfig.updates.keep(update).flatMap(globalFilter(_, repoConfig))
 
-  private def globalFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
+  private def globalFilter(update: Update.ForArtifactId, repoConfig: RepoConfig): FilterResult =
     selectSuitableNextVersion(update, repoConfig).flatMap(checkVersionOrdering)
 
   def isDependencyConfigurationIgnored(dependency: Dependency): Boolean =
@@ -80,7 +80,7 @@ object FilterAlg {
     }
 
   private def selectSuitableNextVersion(
-      update: Update.Single,
+      update: Update.ForArtifactId,
       repoConfig: RepoConfig
   ): FilterResult = {
     val newerVersions = update.newerVersions.toList
@@ -94,7 +94,7 @@ object FilterAlg {
     }
   }
 
-  private def checkVersionOrdering(update: Update.Single): FilterResult = {
+  private def checkVersionOrdering(update: Update.ForArtifactId): FilterResult = {
     val current = coursier.core.Version(update.currentVersion.value)
     val next = coursier.core.Version(update.nextVersion.value)
     if (current > next) Left(VersionOrderingConflict(update)) else Right(update)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -25,7 +25,7 @@ sealed trait UpdateState extends Product with Serializable {
 
 object UpdateState {
   sealed trait WithUpdate extends UpdateState {
-    def update: Update.Single
+    def update: Update.ForArtifactId
   }
 
   sealed trait WithPullRequest extends WithUpdate {
@@ -38,24 +38,24 @@ object UpdateState {
 
   final case class DependencyOutdated(
       crossDependency: CrossDependency,
-      update: Update.Single
+      update: Update.ForArtifactId
   ) extends WithUpdate
 
   final case class PullRequestUpToDate(
       crossDependency: CrossDependency,
-      update: Update.Single,
+      update: Update.ForArtifactId,
       pullRequest: Uri
   ) extends WithPullRequest
 
   final case class PullRequestOutdated(
       crossDependency: CrossDependency,
-      update: Update.Single,
+      update: Update.ForArtifactId,
       pullRequest: Uri
   ) extends WithPullRequest
 
   final case class PullRequestClosed(
       crossDependency: CrossDependency,
-      update: Update.Single,
+      update: Update.ForArtifactId,
       pullRequest: Uri
   ) extends WithPullRequest
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 
 object show {
-  def oneLiner(update: Update): String =
+  def oneLiner(update: Update.Single): String =
     commaSeparated(update.groupId, update.crossDependencies.map(_.head.artifactId.name))
 
   private def commaSeparated(groupId: GroupId, artifactIds: Nel[String]): String = {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -18,9 +18,7 @@ package org.scalasteward.core.util
 
 import cats.syntax.all._
 import cats.{Monad, MonadThrow}
-import org.scalasteward.core.data.GroupedUpdate
 import org.scalasteward.core.data.Update
-import org.scalasteward.core.data.AnUpdate
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration.FiniteDuration
 
@@ -68,11 +66,11 @@ object logger {
     }
   }
 
-  def showUpdates(allUpdates: List[AnUpdate]): String = {
+  def showUpdates(allUpdates: List[Update]): String = {
     val updates = allUpdates.map {
-      case g: GroupedUpdate =>
+      case g: Update.Grouped =>
         g.updates.map(_.show).mkString(s"${g.name} (group) {\n    ", "\n    ", "\n  }")
-      case u: Update => u.show
+      case u: Update.Single => u.show
     }
 
     val list = string.indentLines(updates)

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -43,7 +43,7 @@ object TestInstances {
   implicit def scopeCogen[T](implicit cogenT: Cogen[T]): Cogen[Scope[T]] =
     cogenT.contramap(_.value)
 
-  implicit val updateArbitrary: Arbitrary[Update] =
+  implicit val updateArbitrary: Arbitrary[Update.Single] =
     Arbitrary(
       for {
         groupId <- Gen.alphaStr

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -80,43 +80,46 @@ object TestSyntax {
   implicit class DependencyAndNextVersionOps(
       private val self: (Dependency, String)
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2.v))
+    def single: Update.ForArtifactId =
+      Update.ForArtifactId(CrossDependency(self._1), Nel.of(self._2.v))
   }
 
   implicit class DependencyAndNewerVersionsOps(
       private val self: (Dependency, Nel[String])
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), self._2.map(_.v))
+    def single: Update.ForArtifactId =
+      Update.ForArtifactId(CrossDependency(self._1), self._2.map(_.v))
   }
 
   implicit class DependenciesAndNextVersionOps(
       private val self: (Nel[Dependency], String)
   ) extends AnyVal {
-    def single: Update.Single = Update.Single(CrossDependency(self._1), Nel.of(self._2.v))
+    def single: Update.ForArtifactId =
+      Update.ForArtifactId(CrossDependency(self._1), Nel.of(self._2.v))
   }
 
   implicit class GroupIdAndArtifactIdsAndVersionAndNextVersionOps(
       private val self: (GroupId, Nel[ArtifactId], String, String)
   ) extends AnyVal {
-    def single: Update.Single = {
+    def single: Update.ForArtifactId = {
       val crossDependency = CrossDependency(self._2.map(aId => Dependency(self._1, aId, self._3.v)))
-      Update.Single(crossDependency, Nel.of(self._4.v))
+      Update.ForArtifactId(crossDependency, Nel.of(self._4.v))
     }
 
-    def group: Update.Group = {
+    def group: Update.ForGroupId = {
       val crossDependencies =
         self._2.map(aId => CrossDependency(Dependency(self._1, aId, self._3.v)))
-      Update.Group(crossDependencies, Nel.of(self._4.v))
+      Update.ForGroupId(crossDependencies, Nel.of(self._4.v))
     }
   }
 
   implicit class GroupIdAndManyArtifactIdsAndVersionAndNextVersionOps(
       private val self: (GroupId, Nel[Nel[ArtifactId]], String, String)
   ) extends AnyVal {
-    def group: Update.Group = {
+    def group: Update.ForGroupId = {
       val crossDependencies =
         self._2.map(aIds => CrossDependency(aIds.map(aId => Dependency(self._1, aId, self._3.v))))
-      Update.Group(crossDependencies, Nel.of(self._4.v))
+      Update.ForGroupId(crossDependencies, Nel.of(self._4.v))
     }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -57,7 +57,7 @@ class UpdateTest extends FunSuite {
     assertEquals(Update.groupByArtifactIdName(List(update0, update1, update2)), expected)
   }
 
-  test("Single.show") {
+  test("Update.show") {
     val update = ("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single
     assertEquals(update.show, "org.specs2:specs2-core : 3.9.4 -> 3.9.5")
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -288,7 +288,7 @@ class EditAlgTest extends FunSuite {
 
   private def runApplyUpdate(
       repo: Repo,
-      update: Update,
+      update: Update.Single,
       files: Map[String, String]
   ): Map[String, String] = {
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -563,7 +563,7 @@ class UpdateHeuristicTest extends FunSuite {
 }
 
 object UpdateHeuristicTest {
-  implicit class UpdateOps(update: Update) {
+  implicit class UpdateOps(update: Update.Single) {
     def replaceVersionIn(target: String): (Option[String], String) =
       UpdateHeuristic.all.foldLeft((Option.empty[String], "")) {
         case ((None, _), heuristic) => (heuristic.replaceVersion(update)(target), heuristic.name)

--- a/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.update.show
 class gitTest extends ScalaCheckSuite {
   test("commitMsgFor should work with static message") {
     val commitsConfig = CommitsConfig(Some("Static message"))
-    forAll { update: Update =>
+    forAll { update: Update.Single =>
       assertEquals(commitMsgFor(update, commitsConfig, None).title, "Static message")
     }
   }
@@ -18,7 +18,7 @@ class gitTest extends ScalaCheckSuite {
   test("commitMsgFor adds branch if provided") {
     val commitsConfig = CommitsConfig(Some(s"$${default}"))
     val branch = Branch("some-branch")
-    forAll { update: Update =>
+    forAll { update: Update.Single =>
       val expected = s"Update ${show.oneLiner(update)} to ${update.nextVersion} in ${branch.name}"
       assertEquals(commitMsgFor(update, commitsConfig, Some(branch)).title, expected)
     }
@@ -26,7 +26,7 @@ class gitTest extends ScalaCheckSuite {
 
   test("commitMsgFor should work with default message") {
     val commitsConfig = CommitsConfig(Some(s"$${default}"))
-    forAll { update: Update =>
+    forAll { update: Update.Single =>
       val expected = s"Update ${show.oneLiner(update)} to ${update.nextVersion}"
       assertEquals(commitMsgFor(update, commitsConfig, None).title, expected)
     }
@@ -35,7 +35,7 @@ class gitTest extends ScalaCheckSuite {
   test("commitMsgFor should work with templated message") {
     val commitsConfig =
       CommitsConfig(Some(s"Update $${artifactName} from $${currentVersion} to $${nextVersion}"))
-    forAll { update: Update =>
+    forAll { update: Update.Single =>
       val expected =
         s"Update ${show.oneLiner(update)} from ${update.currentVersion} to ${update.nextVersion}"
       assertEquals(commitMsgFor(update, commitsConfig, None).title, expected)
@@ -50,7 +50,7 @@ class gitTest extends ScalaCheckSuite {
         )
       )
     val branch = Branch("some-branch")
-    forAll { update: Update =>
+    forAll { update: Update.Single =>
       val expected =
         s"Update ${show.oneLiner(update)} from ${update.currentVersion} to ${update.nextVersion} in ${branch.name}"
       assertEquals(commitMsgFor(update, commitsConfig, Some(branch)).title, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.GroupedUpdate
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
@@ -142,7 +142,7 @@ class PullRequestRepositoryTest extends FunSuite {
   test("findLatestPullRequest ignores grouped updates") {
     val repo = Repo("pr-repo-test", "repo5")
     val update = portableScala
-    val grouped = GroupedUpdate("group", None, List(update))
+    val grouped = Update.Grouped("group", None, List(update))
     val data = PullRequestData[Id](url, sha1, grouped, Open, number, branch)
 
     val p = for {
@@ -168,7 +168,7 @@ class PullRequestRepositoryTest extends FunSuite {
   test("lastPullRequestCreatedAt returns timestamp for grouped updates") {
     val repo = Repo("pr-repo-test", "repo7")
     val update = catsCore
-    val grouped = GroupedUpdate("group", None, List(update))
+    val grouped = Update.Grouped("group", None, List(update))
     val data = PullRequestData[Id](url, sha1, grouped, Open, number, branch)
 
     val p = for {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{GroupId, GroupedUpdate, SemVer}
+import org.scalasteward.core.data.{GroupId, SemVer, Update}
 import org.scalasteward.core.mock.MockContext.context.repoConfigAlg
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockConfig, MockState}
@@ -285,7 +285,7 @@ class RepoConfigAlgTest extends FunSuite {
   test("configToIgnoreFurtherUpdates with grouped update") {
     val update1 = ("a".g % "b".a % "1" %> "2").single
     val update2 = ("c".g % "d".a % "1" %> "2").single
-    val update = GroupedUpdate("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, List(update1, update2))
     val config = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -7,7 +7,7 @@ import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.util.logger.showUpdates
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.GroupedUpdate
+import org.scalasteward.core.data.Update
 
 class loggerTest extends CatsEffectSuite {
   test("attemptError.label_") {
@@ -36,8 +36,8 @@ class loggerTest extends CatsEffectSuite {
     val c = ("a".g % "c".a % "1.0.0" %> "2.0.0").single
 
     val list = List(
-      GroupedUpdate("all", None, List(a, b, c)),
-      GroupedUpdate("some", None, List(a, b)),
+      Update.Grouped("all", None, List(a, b, c)),
+      Update.Grouped("some", None, List(a, b)),
       a,
       b,
       c

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -5,7 +5,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.git
 import org.scalasteward.core.vcs.VCSType.{GitHub, GitLab}
-import org.scalasteward.core.data.GroupedUpdate
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.vcs.data.Repo
 
 class VCSPackageTest extends FunSuite {
@@ -240,7 +240,7 @@ class VCSPackageTest extends FunSuite {
 
   {
 
-    val update = GroupedUpdate(
+    val update = Update.Grouped(
       name = "my-group",
       title = None,
       updates = List(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -7,7 +7,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data.{GroupedUpdate, ReleaseRelatedUrl, RepoData, UpdateData, Version}
+import org.scalasteward.core.data.{ReleaseRelatedUrl, RepoData, Update, UpdateData, Version}
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.git.{Branch, Commit}
@@ -323,7 +323,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("label for grouped updates add labels for all update types & version changes") {
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = GroupedUpdate("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, List(update1, update2))
 
     val labels = labelsFor(update, Nil, Nil, None)
 
@@ -342,7 +342,7 @@ class NewPullRequestDataTest extends FunSuite {
     val files = List("Readme.md", "travis.yml")
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = GroupedUpdate("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, List(update1, update2))
 
     val note = oldVersionNote(files, update)
 
@@ -365,7 +365,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("adjustFutureUpdates for grouped udpates shows settings for each update") {
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = GroupedUpdate("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, List(update1, update2))
 
     val note = adjustFutureUpdates(update)
 
@@ -402,7 +402,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("NewPullRequestData.from works for `GroupedUpdate`") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
-    val update = GroupedUpdate("my-group", "The PR title".some, List(update1, update2))
+    val update = Update.Grouped("my-group", "The PR title".some, List(update1, update2))
     val data = UpdateData(
       RepoData(Repo("foo", "bar"), dummyRepoCache, RepoConfig.empty),
       Repo("scala-steward", "bar"),


### PR DESCRIPTION
This new ADT was introduced in #2714 for enabling supporting grouping updates, but the naming was not very good. This PR fixes the hierarchy names.

## Renames in this PR
- `Update.Single` => `Update.ForArtifactId`
- `Update.Group` => `Update.ForGroupId`
- `Update` => `Update.Single`
- `GroupedUpdate` => `Update.Grouped`
- `AnUpdate` => `Update`

## Functional changes in this PR

Instead of deriving circe's `Codec` for the whole `Update` ADT, individual `Decoder` are created to ensure JSON created using older versions of Scala Steward will still be decoded.

```scala
implicit val ForGroupIdDecoder: Decoder[ForGroupId] = {
  val derived = deriveDecoder[ForGroupId]
  derived
    .prepare(_.downField("ForGroupId"))
    .or(derived.prepare(_.downField("Group")))
}

implicit val UpdateEncoder: Encoder[Update] = deriveEncoder

implicit val UpdateDecoder: Decoder[Update] =
    ForArtifactIdDecoder
      .widen[Update]
      .or(ForGroupIdDecoder.widen[Update])
      .or(Decoder[Grouped].widen[Update])
```

vs

```scala
implicit val UpdateCodec: Codec[Update] = deriveCodec
```