### PR TITLE
Allow `--url-checker-test-url` option multiple times

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ All command line arguments for the `scala-steward` application.
 ```
 Usage:
     scala-steward validate-repo-config
-    scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>] [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
+    scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--vcs-type <vcs-type>] [--vcs-api-host <uri>] --vcs-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
 
 
 
@@ -77,7 +77,7 @@ Options and flags:
     --github-app-key-file <file>
         GitHub application key file
     --url-checker-test-url <uri>
-        default: https://github.com
+        URL for testing the UrlChecker at start-up (can be used multiple times); default: https://github.com
     --default-maven-repo <string>
         default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -26,11 +26,11 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Config._
 import org.scalasteward.core.data.Resolver
 import org.scalasteward.core.git.Author
+import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.dateTime.renderFiniteDuration
 import org.scalasteward.core.vcs.VCSType
 import org.scalasteward.core.vcs.VCSType.GitHub
 import org.scalasteward.core.vcs.github.GitHubApp
-
 import scala.concurrent.duration._
 
 object Cli {
@@ -61,6 +61,8 @@ object Cli {
     Argument.from("vcs-type") { s =>
       Validated.fromEither(VCSType.parse(s)).toValidatedNel
     }
+
+  private val multiple = "(can be used multiple times)"
 
   private val workspace: Opts[File] =
     option[File]("workspace", "Location for cache and temporary files")
@@ -124,7 +126,7 @@ object Cli {
     ).orFalse
 
   private val envVar: Opts[List[EnvVar]] = {
-    val help = "Assigns the value to the environment variable name (can be used multiple times)"
+    val help = s"Assigns the value to the environment variable name $multiple"
     options[EnvVar]("env-var", help).orEmpty
   }
 
@@ -138,13 +140,13 @@ object Cli {
   private val whitelist: Opts[List[String]] =
     options[String](
       "whitelist",
-      "Directory white listed for the sandbox (can be used multiple times)"
+      s"Directory white listed for the sandbox $multiple"
     ).orEmpty
 
   private val readOnly: Opts[List[String]] =
     options[String](
       "read-only",
-      "Read only directory for the sandbox (can be used multiple times)"
+      s"Read only directory for the sandbox $multiple"
     ).orEmpty
 
   private val enableSandbox: Opts[Boolean] =
@@ -167,7 +169,7 @@ object Cli {
     (envVar, processTimeout, sandboxCfg, maxBufferSize).mapN(ProcessCfg.apply)
 
   private val repoConfig: Opts[List[Uri]] =
-    options[Uri]("repo-config", "Additional repo config file (can be used multiple times)").orEmpty
+    options[Uri]("repo-config", s"Additional repo config file $multiple").orEmpty
 
   private val disableDefaultRepoConfig: Opts[Boolean] =
     flag("disable-default-repo-config", "Whether to disable the default repo config file").orFalse
@@ -178,7 +180,7 @@ object Cli {
   private val scalafixMigrations: Opts[List[Uri]] =
     options[Uri](
       "scalafix-migrations",
-      "Additional scalafix migrations configuration file (can be used multiple times)"
+      s"Additional scalafix migrations configuration file $multiple"
     ).orEmpty
 
   private val disableDefaultScalafixMigrations: Opts[Boolean] =
@@ -193,7 +195,7 @@ object Cli {
   private val artifactMigrations: Opts[List[Uri]] =
     options[Uri](
       "artifact-migrations",
-      "Additional artifact migration configuration file (can be used multiple times)"
+      s"Additional artifact migration configuration file $multiple"
     ).orEmpty
 
   private val disableDefaultArtifactMigrations: Opts[Boolean] =
@@ -251,9 +253,12 @@ object Cli {
     option[FiniteDuration]("refresh-backoff-period", help).withDefault(default)
   }
 
-  private val urlCheckerTestUrl: Opts[Uri] = {
+  private val urlCheckerTestUrls: Opts[Nel[Uri]] = {
     val default = uri"https://github.com"
-    option[Uri]("url-checker-test-url", s"default: $default").withDefault(default)
+    options[Uri](
+      "url-checker-test-url",
+      s"URL for testing the UrlChecker at start-up $multiple; default: $default"
+    ).withDefault(Nel.one(default))
   }
 
   private val defaultMavenRepo: Opts[Resolver] = {
@@ -286,7 +291,7 @@ object Cli {
     bitbucketServerCfg,
     gitLabCfg,
     gitHubApp,
-    urlCheckerTestUrl,
+    urlCheckerTestUrls,
     defaultMavenRepo,
     refreshBackoffPeriod
   ).mapN(Config.apply)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -66,7 +66,7 @@ final case class Config(
     bitbucketServerCfg: BitbucketServerCfg,
     gitLabCfg: GitLabCfg,
     githubApp: Option[GitHubApp],
-    urlCheckerTestUrl: Uri,
+    urlCheckerTestUrls: Nel[Uri],
     defaultResolver: Resolver,
     refreshBackoffPeriod: FiniteDuration
 ) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -62,11 +62,11 @@ final class SelfCheckAlg[F[_]](config: Config)(implicit
     s"Failed to execute $binary  -- make sure it is on the PATH; following the detailed exception:"
 
   private def checkUrlChecker: F[Unit] =
-    for {
-      _ <- F.unit
-      url = config.urlCheckerTestUrl
-      urlExists <- urlChecker.exists(url)
-      msg = s"Self check of UrlChecker failed: checking that $url exists failed"
-      _ <- F.whenA(!urlExists)(logger.warn(msg))
-    } yield ()
+    config.urlCheckerTestUrls.traverse_ { url =>
+      urlChecker.exists(url).flatMap {
+        case true => F.unit
+        case false =>
+          logger.warn(s"Self check of UrlChecker failed: checking that $url exists failed")
+      }
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -63,10 +63,9 @@ final class SelfCheckAlg[F[_]](config: Config)(implicit
 
   private def checkUrlChecker: F[Unit] =
     config.urlCheckerTestUrls.traverse_ { url =>
-      urlChecker.exists(url).flatMap {
-        case true => F.unit
-        case false =>
-          logger.warn(s"Self check of UrlChecker failed: checking that $url exists failed")
+      urlChecker.exists(url).flatMap { urlExists =>
+        val msg = s"Self check of UrlChecker failed: checking that $url exists failed"
+        F.whenA(!urlExists)(logger.warn(msg))
       }
     }
 }


### PR DESCRIPTION
This allows the `--url-checker-test-url` option to be used multiple times. Each argument of this option is checked with the `UrlChecker` in `SelfCheckAlg` at program start-up.

This is useful when Scala Steward is used in corporate environments where one wants to ensure that it can check internal and externals URLs.