### PR TITLE
Revert "Add Dependabot configuration for GitHub Actions updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"


### PR DESCRIPTION
Reverts scala-steward-org/scala-steward#2771

Because most of actions are managed in https://github.com/djspiewak/sbt-github-actions