### PR TITLE
Replace Java 8 with newer LTS Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.17, 2.13.10]
-        java: [adopt-hotspot@8, adopt-hotspot@11]
+        java: [adopt-hotspot@17, adopt-hotspot@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (adopt-hotspot@8)
-        if: matrix.java == 'adopt-hotspot@8'
+      - name: Setup Java (adopt-hotspot@17)
+        if: matrix.java == 'adopt-hotspot@17'
         uses: actions/setup-java@v2
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: 17
 
       - name: Setup Java (adopt-hotspot@11)
         if: matrix.java == 'adopt-hotspot@11'
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.17]
-        java: [adopt-hotspot@8]
+        java: [adopt-hotspot@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -92,12 +92,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (adopt-hotspot@8)
-        if: matrix.java == 'adopt-hotspot@8'
+      - name: Setup Java (adopt-hotspot@17)
+        if: matrix.java == 'adopt-hotspot@17'
         uses: actions/setup-java@v2
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: 17
 
       - name: Setup Java (adopt-hotspot@11)
         if: matrix.java == 'adopt-hotspot@11'

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ ThisBuild / githubWorkflowPublish := Seq(
     name = Some("Publish Docker image")
   )
 )
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Adopt, "8"), JavaSpec(Adopt, "11"))
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Adopt, "17"), JavaSpec(Adopt, "11"))
 ThisBuild / githubWorkflowBuild :=
   Seq(
     WorkflowStep.Sbt(List("validate"), name = Some("Build project")),


### PR DESCRIPTION
Closes #2746

Unfortunately, not a small number of libraries used in Scala Steward dropped Java 8.
Since scala-steward is not a library, I think long-term Java 8 support is not needed fundamentally.
