### PR TITLE
Revert "Update coursier to 2.1.0-RC2"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeGeneric.revision
   val circeRefined = "io.circe" %% "circe-refined" % circeGeneric.revision
   val commonsIo = "commons-io" % "commons-io" % "2.11.0"
-  val coursierCore = "io.get-coursier" %% "coursier" % "2.1.0-RC2"
+  val coursierCore = "io.get-coursier" %% "coursier" % "2.1.0-RC1"
   val cron4sCore = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.1"
   val decline = "com.monovore" %% "decline" % "2.4.0"
   val disciplineMunit = "org.typelevel" %% "discipline-munit" % "1.0.9"


### PR DESCRIPTION
Reverts scala-steward-org/scala-steward#2769

Temporary workaround for https://github.com/scala-steward-org/scala-steward/issues/2797