### PR TITLE
Add scala-collection-compact Scalafile rule when bump from 2.12 to 2.13

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -205,5 +205,13 @@ migrations = [
     newVersion: "0.14.0",
     rewriteRules: ["github:trace4cats/trace4cats-scalafix/v0_14?sha=v0.14.0"],
     doc: "https://github.com/trace4cats/trace4cats-docs/blob/master/docs/migrating.md"
+  },
+  {
+    groupId: "org.scala-lang",
+    artifactIds: ["scala-library", "scala-compiler", "scala-reflect", "scalap"],
+    newVersion: "2.13.0",
+    doc: "https://github.com/scala/scala-collection-compat#collection213upgrade",
+    rewriteRules: ["dependency:Collection213Upgrade@org.scala-lang.modules:scala-collection-migrations:2.8.1"], 
+    scalacOptions: ["-P:semanticdb:synthetics:on"]
   }
 ]


### PR DESCRIPTION
Address #2770 

I'm not sure if my rule is too specific to the `scala-compact-library` and should be more general to the scala bumping version.