### PR TITLE
Revert "Update logback-classic only on 1.3.x series that supports JDK 8"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,2 @@
 updatePullRequests = "always"
 
-updates.pin = [
-  # We may drop this when we drop JDK 8 since minimum JDK is 11 from logback-classic 1.4.0
-  { groupId = "ch.qos.logback", artifactId="logback-classic", version="1.3." }
-]


### PR DESCRIPTION
Reverts scala-steward-org/scala-steward#2745

Unpin logback-classic as mentioned in https://github.com/scala-steward-org/scala-steward/issues/2746#issue-1416131445.