### PR TITLE
Scalafix artifactId patterns must match whole artifactIds

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
@@ -17,6 +17,7 @@
 package org.scalasteward.core.edit.scalafix
 
 import cats.syntax.all._
+import java.util.regex.Pattern
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.ExecutionOrder
 
@@ -26,7 +27,8 @@ final class ScalafixMigrationsFinder(migrations: List[ScalafixMigration]) {
       .filter { migration =>
         update.groupId === migration.groupId &&
         migration.artifactIds.exists { re =>
-          update.artifactIds.exists(artifactId => re.r.findFirstIn(artifactId.name).isDefined)
+          val pattern = Pattern.compile(re)
+          update.artifactIds.exists(artifactId => pattern.matcher(artifactId.name).matches())
         } &&
         update.currentVersion < migration.newVersion &&
         update.nextVersion >= migration.newVersion

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
@@ -9,7 +9,7 @@ import org.scalasteward.core.util.Nel
 class ScalafixMigrationsFinderTest extends FunSuite {
   test("findMigrations") {
     val update = ("org.typelevel".g % "cats-core".a % "2.1.0" %> "2.2.0").single
-    val migrations = scalafixMigrationsFinder.findMigrations(update)
+    val obtained = scalafixMigrationsFinder.findMigrations(update)
     val expected = (
       List(
         ScalafixMigration(
@@ -25,6 +25,13 @@ class ScalafixMigrationsFinderTest extends FunSuite {
       ),
       List()
     )
-    assertEquals(migrations, expected)
+    assertEquals(obtained, expected)
+  }
+
+  test("findMigrations: pattern must match whole artifactId") {
+    val update = ("org.typelevel".g % "log4cats-core".a % "2.1.1" %> "2.4.0").single
+    val obtained = scalafixMigrationsFinder.findMigrations(update)
+    val expected = (List(), List())
+    assertEquals(obtained, expected)
   }
 }


### PR DESCRIPTION
Closes https://github.com/scala-steward-org/scala-steward/issues/2682.