### PR TITLE
Fix bug on `Update` JSON encoders

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -3,6 +3,8 @@ package org.scalasteward.core.data
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.util.Nel
+import io.circe.syntax._
+import io.circe.Json
 
 class UpdateTest extends FunSuite {
   test("Group.mainArtifactId") {
@@ -66,5 +68,136 @@ class UpdateTest extends FunSuite {
     val update =
       ("org.scala-sbt".g % Nel.of("sbt-launch".a, "scripted-plugin".a) % "1.2.1" %> "1.2.4").group
     assertEquals(update.show, "org.scala-sbt:{sbt-launch, scripted-plugin} : 1.2.1 -> 1.2.4")
+  }
+
+  test("ForArtifactId Encoder/Decoder") {
+    val update1: Update =
+      ("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single
+    val update2: Update.ForArtifactId =
+      ("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single
+
+    val expected = Json.obj(
+      "ForArtifactId" := Json.obj(
+        "crossDependency" := Json.arr(
+          Json.obj(
+            "groupId" := "org.specs2",
+            "artifactId" := Json.obj(
+              "name" := "specs2-core",
+              "maybeCrossName" := None
+            ),
+            "version" := "3.9.4",
+            "sbtVersion" := None,
+            "scalaVersion" := None,
+            "configurations" := "test"
+          )
+        ),
+        "newerVersions" := List("3.9.5"),
+        "newerGroupId" := None,
+        "newerArtifactId" := None
+      )
+    )
+
+    assertEquals(update1.asJson, expected)
+    assertEquals(update1.asJson, update2.asJson)
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update])
+    assertEquals(update1.asJson.as[Update.ForArtifactId], update2.asJson.as[Update.ForArtifactId])
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update.ForArtifactId])
+  }
+
+  test("ForGroupId Encoder/Decoder") {
+    val update1: Update =
+      ("org.scala-sbt".g % Nel.of("sbt-launch".a, "scripted-plugin".a) % "1.2.1" %> "1.2.4").group
+    val update2: Update.ForGroupId =
+      ("org.scala-sbt".g % Nel.of("sbt-launch".a, "scripted-plugin".a) % "1.2.1" %> "1.2.4").group
+
+    val expected = Json.obj(
+      "ForGroupId" := Json.obj(
+        "crossDependencies" := Json.arr(
+          Json.arr(
+            Json.obj(
+              "groupId" := "org.scala-sbt",
+              "artifactId" := Json.obj(
+                "name" := "sbt-launch",
+                "maybeCrossName" := None
+              ),
+              "version" := "1.2.1",
+              "sbtVersion" := None,
+              "scalaVersion" := None,
+              "configurations" := None
+            )
+          ),
+          Json.arr(
+            Json.obj(
+              "groupId" := "org.scala-sbt",
+              "artifactId" := Json.obj(
+                "name" := "scripted-plugin",
+                "maybeCrossName" := None
+              ),
+              "version" := "1.2.1",
+              "sbtVersion" := None,
+              "scalaVersion" := None,
+              "configurations" := None
+            )
+          )
+        ),
+        "newerVersions" := List("1.2.4")
+      )
+    )
+
+    assertEquals(update1.asJson, expected)
+    assertEquals(update1.asJson, update2.asJson)
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update])
+    assertEquals(update1.asJson.as[Update.ForGroupId], update2.asJson.as[Update.ForGroupId])
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update.ForGroupId])
+  }
+
+  test("Grouped Encoder/Decoder") {
+    val update1: Update =
+      Update.Grouped(
+        name = "all",
+        title = Some("All"),
+        updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
+      )
+    val update2: Update.Grouped =
+      Update.Grouped(
+        name = "all",
+        title = Some("All"),
+        updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
+      )
+
+    val expected = Json.obj(
+      "Grouped" := Json.obj(
+        "name" := "all",
+        "title" := "All",
+        "updates" := Json.arr(
+          Json.obj(
+            "ForArtifactId" := Json.obj(
+              "crossDependency" := Json.arr(
+                Json.obj(
+                  "groupId" := "org.specs2",
+                  "artifactId" := Json.obj(
+                    "name" := "specs2-core",
+                    "maybeCrossName" := None
+                  ),
+                  "version" := "3.9.4",
+                  "sbtVersion" := None,
+                  "scalaVersion" := None,
+                  "configurations" := "test"
+                )
+              ),
+              "newerVersions" := List("3.9.5"),
+              "newerGroupId" := None,
+              "newerArtifactId" := None
+            )
+          )
+        )
+      )
+    )
+
+    assertEquals(update1.asJson, expected)
+    assertEquals(update1.asJson, update2.asJson)
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update])
+    assertEquals(update1.asJson.as[Update.Grouped], update2.asJson.as[Update.Grouped])
+    assertEquals(update1.asJson.as[Update], update2.asJson.as[Update.Grouped])
   }
 }


### PR DESCRIPTION
> ❗ This must be released as a patch version ASAP.

## 🐛 The bug

`Update` decoders are expecting JSON objects to be wrapped in a field named as the class:

```json
"ForArtifactId": {
   ...
}
```

While individual encoders are not creating this field.

This only happens when decoding `Grouped` updates, since it is the only place an individual encoder was being used.

## 👨🏼‍💻 The solution

This PR ensures encoders always introduce this wrapper-field so updates are correctly parsed on every situation.

## References

Fixes #2802 