### PR TITLE
Use init.defaultBranch instead of --initial-branch option

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -205,7 +205,7 @@ object FileGitAlgTest {
       for {
         _ <- gitAlg.removeClone(repo)
         _ <- fileAlg.ensureExists(repo)
-        _ <- git("-c", s"init.defaultBranch=$master", "init", ".")(repo)
+        _ <- git("-c", s"init.defaultBranch=${master.name}", "init", ".")(repo)
         _ <- gitAlg.setAuthor(repo, config.gitCfg.gitAuthor)
         _ <- git("commit", "--allow-empty", "-m", "Initial commit")(repo)
       } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -205,7 +205,7 @@ object FileGitAlgTest {
       for {
         _ <- gitAlg.removeClone(repo)
         _ <- fileAlg.ensureExists(repo)
-        _ <- git("-c", "init.defaultBranch=master", "init", ".")(repo)
+        _ <- git("-c", s"init.defaultBranch=$master", "init", ".")(repo)
         _ <- gitAlg.setAuthor(repo, config.gitCfg.gitAuthor)
         _ <- git("commit", "--allow-empty", "-m", "Initial commit")(repo)
       } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -205,7 +205,7 @@ object FileGitAlgTest {
       for {
         _ <- gitAlg.removeClone(repo)
         _ <- fileAlg.ensureExists(repo)
-        _ <- git("init", ".", "--initial-branch", "master")(repo)
+        _ <- git("-c", "init.defaultBranch=master", "init", ".")(repo)
         _ <- gitAlg.setAuthor(repo, config.gitCfg.gitAuthor)
         _ <- git("commit", "--allow-empty", "-m", "Initial commit")(repo)
       } yield ()


### PR DESCRIPTION
My local Git version does not yet know the `--initial-branch` and thus the `FileGitAlgTest` fails for me with:
```
org.scalasteward.core.git.FileGitAlgTest:
==> X org.scalasteward.core.git.FileGitAlgTest.branchAuthors  0.585s java.io.IOException: 'VAR1=val1 VAR2=val2 git init . --initial-branch master' exited with code 129
error: unknown option `initial-branch'
```

Instead of using this option, we call `git init` now with the `init.defaultBranch=master` config which should have the same effect as the `--initial-branch` option according to the [docs](https://git-scm.com/docs/git-init). Older Git versions just ignore this config.

I hope this also fixes the problem mentioned in https://github.com/scala-steward-org/scala-steward/commit/cfe58570d4ddb9abd6efa40ffa7f625f968e8144