### PR TITLE
Add note to default config files that are downloaded at start-up

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1,3 +1,9 @@
+// NOTE: The latest version of this file in the scala-steward Git repository
+//   is loaded by every Scala Steward instance on start-up, unless it is
+//   started with the --disable-default-artifact-migrations option.
+//   Changes to this file are therefore immediately visible to all
+//   Scala Steward instances.
+
 changes = [
   {
     groupIdBefore = com.eed3si9n

--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -1,3 +1,9 @@
+// NOTE: The latest version of this file in the scala-steward Git repository
+//   is loaded by every Scala Steward instance on start-up, unless it is
+//   started with the --disable-default-repo-config option.
+//   Changes to this file are therefore immediately visible to all
+//   Scala Steward instances.
+
 postUpdateHooks = [
   {
     groupId = "com.github.liancheng",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -1,3 +1,9 @@
+// NOTE: The latest version of this file in the scala-steward Git repository
+//   is loaded by every Scala Steward instance on start-up, unless it is
+//   started with the --disable-default-scalafix-migrations option.
+//   Changes to this file are therefore immediately visible to all
+//   Scala Steward instances.
+
 migrations = [
   {
     groupId: "co.fs2",


### PR DESCRIPTION
This should clarify that the latest versions of these default config files are downloaded by all Scala Steward instances.