### PR TITLE
Bump JDK versions in Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,9 +10,9 @@ pull_request_rules:
   - name: merge scala-steward's PRs
     conditions:
       - author=scala-steward
-      - status-success=Build and Test (ubuntu-latest, 2.12.17, adopt-hotspot@8)
+      - status-success=Build and Test (ubuntu-latest, 2.12.17, adopt-hotspot@17)
       - status-success=Build and Test (ubuntu-latest, 2.12.17, adopt-hotspot@11)
-      - status-success=Build and Test (ubuntu-latest, 2.13.10, adopt-hotspot@8)
+      - status-success=Build and Test (ubuntu-latest, 2.13.10, adopt-hotspot@17)
       - status-success=Build and Test (ubuntu-latest, 2.13.10, adopt-hotspot@11)
     actions:
       merge:


### PR DESCRIPTION
So that Mergify automatically merges Scala Steward's PRs again.