### PR TITLE
Fix: Replaced import logic in predef script for Mill projects

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -85,7 +85,7 @@ final class MillAlg[F[_]](implicit
 object MillAlg {
   private[mill] def content(millVersion: Option[Version]) = {
     def rawContent(millBinPlatform: String) =
-      s"""|import $ivy.`${org.scalasteward.core.BuildInfo.organization}::${org.scalasteward.core.BuildInfo.millPluginArtifactName}_mill${millBinPlatform}:${org.scalasteward.core.BuildInfo.millPluginVersion}`
+      s"""|import $$ivy.`${org.scalasteward.core.BuildInfo.organization}::${org.scalasteward.core.BuildInfo.millPluginArtifactName}_mill${millBinPlatform}:${org.scalasteward.core.BuildInfo.millPluginVersion}`
           |""".stripMargin
 
     millVersion match {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -85,19 +85,14 @@ final class MillAlg[F[_]](implicit
 object MillAlg {
   private[mill] def content(millVersion: Option[Version]) = {
     def rawContent(millBinPlatform: String) =
-      s"""|import coursierapi.MavenRepository
-          |
-          |interp.repositories() ++= Seq(
-          |  MavenRepository.of("https://oss.sonatype.org/content/repositories/snapshots/")
-          |)
-          |interp.load.ivy("${org.scalasteward.core.BuildInfo.organization}" %% "${org.scalasteward.core.BuildInfo.millPluginArtifactName}_mill${millBinPlatform}" % "${org.scalasteward.core.BuildInfo.millPluginVersion}")
+      s"""|import $ivy.`${org.scalasteward.core.BuildInfo.organization}::${org.scalasteward.core.BuildInfo.millPluginArtifactName}_mill${millBinPlatform}:${org.scalasteward.core.BuildInfo.millPluginVersion}`
           |""".stripMargin
 
     millVersion match {
       case None => rawContent("$MILL_BIN_PLATFORM")
       case Some(millVersion) =>
         millVersion.value.trim.split("[.]", 3).take(2) match {
-          // We support these platform, but we can't take the $$MILL_BIN_PLATFORM support for granted
+          // We support these platforms, but we can't take the $MILL_BIN_PLATFORM support for granted
           case Array("0", "6")       => rawContent("0.6")
           case Array("0", "7" | "8") => rawContent("0.7")
           case Array("0", "9")       => rawContent("0.9")


### PR DESCRIPTION
The `$MILL_BIN_PLATFORM` replacement is only supported when used with `import $ivy`.

Fix issues introduced in #2821 