### PR TITLE
Update links to Scalafix documentation

### DIFF
--- a/docs/scalafix-migrations.md
+++ b/docs/scalafix-migrations.md
@@ -31,7 +31,7 @@ which resolves those rules and edits the source code accordingly.
 See the [Scalafix Developer Guide][scalafix-dev-guide] for more information
 about writing rewrite rules or have a look at the existing
 [migration rules][migrations] for inspiration. Rules in Scala Steward must be
-accessible via the [github:][using-github], the [http:][using-http] or the
+accessible via the [github:][using-github], the [http:][using-http], or the
 [dependency:][using-dependency] schemes.
 
 ## Adding migration rules to Scala Steward
@@ -63,7 +63,7 @@ Pull requests that added migration rules can be found [here][scalafix-prs].
 [migrations]: https://github.com/scala-steward-org/scala-steward/blob/main/modules/core/src/main/resources/scalafix-migrations.conf
 [scalafix-dev-guide]: https://scalacenter.github.io/scalafix/docs/developers/setup.html
 [using-dependency]: https://scalacenter.github.io/scalafix/docs/rules/external-rules.html
-[using-github]: https://scalacenter.github.io/scalafix/docs/developers/sharing-rules.html#using-github
-[using-http]: https://scalacenter.github.io/scalafix/docs/developers/sharing-rules.html#using-http
+[using-github]: https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-github
+[using-http]: https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-http
 [scalafix-prs]: https://github.com/scala-steward-org/scala-steward/pulls?q=label%3Ascalafix-migration
 [HOCON]: https://github.com/lightbend/config/blob/master/HOCON.md

--- a/modules/docs/mdoc/scalafix-migrations.md
+++ b/modules/docs/mdoc/scalafix-migrations.md
@@ -31,7 +31,7 @@ which resolves those rules and edits the source code accordingly.
 See the [Scalafix Developer Guide][scalafix-dev-guide] for more information
 about writing rewrite rules or have a look at the existing
 [migration rules][migrations] for inspiration. Rules in Scala Steward must be
-accessible via the [github:][using-github], the [http:][using-http] or the
+accessible via the [github:][using-github], the [http:][using-http], or the
 [dependency:][using-dependency] schemes.
 
 ## Adding migration rules to Scala Steward
@@ -63,7 +63,7 @@ Pull requests that added migration rules can be found [here][scalafix-prs].
 [migrations]: @GITHUB_URL@/blob/@MAIN_BRANCH@/modules/core/src/main/resources/scalafix-migrations.conf
 [scalafix-dev-guide]: https://scalacenter.github.io/scalafix/docs/developers/setup.html
 [using-dependency]: https://scalacenter.github.io/scalafix/docs/rules/external-rules.html
-[using-github]: https://scalacenter.github.io/scalafix/docs/developers/sharing-rules.html#using-github
-[using-http]: https://scalacenter.github.io/scalafix/docs/developers/sharing-rules.html#using-http
+[using-github]: https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-github
+[using-http]: https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-http
 [scalafix-prs]: @GITHUB_URL@/pulls?q=label%3Ascalafix-migration
 [HOCON]: https://github.com/lightbend/config/blob/master/HOCON.md


### PR DESCRIPTION
The old URLs are 404s now.