### PR TITLE
CI: Introduce link checker job

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,19 @@
+name: Link checker
+
+on: push
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    name: Link checker
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: 'mlc_config.json'
+          folder-path: 'docs' # comma separated
+          max-depth: 2
+          check-modified-files-only: ${{ github.ref_name == 'main' && 'no' || 'yes' }}
+          base-branch: main

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -12,8 +12,8 @@ jobs:
           fetch-depth: 0
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          config-file: 'mlc_config.json'
           folder-path: 'docs' # comma separated
+          file-path: 'README.md,CODE_OF_CONDUCT.md' # comma separated
           max-depth: 2
           check-modified-files-only: ${{ github.ref_name == 'main' && 'no' || 'yes' }}
           base-branch: main

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
         with:
           folder-path: 'docs' # comma separated
           file-path: 'README.md,CODE_OF_CONDUCT.md' # comma separated

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
         with:
           folder-path: 'docs' # comma separated
           file-path: 'README.md,CODE_OF_CONDUCT.md' # comma separated

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,6 +1,10 @@
 name: Link checker
 
-on: push
+on:
+  pull_request:
+    # On every pull request
+  schedule:
+    - cron: '00 0 * * 1' # Every monday
 
 jobs:
   link-check:

--- a/docs/running.md
+++ b/docs/running.md
@@ -39,7 +39,7 @@ docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
 The [`git-ask-pass` option](https://git-scm.com/docs/gitcredentials) must specify an executable file (script) that returns (on the stdout),
 
 - either the plain text password corresponding to the configured `${LOGIN}`,
-- or (recommended) an authentication token corresponding to `${LOGIN}` (with appropriate permissions to watch the repositories; e.g. [Create a personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) for GitHub).
+- or (recommended) an authentication token corresponding to `${LOGIN}` (with appropriate permissions to watch the repositories; e.g. [Create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for GitHub).
 
 **Note about git-ask-pass option**: The provided script must start with a valid shebang like `#!/bin/sh`, see issue [#1374](https://github.com/scala-steward-org/scala-steward/issues/1374)
 
@@ -75,7 +75,7 @@ If your projects require credentials, you can also provide global credentials in
 The file should contain a single line: `credentials += Credentials("Some Nexus Repository Manager", "my.artifact.repo.net", "admin", "admin123")`.
 
 #### sbt 0.13 workaround
-For sbt 0.13 builds, scala-steward [may be unable](https://gitter.im/fthomas/scala-steward?at=5f0573dac7d15f7d0f7b15ac) to extract credentials for private resolvers. Instead, you can [configure coursier directly](https://get-coursier.io/docs/other-credentials) by adding `~/.config/coursier/credentials.properties`:
+For sbt 0.13 builds, scala-steward [may be unable](https://gitter.im/scala-steward-org/scala-steward?at=5f0573dac7d15f7d0f7b15ac) to extract credentials for private resolvers. Instead, you can [configure coursier directly](https://get-coursier.io/docs/other-credentials) by adding `~/.config/coursier/credentials.properties`:
 ```scala
 example1.username=username
 example1.password=password
@@ -191,7 +191,6 @@ pipelines:
 There is multiple articles on how to run Scala Steward on-premise:
 
 * [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)
-* [Running scala-steward periodically on AWS Fargate](https://medium.com/@tanishiking/running-scala-steward-periodically-on-aws-fargate-3d3d202f0f7)
 * [Scala StewardとGitHub Actionsで依存ライブラリの更新を自動化する](https://scalapedia.com/articles/145/Scala+Steward%E3%81%A8GitHub+Actions%E3%81%A7%E4%BE%9D%E5%AD%98%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AE%E6%9B%B4%E6%96%B0%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B)
 * [Centralized Scala Steward with GitHub Actions](https://hector.dev/2020/11/18/centralized-scala-steward-with-github-actions)
 * [Big Timesavers for Busy Scala Developers](https://speakerdeck.com/exoego/big-timesavers-for-busy-scala-developers)

--- a/docs/scalafix-migrations.md
+++ b/docs/scalafix-migrations.md
@@ -13,10 +13,13 @@ Here are two pull requests that demonstrate this feature:
 And here are all pull requests where Scala Steward applied Scalafix
 migrations:
 
+<!-- These links exists but returns 404 often so skip check -->
+<!-- markdown-link-check-disable -->
 * [Created pull requests](https://github.com/search?q=author%3Ascala-steward+is%3Apr+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Apr+scalafix-migrations))
 * [Merged pull requests]( https://github.com/search?q=author%3Ascala-steward+is%3Amerged+sort%3Aupdated-desc+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Amerged+sort%3Aupdated-desc+scalafix-migrations))
+<!-- markdown-link-check-enable -->
 
 ## How does this work?
 

--- a/docs/scalafix-migrations.md
+++ b/docs/scalafix-migrations.md
@@ -13,7 +13,7 @@ Here are two pull requests that demonstrate this feature:
 And here are all pull requests where Scala Steward applied Scalafix
 migrations:
 
-<!-- These links exists but returns 404 often so skip check -->
+<!-- These links returns 404 unless user is logged into GitHub. So let's skip -->
 <!-- markdown-link-check-disable -->
 * [Created pull requests](https://github.com/search?q=author%3Ascala-steward+is%3Apr+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Apr+scalafix-migrations))

--- a/modules/docs/mdoc/running.md
+++ b/modules/docs/mdoc/running.md
@@ -39,7 +39,7 @@ docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
 The [`git-ask-pass` option](https://git-scm.com/docs/gitcredentials) must specify an executable file (script) that returns (on the stdout),
 
 - either the plain text password corresponding to the configured `${LOGIN}`,
-- or (recommended) an authentication token corresponding to `${LOGIN}` (with appropriate permissions to watch the repositories; e.g. [Create a personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) for GitHub).
+- or (recommended) an authentication token corresponding to `${LOGIN}` (with appropriate permissions to watch the repositories; e.g. [Create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for GitHub).
 
 **Note about git-ask-pass option**: The provided script must start with a valid shebang like `#!/bin/sh`, see issue [#1374](@GITHUB_URL@/issues/1374)
 
@@ -75,7 +75,7 @@ If your projects require credentials, you can also provide global credentials in
 The file should contain a single line: `credentials += Credentials("Some Nexus Repository Manager", "my.artifact.repo.net", "admin", "admin123")`.
 
 #### sbt 0.13 workaround
-For sbt 0.13 builds, scala-steward [may be unable](https://gitter.im/fthomas/scala-steward?at=5f0573dac7d15f7d0f7b15ac) to extract credentials for private resolvers. Instead, you can [configure coursier directly](https://get-coursier.io/docs/other-credentials) by adding `~/.config/coursier/credentials.properties`:
+For sbt 0.13 builds, scala-steward [may be unable](https://gitter.im/scala-steward-org/scala-steward?at=5f0573dac7d15f7d0f7b15ac) to extract credentials for private resolvers. Instead, you can [configure coursier directly](https://get-coursier.io/docs/other-credentials) by adding `~/.config/coursier/credentials.properties`:
 ```scala
 example1.username=username
 example1.password=password
@@ -191,7 +191,6 @@ pipelines:
 There is multiple articles on how to run Scala Steward on-premise:
 
 * [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)
-* [Running scala-steward periodically on AWS Fargate](https://medium.com/@tanishiking/running-scala-steward-periodically-on-aws-fargate-3d3d202f0f7)
 * [Scala StewardとGitHub Actionsで依存ライブラリの更新を自動化する](https://scalapedia.com/articles/145/Scala+Steward%E3%81%A8GitHub+Actions%E3%81%A7%E4%BE%9D%E5%AD%98%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AE%E6%9B%B4%E6%96%B0%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B)
 * [Centralized Scala Steward with GitHub Actions](https://hector.dev/2020/11/18/centralized-scala-steward-with-github-actions)
 * [Big Timesavers for Busy Scala Developers](https://speakerdeck.com/exoego/big-timesavers-for-busy-scala-developers)

--- a/modules/docs/mdoc/scalafix-migrations.md
+++ b/modules/docs/mdoc/scalafix-migrations.md
@@ -13,10 +13,13 @@ Here are two pull requests that demonstrate this feature:
 And here are all pull requests where Scala Steward applied Scalafix
 migrations:
 
+<!-- These links exists but returns 404 often so skip check -->
+<!-- markdown-link-check-disable -->
 * [Created pull requests](https://github.com/search?q=author%3Ascala-steward+is%3Apr+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Apr+scalafix-migrations))
 * [Merged pull requests]( https://github.com/search?q=author%3Ascala-steward+is%3Amerged+sort%3Aupdated-desc+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Amerged+sort%3Aupdated-desc+scalafix-migrations))
+<!-- markdown-link-check-enable -->
 
 ## How does this work?
 

--- a/modules/docs/mdoc/scalafix-migrations.md
+++ b/modules/docs/mdoc/scalafix-migrations.md
@@ -13,7 +13,7 @@ Here are two pull requests that demonstrate this feature:
 And here are all pull requests where Scala Steward applied Scalafix
 migrations:
 
-<!-- These links exists but returns 404 often so skip check -->
+<!-- These links returns 404 unless user is logged into GitHub. So let's skip -->
 <!-- markdown-link-check-disable -->
 * [Created pull requests](https://github.com/search?q=author%3Ascala-steward+is%3Apr+scalafix-migrations)
   ([compact](             https://github.com/pulls?q=author%3Ascala-steward+is%3Apr+scalafix-migrations))


### PR DESCRIPTION
Follow-up of #2842 

- Checker typically ends within 30 seconds which sounds acceptable. Faster than Scala jobs anyway.
- Check is skipped if no `~.md` are changed, so false alerts due to tentative network failure are less likely to happen 

https://github.com/gaurav-nelson/github-action-markdown-link-check is used since it is highly starred in this area and its README are well-written.

Also fixed some "broken" links found in test runs.


## Example

### Failure

https://github.com/exoego/scala-steward/actions/runs/3746779243/jobs/6362385292

<img width="842" alt="image" src="https://user-images.githubusercontent.com/127635/208831274-a74486a9-6785-4cc1-a0b1-0c8006134e55.png">

<img width="877" alt="image" src="https://user-images.githubusercontent.com/127635/208831458-69824b21-6246-4cc0-8be9-b8c81957a1c3.png">

### Succcess
https://github.com/exoego/scala-steward/actions/runs/3746849923/jobs/6362522900
<img width="740" alt="image" src="https://user-images.githubusercontent.com/127635/208833367-f788054b-0cb7-4ead-9586-4a6f4260269d.png">
