### PR TITLE
Do not run sbt if the project uses a sbt version < 1.3.0

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -21,7 +21,7 @@ class BuildToolDispatcherTest extends FunSuite {
     val repoDir = config.workspace / repo.toPath
     val initial = MockState.empty
       .addFiles(
-        repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
+        repoDir / "project" / "build.properties" -> "sbt.version=1.3.0",
         repoDir / scalafmtConfName -> "version=2.0.0"
       )
       .unsafeRunSync()
@@ -33,6 +33,7 @@ class BuildToolDispatcherTest extends FunSuite {
         Cmd("test", "-f", s"$repoDir/pom.xml"),
         Cmd("test", "-f", s"$repoDir/build.sc"),
         Cmd("test", "-f", s"$repoDir/build.sbt"),
+        Cmd("read", s"$repoDir/project/build.properties"),
         Cmd(
           repoDir.toString,
           "firejail",
@@ -56,7 +57,7 @@ class BuildToolDispatcherTest extends FunSuite {
     val expectedDeps = List(
       Scope(
         List(
-          sbt.sbtDependency(SbtVersion("1.2.6")).get,
+          sbt.sbtDependency(SbtVersion("1.3.0")).get,
           scalafmt.scalafmtDependency(Version("2.0.0"))
         ),
         List(Resolver.mavenCentral)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -37,11 +37,12 @@ class SbtAlgTest extends FunSuite {
     val repo = Repo("typelevel", "cats")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.toPath
-    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.2.6")
+    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.3.6")
     val initial = MockState.empty.copy(files = files)
     val state = sbtAlg.getDependencies(buildRoot).runS(initial).unsafeRunSync()
     val expected = initial.copy(
       trace = Vector(
+        Cmd("read", s"$repoDir/project/build.properties"),
         Cmd(
           repoDir.toString,
           "firejail",


### PR DESCRIPTION
This logs an error instead of trying to run sbt which is bound to fail because of #2847.