### PR TITLE
Add node/yarn to the docker image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -334,11 +334,12 @@ lazy val dockerSettings = Def.settings(
     val coursierBin = s"$binDir/coursier"
     Seq(
       Cmd("USER", "root"),
-      Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh"),
+      Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
-      Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt")
+      Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
+      Cmd("RUN", "npm install --global yarn")
     )
   },
   Docker / packageName := s"fthomas/${name.value}",


### PR DESCRIPTION
These tools are required to deal with some scala.js projects.

See https://github.com/wiringbits/scala-webapp-template/issues/298

NOTE:
- I have tested that the docker image can be published locally.
- I'm yet to test that this change fixes https://github.com/wiringbits/scala-webapp-template/issues/298
- A potential improvement could be to install nvm instead but that would require to install yarn per repository.