### PR TITLE
Add sbt plugins locally and not globally

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -20,7 +20,6 @@ import better.files.File
 import cats.effect.{ExitCode, Sync}
 import cats.syntax.all._
 import fs2.Stream
-import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
@@ -44,7 +43,6 @@ final class StewardAlg[F[_]](config: Config)(implicit
     nurtureAlg: NurtureAlg[F],
     pruningAlg: PruningAlg[F],
     repoCacheAlg: RepoCacheAlg[F],
-    sbtAlg: SbtAlg[F],
     selfCheckAlg: SelfCheckAlg[F],
     workspaceAlg: WorkspaceAlg[F],
     F: Sync[F]
@@ -95,7 +93,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
       for {
         _ <- selfCheckAlg.checkAll
         _ <- workspaceAlg.cleanWorkspace
-        exitCode <- sbtAlg.addGlobalPlugins.surround {
+        exitCode <-
           (config.githubApp.map(getGitHubAppRepos).getOrElse(Stream.empty) ++
             readRepos(config.reposFile))
             .evalMap(steward)
@@ -109,7 +107,6 @@ final class StewardAlg[F[_]](config: Config)(implicit
                   s"""The format is "- $$owner/$$repo" or "- $$owner/$$repo:$$branch"."""
                 logger.warn(msg).as(ExitCode.Success)
             }
-        }
       } yield exitCode
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -25,16 +25,14 @@ import org.scalasteward.core.buildtool.BuildToolAlg
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.coursier.VersionsCache
-import org.scalasteward.core.data.{Dependency, Scope}
+import org.scalasteward.core.data.{Dependency, Scope, Version}
 import org.scalasteward.core.edit.scalafix.{ScalafixCli, ScalafixMigration}
-import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.BuildRoot
-import org.typelevel.log4cats.Logger
 
 final class SbtAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],
-    logger: Logger[F],
     processAlg: ProcessAlg[F],
     scalafixCli: ScalafixCli[F],
     workspaceAlg: WorkspaceAlg[F],
@@ -44,17 +42,6 @@ final class SbtAlg[F[_]](config: Config)(implicit
   private def getSbtDependency(buildRoot: BuildRoot): F[Option[Dependency]] =
     OptionT(getSbtVersion(buildRoot)).subflatMap(sbtDependency).value
 
-  private def addGlobalPluginTemporarily(plugin: FileData): Resource[F, Unit] =
-    Resource.eval(sbtDir).flatMap { dir =>
-      List("0.13", "1.0").traverse_ { version =>
-        fileAlg.createTemporarily(dir / version / "plugins" / plugin.name, plugin.content)
-      }
-    }
-
-  def addGlobalPlugins: Resource[F, Unit] =
-    Resource.eval(logger.info("Add global sbt plugins")) >>
-      Resource.eval(stewardPlugin).flatMap(addGlobalPluginTemporarily)
-
   override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
     workspaceAlg
       .buildRootDir(buildRoot)
@@ -63,18 +50,28 @@ final class SbtAlg[F[_]](config: Config)(implicit
   private def getSbtVersion(buildRoot: BuildRoot): F[Option[SbtVersion]] =
     for {
       buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-      maybeProperties <- fileAlg.readFile(buildRootDir / "project" / "build.properties")
+      maybeProperties <- fileAlg.readFile(buildRootDir / project / "build.properties")
       version = maybeProperties.flatMap(parser.parseBuildProperties)
     } yield version
 
   override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
+    addStewardPluginTemporarily(buildRoot).surround {
+      for {
+        buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+        commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
+        lines <- sbt(commands, buildRootDir)
+        dependencies = parser.parseDependencies(lines)
+        additionalDependencies <- getAdditionalDependencies(buildRoot)
+      } yield additionalDependencies ::: dependencies
+    }
+
+  private def addStewardPluginTemporarily(buildRoot: BuildRoot): Resource[F, Unit] =
     for {
-      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-      commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
-      lines <- sbt(commands, buildRootDir)
-      dependencies = parser.parseDependencies(lines)
-      additionalDependencies <- getAdditionalDependencies(buildRoot)
-    } yield additionalDependencies ::: dependencies
+      buildRootDir <- Resource.eval(workspaceAlg.buildRootDir(buildRoot))
+      plugin <- Resource.eval(stewardPlugin[F])
+      _ <- fileAlg.createTemporarily(buildRootDir / project / plugin.name, plugin.content)
+      _ <- fileAlg.createTemporarily(buildRootDir / project / project / plugin.name, plugin.content)
+    } yield ()
 
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     migration.targetOrDefault match {
@@ -83,31 +80,29 @@ final class SbtAlg[F[_]](config: Config)(implicit
     }
 
   private def runSourcesMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-    sbtScalaFixPluginVersion.foreachF { pluginVersion =>
-      addGlobalPluginTemporarily(scalaStewardScalafixSbt(pluginVersion)).surround {
-        workspaceAlg.buildRootDir(buildRoot).flatMap { buildRootDir =>
-          val withScalacOptions =
-            migration.scalacOptions.fold(Resource.unit[F]) { opts =>
-              val file = scalaStewardScalafixOptions(opts.toList)
-              fileAlg.createTemporarily(buildRootDir / file.name, file.content)
-            }
+    OptionT(latestSbtScalafixVersion).foreachF { pluginVersion =>
+      workspaceAlg.buildRootDir(buildRoot).flatMap { buildRootDir =>
+        val plugin = scalaStewardSbtScalafix(pluginVersion)
+        fileAlg.createTemporarily(buildRootDir / project / plugin.name, plugin.content).surround {
+          val withScalacOptions = migration.scalacOptions.fold(Resource.unit[F]) { opts =>
+            val options = scalaStewardScalafixOptions(opts.toList)
+            fileAlg.createTemporarily(buildRootDir / options.name, options.content)
+          }
           val scalafixCmds = migration.rewriteRules.map(rule => s"$scalafixAll $rule").toList
           withScalacOptions.surround(sbt(Nel(scalafixEnable, scalafixCmds), buildRootDir).void)
         }
       }
     }
 
-  private def sbtScalaFixPluginVersion: OptionT[F, String] =
-    OptionT(
-      versionsCache
-        .getVersions(Scope(sbtScalaFixDependency, List(config.defaultResolver)), None)
-        .map(_.lastOption.map(_.value))
-    )
+  private def latestSbtScalafixVersion: F[Option[Version]] =
+    versionsCache
+      .getVersions(Scope(sbtScalafixDependency, List(config.defaultResolver)), None)
+      .map(_.lastOption)
 
   private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     for {
       buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-      projectDir = buildRootDir / "project"
+      projectDir = buildRootDir / project
       files0 <- (
         fileAlg.walk(buildRootDir, 1).filter(_.extension.contains(".sbt")) ++
           fileAlg.walk(projectDir, 3).filter(_.extension.exists(Set(".sbt", ".scala")))
@@ -116,9 +111,6 @@ final class SbtAlg[F[_]](config: Config)(implicit
         scalafixCli.runMigration(buildRootDir, files1, migration)
       }
     } yield ()
-
-  private val sbtDir: F[File] =
-    fileAlg.home.map(_ / ".sbt")
 
   private def sbt(sbtCommands: Nel[String], repoDir: File): F[List[String]] =
     maybeIgnoreOptsFiles(repoDir).surround {
@@ -133,7 +125,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
       processAlg.execSandboxed(command, repoDir)
     }
 
-  private def maybeIgnoreOptsFiles[A](dir: File): Resource[F, Unit] =
+  private def maybeIgnoreOptsFiles(dir: File): Resource[F, Unit] =
     if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
 
   private def ignoreOptsFiles(dir: File): Resource[F, Unit] =
@@ -142,4 +134,6 @@ final class SbtAlg[F[_]](config: Config)(implicit
   private def getAdditionalDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
     getSbtDependency(buildRoot)
       .map(_.map(dep => Scope(List(dep), List(config.defaultResolver))).toList)
+
+  private val project = "project"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -35,23 +35,24 @@ package object sbt {
     Option.when(version >= Version("1.0.0"))(Dependency(sbtGroupId, sbtArtifactId, version))
   }
 
-  val sbtScalaFixGroupId = GroupId("ch.epfl.scala")
-  val sbtScalaFixArtifactId = ArtifactId("sbt-scalafix")
+  val sbtScalafixGroupId: GroupId = GroupId("ch.epfl.scala")
 
-  val sbtScalaFixDependency: Dependency =
+  val sbtScalafixArtifactId: ArtifactId = ArtifactId("sbt-scalafix")
+
+  val sbtScalafixDependency: Dependency =
     Dependency(
-      sbtScalaFixGroupId,
-      sbtScalaFixArtifactId,
+      sbtScalafixGroupId,
+      sbtScalafixArtifactId,
       Version(""),
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
     )
 
-  def scalaStewardScalafixSbt(version: String): FileData =
-    FileData(
-      "scala-steward-scalafix.sbt",
-      s"""addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "$version")"""
-    )
+  def scalaStewardSbtScalafix(version: Version): FileData = {
+    val content =
+      s"""addSbtPlugin("${sbtScalafixGroupId.value}" % "${sbtScalafixArtifactId.name}" % "$version")"""
+    FileData("scala-steward-sbt-scalafix.sbt", content)
+  }
 
   def scalaStewardScalafixOptions(scalacOptions: List[String]): FileData = {
     val args = scalacOptions.map(s => s""""$s"""").mkString(", ")
@@ -63,6 +64,6 @@ package object sbt {
     val name = "StewardPlugin.scala"
     fileAlg
       .readResource(s"${pkg.replace('.', '/')}/$name")
-      .map(FileData(name, _))
+      .map(FileData(s"scala-steward-$name", _))
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -22,8 +22,8 @@ import cats.syntax.all._
 import org.scalasteward.core.buildtool.sbt.{
   sbtArtifactId,
   sbtGroupId,
-  sbtScalaFixArtifactId,
-  sbtScalaFixGroupId
+  sbtScalafixArtifactId,
+  sbtScalafixGroupId
 }
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.EditAttempt
@@ -123,7 +123,7 @@ object HookExecutor {
 
   // Modules that most likely require the workflow to be regenerated if updated.
   private val conditionalSbtGitHubWorkflowGenerateModules =
-    (sbtGroupId, sbtArtifactId) :: (sbtScalaFixGroupId, sbtScalaFixArtifactId) :: scalaLangModules
+    (sbtGroupId, sbtArtifactId) :: (sbtScalafixGroupId, sbtScalafixArtifactId) :: scalaLangModules
 
   private def sbtGithubWorkflowGenerateHook(
       groupId: GroupId,

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -56,6 +56,11 @@ trait FileAlg[F[_]] {
     Resource.make(create)(_ => delete)
   }
 
+  final def createTemporarily[E](dir: File, data: FileData)(implicit
+      F: ApplicativeError[F, E]
+  ): Resource[F, Unit] =
+    createTemporarily(dir / data.name, data.content)
+
   final def editFile(file: File, edit: String => Option[String])(implicit
       F: MonadThrow[F]
   ): F[Boolean] =

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -32,8 +32,6 @@ trait FileAlg[F[_]] {
 
   def ensureExists(dir: File): F[File]
 
-  def home: F[File]
-
   def isDirectory(file: File): F[Boolean]
 
   def isRegularFile(file: File): F[Boolean]
@@ -98,9 +96,6 @@ object FileAlg {
           if (!dir.exists) dir.createDirectories()
           dir
         }
-
-      override def home: F[File] =
-        F.delay(File.home)
 
       override def isDirectory(file: File): F[Boolean] =
         F.blocking(file.isDirectory(File.LinkOptions.noFollow))

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -33,6 +33,9 @@ class BuildToolDispatcherTest extends FunSuite {
         Cmd("test", "-f", s"$repoDir/pom.xml"),
         Cmd("test", "-f", s"$repoDir/build.sc"),
         Cmd("test", "-f", s"$repoDir/build.sbt"),
+        Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
+        Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
+        Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
         Cmd(
           repoDir.toString,
           "firejail",
@@ -47,6 +50,8 @@ class BuildToolDispatcherTest extends FunSuite {
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         Cmd("read", s"$repoDir/project/build.properties"),
+        Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
+        Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
         Cmd("read", s"$repoDir/$scalafmtConfName")
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -56,10 +56,10 @@ class FileAlgTest extends FunSuite {
   }
 
   test("editFile: nonexistent file") {
-    val (state, edited) = (for {
-      home <- fileAlg.home
-      edited <- fileAlg.editFile(home / "does-not-exists.txt", Some.apply)
-    } yield edited).runSA(MockState.empty).unsafeRunSync()
+    val (state, edited) = fileAlg
+      .editFile(mockRoot / "does-not-exists.txt", Some.apply)
+      .runSA(MockState.empty)
+      .unsafeRunSync()
 
     val expected =
       MockState.empty.copy(trace = Vector(Cmd("read", s"$mockRoot/does-not-exists.txt")))

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -51,18 +51,18 @@ class FileAlgTest extends FunSuite {
   }
 
   test("removeTemporarily: nonexistent file") {
-    val file = mockRoot / "does-not-exists.txt"
+    val file = mockRoot / "does-not-exist.txt"
     assertEquals(ioFileAlg.removeTemporarily(file).surround(IO.pure(42)).unsafeRunSync(), 42)
   }
 
   test("editFile: nonexistent file") {
     val (state, edited) = fileAlg
-      .editFile(mockRoot / "does-not-exists.txt", Some.apply)
+      .editFile(mockRoot / "does-not-exist.txt", Some.apply)
       .runSA(MockState.empty)
       .unsafeRunSync()
 
     val expected =
-      MockState.empty.copy(trace = Vector(Cmd("read", s"$mockRoot/does-not-exists.txt")))
+      MockState.empty.copy(trace = Vector(Cmd("read", s"$mockRoot/does-not-exist.txt")))
     assertEquals(state, expected)
     assert(!edited)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
@@ -15,9 +15,6 @@ class MockFileAlg extends FileAlg[MockEff] {
   override def ensureExists(dir: File): MockEff[File] =
     Kleisli(_.update(_.exec(List("mkdir", "-p", dir.pathAsString))) >> ioFileAlg.ensureExists(dir))
 
-  override def home: MockEff[File] =
-    Kleisli.pure(MockConfig.mockRoot)
-
   override def isDirectory(file: File): MockEff[Boolean] =
     Kleisli(_.update(_.exec(List("test", "-d", file.pathAsString))) >> ioFileAlg.isDirectory(file))
 


### PR DESCRIPTION
`StewardPlugin.scala` is the sbt plugin that outputs all relevant information from a build for consumption by Scala Steward. That plugin has been installed so far globally at the start of Scala Steward into sbt's home directory. With this PR, that plugin is now installed into the local `project/` directories as long as it is needed to run `sbt stewardDependencies`.

This change is motivated by #2847 - i.e. only sbt >= 1.3.0 can currently load our sbt plugin. With this change we would be able to use different plugins dependending on a repo's sbt version.

closes: #1624