### PR TITLE
Show that our sbt plugin requires at least 1.3.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,7 +245,8 @@ lazy val `sbt-plugin` = myCrossProject("sbt-plugin")
   .settings(noPublishSettings)
   .settings(
     scalaVersion := Scala212,
-    sbtPlugin := true
+    sbtPlugin := true,
+    pluginCrossBuild / sbtVersion := "1.3.10"
   )
 
 /// settings

--- a/build.sbt
+++ b/build.sbt
@@ -246,7 +246,7 @@ lazy val `sbt-plugin` = myCrossProject("sbt-plugin")
   .settings(
     scalaVersion := Scala212,
     sbtPlugin := true,
-    pluginCrossBuild / sbtVersion := "1.3.10"
+    pluginCrossBuild / sbtVersion := "1.3.11"
   )
 
 /// settings


### PR DESCRIPTION
This sets the sbt version that is used to compile our plugin and it shows that we currently require at least 1.3.11 (see also https://github.com/scala-steward-org/scala-steward/issues/2847#issuecomment-1364132307). This setting should also help with making us aware of any changes in the plugin that would require a newer sbt version.