### PR TITLE
Use a version dependent sbt plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Compress target directories
-        run: tar cf targets.tar target modules/docs/.jvm/target modules/dummy/.jvm/target modules/sbt-plugin/.jvm/target modules/core/.jvm/target modules/benchmark/.jvm/target project/target
+        run: tar cf targets.tar target modules/docs/.jvm/target modules/sbt-plugin-1_0_0/.jvm/target modules/dummy/.jvm/target modules/sbt-plugin-1_3_11/.jvm/target modules/core/.jvm/target modules/benchmark/.jvm/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "core" -> List(JVMPlatform),
   "docs" -> List(JVMPlatform),
   "dummy" -> List(JVMPlatform),
-  "sbt-plugin" -> List(JVMPlatform),
+  "sbt-plugin-1_3_11" -> List(JVMPlatform),
   "sbt-plugin-1_0_0" -> List(JVMPlatform)
 )
 
@@ -71,7 +71,14 @@ ThisBuild / evictionErrorLevel := Level.Info
 
 lazy val root = project
   .in(file("."))
-  .aggregate(benchmark.jvm, core.jvm, docs.jvm, dummy.jvm, `sbt-plugin`.jvm, `sbt-plugin-1_0_0`.jvm)
+  .aggregate(
+    benchmark.jvm,
+    core.jvm,
+    docs.jvm,
+    dummy.jvm,
+    `sbt-plugin-1_3_11`.jvm,
+    `sbt-plugin-1_0_0`.jvm
+  )
   .settings(commonSettings)
   .settings(noPublishSettings)
 
@@ -160,9 +167,6 @@ lazy val core = myCrossProject("core")
       BuildInfoKey("gitHubUserContent" -> gitHubUserContent),
       BuildInfoKey("mainBranch" -> mainBranch),
       BuildInfoKey.map(git.gitHeadCommit) { case (k, v) => k -> v.getOrElse(mainBranch) },
-      BuildInfoKey.map(`sbt-plugin`.jvm / moduleRootPkg) { case (_, v) =>
-        "sbtPluginModuleRootPkg" -> v
-      },
       BuildInfoKey("millPluginArtifactName" -> Dependencies.scalaStewardMillPluginArtifactName),
       BuildInfoKey("millPluginVersion" -> Dependencies.scalaStewardMillPlugin.revision)
     ),
@@ -200,7 +204,7 @@ lazy val core = myCrossProject("core")
     Test / testOptions +=
       Tests.Cleanup(() => Path(file(Properties.tmpDir) / "scala-steward").deleteRecursively()),
     Compile / unmanagedResourceDirectories ++=
-      (`sbt-plugin`.jvm / Compile / unmanagedSourceDirectories).value ++
+      (`sbt-plugin-1_3_11`.jvm / Compile / unmanagedSourceDirectories).value ++
         (`sbt-plugin-1_0_0`.jvm / Compile / unmanagedSourceDirectories).value
   )
 
@@ -244,7 +248,7 @@ lazy val dummy = myCrossProject("dummy")
     )
   )
 
-lazy val `sbt-plugin` = myCrossProject("sbt-plugin")
+lazy val `sbt-plugin-1_3_11` = myCrossProject("sbt-plugin-1_3_11")
   .settings(noPublishSettings)
   .settings(
     scalaVersion := Scala212,
@@ -385,14 +389,6 @@ lazy val scaladocSettings = Def.settings(
 /// setting keys
 
 lazy val checkDocs = taskKey[Unit]("")
-
-lazy val installPlugin = taskKey[Unit]("Copies StewardPlugin.scala into global plugins directory.")
-installPlugin := {
-  val name = "StewardPlugin.scala"
-  val source = (`sbt-plugin`.jvm / Compile / sources).value.find(_.name == name).get
-  val target = file(System.getProperty("user.home")) / ".sbt" / "1.0" / "plugins" / name
-  IO.copyFile(source, target)
-}
 
 lazy val moduleRootPkg = settingKey[String]("").withRank(KeyRanks.Invisible)
 moduleRootPkg := rootPkg

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "core" -> List(JVMPlatform),
   "docs" -> List(JVMPlatform),
   "dummy" -> List(JVMPlatform),
-  "sbt-plugin" -> List(JVMPlatform)
+  "sbt-plugin" -> List(JVMPlatform),
+  "sbt-plugin-1_0_0" -> List(JVMPlatform)
 )
 
 val Scala212 = "2.12.17"
@@ -70,7 +71,7 @@ ThisBuild / evictionErrorLevel := Level.Info
 
 lazy val root = project
   .in(file("."))
-  .aggregate(benchmark.jvm, core.jvm, docs.jvm, dummy.jvm, `sbt-plugin`.jvm)
+  .aggregate(benchmark.jvm, core.jvm, docs.jvm, dummy.jvm, `sbt-plugin`.jvm, `sbt-plugin-1_0_0`.jvm)
   .settings(commonSettings)
   .settings(noPublishSettings)
 
@@ -198,7 +199,9 @@ lazy val core = myCrossProject("core")
     Test / fork := true,
     Test / testOptions +=
       Tests.Cleanup(() => Path(file(Properties.tmpDir) / "scala-steward").deleteRecursively()),
-    Compile / unmanagedResourceDirectories ++= (`sbt-plugin`.jvm / Compile / unmanagedSourceDirectories).value
+    Compile / unmanagedResourceDirectories ++=
+      (`sbt-plugin`.jvm / Compile / unmanagedSourceDirectories).value ++
+        (`sbt-plugin-1_0_0`.jvm / Compile / unmanagedSourceDirectories).value
   )
 
 lazy val docs = myCrossProject("docs")
@@ -247,6 +250,14 @@ lazy val `sbt-plugin` = myCrossProject("sbt-plugin")
     scalaVersion := Scala212,
     sbtPlugin := true,
     pluginCrossBuild / sbtVersion := "1.3.11"
+  )
+
+lazy val `sbt-plugin-1_0_0` = myCrossProject("sbt-plugin-1_0_0")
+  .settings(noPublishSettings)
+  .settings(
+    scalaVersion := Scala212,
+    sbtPlugin := true,
+    pluginCrossBuild / sbtVersion := "1.0.0"
   )
 
 /// settings

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -71,7 +71,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
     for {
       plugin <- maybeSbtVersion.map(_.toVersion) match {
         case Some(v) if v < Version("1.3.11") => Resource.eval(stewardPlugin_1_0_0[F])
-        case _                                => Resource.eval(stewardPlugin[F])
+        case _                                => Resource.eval(stewardPlugin_1_3_11[F])
       }
       _ <- fileAlg.createTemporarily(buildRootDir / project, plugin)
       _ <- fileAlg.createTemporarily(buildRootDir / project / project, plugin)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -41,39 +41,44 @@ final class SbtAlg[F[_]](config: Config)(implicit
 ) extends BuildToolAlg[F] {
   override def name: String = "sbt"
 
-  private def getSbtDependency(buildRoot: BuildRoot): F[Option[Dependency]] =
-    OptionT(getSbtVersion(buildRoot)).subflatMap(sbtDependency).value
-
   override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
     workspaceAlg
       .buildRootDir(buildRoot)
       .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "build.sbt"))
 
-  private def getSbtVersion(buildRoot: BuildRoot): F[Option[SbtVersion]] =
+  private def getSbtVersion(buildRootDir: File): F[Option[SbtVersion]] =
     for {
-      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
       maybeProperties <- fileAlg.readFile(buildRootDir / project / buildPropertiesName)
       version = maybeProperties.flatMap(parser.parseBuildProperties)
     } yield version
 
   override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
-    addStewardPluginTemporarily(buildRoot).surround {
-      for {
-        buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-        commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
-        lines <- sbt(commands, buildRootDir)
-        dependencies = parser.parseDependencies(lines)
-        additionalDependencies <- getAdditionalDependencies(buildRoot)
-      } yield additionalDependencies ::: dependencies
-    }
-
-  private def addStewardPluginTemporarily(buildRoot: BuildRoot): Resource[F, Unit] =
     for {
-      buildRootDir <- Resource.eval(workspaceAlg.buildRootDir(buildRoot))
-      plugin <- Resource.eval(stewardPlugin[F])
+      buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
+      maybeSbtVersion <- getSbtVersion(buildRootDir)
+      lines <- addStewardPluginTemporarily(buildRootDir, maybeSbtVersion).surround {
+        val commands = Nel.of(crossStewardDependencies, reloadPlugins, stewardDependencies)
+        sbt(commands, buildRootDir)
+      }
+      dependencies = parser.parseDependencies(lines)
+      maybeSbtDependency = maybeSbtVersion.flatMap(scopedSbtDependency).map(_.map(List(_))).toList
+    } yield maybeSbtDependency ::: dependencies
+
+  private def addStewardPluginTemporarily(
+      buildRootDir: File,
+      maybeSbtVersion: Option[SbtVersion]
+  ): Resource[F, Unit] =
+    for {
+      plugin <- maybeSbtVersion.map(_.toVersion) match {
+        case Some(v) if v < Version("1.3.11") => Resource.eval(stewardPlugin_1_0_0[F])
+        case _                                => Resource.eval(stewardPlugin[F])
+      }
       _ <- fileAlg.createTemporarily(buildRootDir / project, plugin)
       _ <- fileAlg.createTemporarily(buildRootDir / project / project, plugin)
     } yield ()
+
+  private def scopedSbtDependency(sbtVersion: SbtVersion): Option[Scope[Dependency]] =
+    sbtDependency(sbtVersion).map(dep => Scope(dep, List(config.defaultResolver)))
 
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     migration.targetOrDefault match {
@@ -132,10 +137,6 @@ final class SbtAlg[F[_]](config: Config)(implicit
 
   private def ignoreOptsFiles(dir: File): Resource[F, Unit] =
     List(".jvmopts", ".sbtopts").traverse_(file => fileAlg.removeTemporarily(dir / file))
-
-  private def getAdditionalDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
-    getSbtDependency(buildRoot)
-      .map(_.map(dep => Scope(List(dep), List(config.defaultResolver))).toList)
 
   private val project = "project"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
@@ -20,11 +20,8 @@ import cats.Order
 import cats.syntax.all._
 import io.circe.Codec
 import io.circe.generic.extras.semiauto._
-import org.scalasteward.core.data.Version
 
-final case class SbtVersion(value: String) {
-  def toVersion: Version = Version(value)
-}
+final case class SbtVersion(value: String)
 
 object SbtVersion {
   implicit val sbtVersionCodec: Codec[SbtVersion] =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -16,11 +16,10 @@
 
 package org.scalasteward.core.buildtool
 
-import cats.Functor
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data._
-import org.scalasteward.core.io.{FileAlg, FileData}
+import org.scalasteward.core.io.FileData
 
 package object sbt {
   val defaultScalaBinaryVersion: String =
@@ -36,10 +35,8 @@ package object sbt {
     update.groupId === sbtGroupId &&
       update.artifactIds.exists(_.name === sbtArtifactId.name)
 
-  def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] = {
-    val version = sbtVersion.toVersion
+  def sbtDependency(version: Version): Option[Dependency] =
     Option.when(version >= Version("1.0.0"))(Dependency(sbtGroupId, sbtArtifactId, version))
-  }
 
   val sbtScalafixGroupId: GroupId = GroupId("ch.epfl.scala")
 
@@ -63,21 +60,5 @@ package object sbt {
   def scalaStewardScalafixOptions(scalacOptions: List[String]): FileData = {
     val args = scalacOptions.map(s => s""""$s"""").mkString(", ")
     FileData("scala-steward-scalafix-options.sbt", s"ThisBuild / scalacOptions ++= List($args)")
-  }
-
-  def stewardPlugin_1_3_11[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
-    val pkg = "org.scalasteward.sbt.plugin"
-    val name = "StewardPlugin_1_3_11.scala"
-    fileAlg
-      .readResource(s"${pkg.replace('.', '/')}/$name")
-      .map(FileData(s"scala-steward-$name", _))
-  }
-
-  def stewardPlugin_1_0_0[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
-    val pkg = "org.scalasteward.sbt.plugin"
-    val name = "StewardPlugin_1_0_0.scala"
-    fileAlg
-      .readResource(s"${pkg.replace('.', '/')}/$name")
-      .map(FileData(s"scala-steward-$name", _))
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -65,16 +65,16 @@ package object sbt {
     FileData("scala-steward-scalafix-options.sbt", s"ThisBuild / scalacOptions ++= List($args)")
   }
 
-  def stewardPlugin[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
-    val pkg: String = org.scalasteward.core.BuildInfo.sbtPluginModuleRootPkg
-    val name = "StewardPlugin.scala"
+  def stewardPlugin_1_3_11[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
+    val pkg = "org.scalasteward.sbt.plugin"
+    val name = "StewardPlugin_1_3_11.scala"
     fileAlg
       .readResource(s"${pkg.replace('.', '/')}/$name")
       .map(FileData(s"scala-steward-$name", _))
   }
 
   def stewardPlugin_1_0_0[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
-    val pkg: String = org.scalasteward.core.BuildInfo.sbtPluginModuleRootPkg
+    val pkg = "org.scalasteward.sbt.plugin"
     val name = "StewardPlugin_1_0_0.scala"
     fileAlg
       .readResource(s"${pkg.replace('.', '/')}/$name")

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -72,4 +72,12 @@ package object sbt {
       .readResource(s"${pkg.replace('.', '/')}/$name")
       .map(FileData(s"scala-steward-$name", _))
   }
+
+  def stewardPlugin_1_0_0[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
+    val pkg: String = org.scalasteward.core.BuildInfo.sbtPluginModuleRootPkg
+    val name = "StewardPlugin_1_0_0.scala"
+    fileAlg
+      .readResource(s"${pkg.replace('.', '/')}/$name")
+      .map(FileData(s"scala-steward-$name", _))
+  }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
@@ -19,12 +19,11 @@ package org.scalasteward.core.buildtool.sbt
 import cats.implicits._
 import io.circe.Decoder
 import io.circe.parser._
-import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data._
 
 object parser {
-  def parseBuildProperties(s: String): Option[SbtVersion] =
-    """sbt.version\s*=\s*(.+)""".r.findFirstMatchIn(s).map(_.group(1)).map(SbtVersion.apply)
+  def parseBuildProperties(s: String): Option[Version] =
+    """sbt.version\s*=\s*(\S+)""".r.findFirstMatchIn(s).map(_.group(1)).map(Version.apply)
 
   /** Parses the output of our own `stewardDependencies` task. */
   def parseDependencies(lines: List[String]): List[Scope.Dependencies] = {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -3,7 +3,6 @@ package org.scalasteward.core.buildtool
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
-import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
@@ -93,7 +92,7 @@ class BuildToolDispatcherTest extends FunSuite {
     val expectedDeps = List(
       Scope(
         List(
-          sbt.sbtDependency(SbtVersion("1.2.6")).get,
+          sbt.sbtDependency(Version("1.2.6")).get,
           scalafmt.scalafmtDependency(Version("2.0.0"))
         ),
         List(Resolver.mavenCentral)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -40,9 +40,10 @@ class BuildToolDispatcherTest extends FunSuite {
         Cmd("test", "-f", s"$repoDir/mvn-build/build.sc"),
         Cmd("test", "-f", s"$repoDir/mvn-build/build.sbt"),
         Log("Get dependencies in . from sbt"),
-        Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
-        Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
-        Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
+        Cmd("read", s"$repoDir/project/build.properties"),
+        Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala"),
+        Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin_1_0_0.scala"),
+        Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin_1_0_0.scala"),
         Cmd(
           repoDir.toString,
           "firejail",
@@ -56,9 +57,8 @@ class BuildToolDispatcherTest extends FunSuite {
           "-Dsbt.supershell=false",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
-        Cmd("read", s"$repoDir/project/build.properties"),
-        Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
-        Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
+        Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_0_0.scala"),
+        Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin_1_0_0.scala"),
         Cmd("read", s"$repoDir/$scalafmtConfName"),
         Log("Get dependencies in mvn-build from Maven"),
         Cmd(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -17,11 +17,12 @@ class SbtAlgTest extends FunSuite {
     val repo = Repo("typelevel", "cats")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = config.workspace / repo.toPath
-    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.2.6")
+    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.3.6")
     val initial = MockState.empty.copy(files = files)
     val state = sbtAlg.getDependencies(buildRoot).runS(initial).unsafeRunSync()
     val expected = initial.copy(
       trace = Vector(
+        Cmd("read", s"$repoDir/project/build.properties"),
         Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
         Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
         Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
@@ -38,7 +39,6 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.supershell=false",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
-        Cmd("read", s"$repoDir/project/build.properties"),
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
         Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin.scala")
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -23,9 +23,9 @@ class SbtAlgTest extends FunSuite {
     val expected = initial.copy(
       trace = Vector(
         Cmd("read", s"$repoDir/project/build.properties"),
-        Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
-        Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin.scala"),
-        Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
+        Cmd("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala"),
+        Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin_1_3_11.scala"),
+        Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd(
           repoDir.toString,
           "firejail",
@@ -39,8 +39,8 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.supershell=false",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
-        Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin.scala"),
-        Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin.scala")
+        Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
+        Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin_1_3_11.scala")
       )
     )
     assertEquals(state, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
@@ -5,11 +5,11 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.buildtool.sbt.parser._
 import org.scalasteward.core.data.Resolver.{Credentials, IvyRepository, MavenRepository}
-import org.scalasteward.core.data.{Resolver, Scope}
+import org.scalasteward.core.data.{Resolver, Scope, Version}
 
 class parserTest extends FunSuite {
   test("parseBuildProperties: with whitespace") {
-    assertEquals(parseBuildProperties("sbt.version = 1.2.8"), Some(SbtVersion("1.2.8")))
+    assertEquals(parseBuildProperties("sbt.version = 1.2.8 "), Some(Version("1.2.8")))
   }
 
   test("parseDependencies") {

--- a/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
+++ b/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.sbt.plugin
+
+import sbt.Keys._
+import sbt._
+import scala.util.Try
+
+object StewardPlugin_1_0_0 extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+    val stewardDependencies =
+      taskKey[Unit]("Prints dependencies and resolvers as JSON for consumption by Scala Steward.")
+  }
+
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      stewardDependencies := {
+        val scalaBinaryVersionValue = scalaBinaryVersion.value
+        val scalaVersionValue = scalaVersion.value
+        val sbtCredentials = findCredentials.value
+
+        val libraryDeps = libraryDependencies.value
+          .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
+
+        val scalafixDeps = findScalafixDependencies.value
+          .getOrElse(Seq.empty)
+          .map(moduleId =>
+            toDependency(
+              moduleId,
+              scalaVersionValue,
+              scalaBinaryVersionValue,
+              Some("scalafix-rule")
+            )
+          )
+        val dependencies = libraryDeps ++ scalafixDeps
+
+        def getCredentials(url: URL, name: String): Option[Resolver.Credentials] =
+          (for {
+            allDirect <- Try(Credentials.allDirect(sbtCredentials)).toOption
+            maybeRealmAndHost = allDirect.find(c => c.realm == name && c.host == url.getHost)
+            maybeRealm = allDirect.find(_.realm == name)
+            maybeHost = allDirect.find(_.host == url.getHost)
+          } yield maybeRealmAndHost.orElse(maybeRealm).orElse(maybeHost)).flatten
+            .map(c => Resolver.Credentials(c.userName, c.passwd))
+
+        val resolvers = fullResolvers.value.collect {
+          case repo: MavenRepository if !repo.root.startsWith("file:") =>
+            val creds = getCredentials(new URL(repo.root), repo.name)
+            Resolver.MavenRepository(repo.name, repo.root, creds)
+          case repo: URLRepository =>
+            val ivyPatterns = repo.patterns.ivyPatterns.mkString
+            val creds = getCredentials(new URL(ivyPatterns), repo.name)
+            Resolver.IvyRepository(repo.name, ivyPatterns, creds)
+        }
+
+        val sb = new StringBuilder()
+        val ls = System.lineSeparator()
+        sb.append("--- snip ---").append(ls)
+        dependencies.foreach(d => sb.append(d.asJson).append(ls))
+        resolvers.foreach(r => sb.append(r.asJson).append(ls))
+        println(sb.result())
+      }
+    )
+
+  // base on mdoc
+  // https://github.com/scalameta/mdoc/blob/62cacfbc4c7b618228e349d4f460061916398424/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala#L164-L182
+  lazy val findScalafixDependencies: Def.Initialize[Option[Seq[ModuleID]]] = Def.settingDyn {
+    try {
+      val scalafixDependencies = SettingKey[Seq[ModuleID]]("scalafixDependencies").?
+      Def.setting {
+        scalafixDependencies.value
+      }
+    } catch {
+      case _: ClassNotFoundException => Def.setting(None)
+    }
+  }
+
+  lazy val findCredentials: Def.Initialize[Task[Seq[Credentials]]] = Def.taskDyn {
+    try {
+      val allCredentials = TaskKey[Seq[Credentials]]("allCredentials").?
+      Def.task {
+        allCredentials.value.getOrElse(Nil)
+      }
+    } catch {
+      case _: ClassNotFoundException => Def.task(credentials.value)
+    }
+  }
+
+  private def crossName(
+      moduleId: ModuleID,
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  ): Option[String] =
+    CrossVersion(moduleId.crossVersion, scalaVersion, scalaBinaryVersion).map(_(moduleId.name))
+
+  private def toDependency(
+      moduleId: ModuleID,
+      scalaVersion: String,
+      scalaBinaryVersion: String,
+      configurations: Option[String] = None
+  ): Dependency =
+    Dependency(
+      groupId = moduleId.organization,
+      artifactId = ArtifactId(moduleId.name, crossName(moduleId, scalaVersion, scalaBinaryVersion)),
+      version = moduleId.revision,
+      sbtVersion = moduleId.extraAttributes.get("e:sbtVersion"),
+      scalaVersion = moduleId.extraAttributes.get("e:scalaVersion"),
+      configurations = configurations.orElse(moduleId.configurations)
+    )
+
+  final private case class ArtifactId(
+      name: String,
+      maybeCrossName: Option[String]
+  ) {
+    def asJson: String =
+      objToJson(
+        List(
+          "name" -> strToJson(name),
+          "maybeCrossName" -> optToJson(maybeCrossName.map(strToJson))
+        )
+      )
+  }
+
+  final private case class Dependency(
+      groupId: String,
+      artifactId: ArtifactId,
+      version: String,
+      sbtVersion: Option[String],
+      scalaVersion: Option[String],
+      configurations: Option[String]
+  ) {
+    def asJson: String =
+      objToJson(
+        List(
+          "groupId" -> strToJson(groupId),
+          "artifactId" -> artifactId.asJson,
+          "version" -> strToJson(version),
+          "sbtVersion" -> optToJson(sbtVersion.map(strToJson)),
+          "scalaVersion" -> optToJson(scalaVersion.map(strToJson)),
+          "configurations" -> optToJson(configurations.map(strToJson))
+        )
+      )
+  }
+
+  sealed trait Resolver extends Product with Serializable {
+    def asJson: String
+  }
+
+  object Resolver {
+    final case class Credentials(user: String, pass: String) {
+      def asJson: String =
+        objToJson(
+          List("user" -> strToJson(user), "pass" -> strToJson(pass))
+        )
+    }
+
+    final case class MavenRepository(
+        name: String,
+        location: String,
+        credentials: Option[Credentials]
+    ) extends Resolver {
+      override def asJson: String =
+        objToJson(
+          List(
+            "MavenRepository" -> objToJson(
+              List(
+                "name" -> strToJson(name),
+                "location" -> strToJson(location),
+                "headers" -> arrToJson(Nil)
+              ) ++
+                credentials.map(c => "credentials" -> c.asJson).toList
+            )
+          )
+        )
+    }
+
+    final case class IvyRepository(name: String, pattern: String, credentials: Option[Credentials])
+        extends Resolver {
+      override def asJson: String =
+        objToJson(
+          List(
+            "IvyRepository" -> objToJson(
+              List(
+                "name" -> strToJson(name),
+                "pattern" -> strToJson(pattern),
+                "headers" -> arrToJson(Nil)
+              ) ++
+                credentials.map(c => "credentials" -> c.asJson).toList
+            )
+          )
+        )
+    }
+  }
+
+  private def strToJson(str: String): String =
+    s""""$str""""
+
+  private def optToJson(opt: Option[String]): String =
+    opt.getOrElse("null")
+
+  private def objToJson(obj: List[(String, String)]): String =
+    obj.map { case (k, v) => s""""$k": $v""" }.mkString("{ ", ", ", " }")
+
+  private def arrToJson(arr: List[String]): String =
+    arr.mkString("[ ", ", ", "]")
+}

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -20,7 +20,7 @@ import sbt.Keys._
 import sbt._
 import scala.util.Try
 
-object StewardPlugin extends AutoPlugin {
+object StewardPlugin_1_3_11 extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   object autoImport {


### PR DESCRIPTION
This PR injects a sbt plugin into a repo's build that depends on the used sbt version. The main motivation of this change is to fix #2847.

The changes here are:
- the `sbt-plugin` project in the build is renamed to `sbt-plugin-1_3_11`. `1_3_11` is used as suffix because the plugin requires at least sbt 1.3.11, see #2858.
- a new `sbt-plugin-1_0_0` is added that contains a `StewardPlugin_1_0_0.scala` that is compatible with sbt 1.0.0 and above. It should also work with sbt 0.13.x but we don't test it here because I don't want to add Scala 2.10 to `crossScalaVersions`.
- `SbtAlg#getDependencies` first reads the sbt version from `build.properties` and then selects the appropriate plugin based on that version.

closes: #2847