### PR TITLE
Do not overwrite version scheme for scala-xml

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,8 +12,3 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
-
-// A workaround until sbt ecosystem migrate to scala-xml 2.x https://github.com/sbt/sbt/issues/6997
-ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)

--- a/repos.md
+++ b/repos.md
@@ -7,6 +7,7 @@ If you want Scala Steward to keep a non-default branch up-to-date, use "- $owner
 All lines that do not start with a hyphen and space are ignored.
 
 - scala-steward-org/mill-plugin
+- scala-steward-org/sbt-plugin
 - scala-steward-org/scala-steward
 - scala-steward-org/test-repo-1
 - scala-steward-org/test-repo-2


### PR DESCRIPTION
It seems that this isn't needed anymore.