### PR TITLE
Show release notes URL from POM in PR body

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -16,15 +16,14 @@
 
 package org.scalasteward.core.coursier
 
+import cats.Parallel
 import cats.effect._
 import cats.implicits._
-import cats.{Applicative, Parallel}
 import coursier.cache.{CachePolicy, FileCache}
 import coursier.core.{Authentication, Project}
-import coursier.{Fetch, Info, Module, ModuleName, Organization}
-import org.http4s.Uri
+import coursier.{Fetch, Module, ModuleName, Organization}
 import org.scalasteward.core.data.Resolver.Credentials
-import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
+import org.scalasteward.core.data.{Dependency, Resolver, Version}
 import org.scalasteward.core.util.uri
 import org.typelevel.log4cats.Logger
 
@@ -32,16 +31,9 @@ import org.typelevel.log4cats.Logger
   * metadata.
   */
 trait CoursierAlg[F[_]] {
-  def getArtifactUrl(dependency: Scope.Dependency): F[Option[Uri]]
+  def getMetadata(dependency: Dependency, resolvers: List[Resolver]): F[Option[DependencyMetadata]]
 
   def getVersions(dependency: Dependency, resolver: Resolver): F[List[Version]]
-
-  final def getArtifactIdUrlMapping(dependencies: Scope.Dependencies)(implicit
-      F: Applicative[F]
-  ): F[Map[String, Uri]] =
-    dependencies.sequence
-      .traverseFilter(dep => getArtifactUrl(dep).map(_.map(dep.value.artifactId.name -> _)))
-      .map(_.toMap)
 }
 
 object CoursierAlg {
@@ -50,64 +42,72 @@ object CoursierAlg {
       parallel: Parallel[F],
       F: Sync[F]
   ): CoursierAlg[F] = {
-    val fetch: Fetch[F] = Fetch[F](FileCache[F]())
+    val fetch: Fetch[F] =
+      Fetch[F](FileCache[F]())
 
     val cacheNoTtl: FileCache[F] =
       FileCache[F]().withTtl(None).withCachePolicies(List(CachePolicy.Update))
 
     new CoursierAlg[F] {
-      override def getArtifactUrl(dependency: Scope.Dependency): F[Option[Uri]] =
-        convertToCoursierTypes(dependency).flatMap((getArtifactUrlImpl _).tupled)
+      override def getMetadata(
+          dependency: Dependency,
+          resolvers: List[Resolver]
+      ): F[Option[DependencyMetadata]] =
+        resolvers.traverseFilter(convertResolver(_).attempt.map(_.toOption)).flatMap {
+          repositories =>
+            val csrDependency = toCoursierDependency(dependency)
+            getMetadataImpl(csrDependency, repositories, None)
+        }
 
-      private def getArtifactUrlImpl(
+      private def getMetadataImpl(
           dependency: coursier.Dependency,
-          repositories: List[coursier.Repository]
-      ): F[Option[Uri]] = {
+          repositories: List[coursier.Repository],
+          acc: Option[DependencyMetadata]
+      ): F[Option[DependencyMetadata]] = {
         val fetchArtifacts = fetch
           .withArtifactTypes(Set(coursier.Type.pom, coursier.Type.ivy))
           .withDependencies(List(dependency))
           .withRepositories(repositories)
+
         fetchArtifacts.ioResult.attempt.flatMap {
           case Left(throwable) =>
-            logger.debug(throwable)(s"Failed to fetch artifacts of $dependency").as(None)
+            logger.debug(throwable)(s"Failed to fetch artifacts of $dependency").as(acc)
           case Right(result) =>
             val maybeProject = result.resolution.projectCache
               .get(dependency.moduleVersion)
               .map { case (_, project) => project }
             maybeProject.traverseFilter { project =>
-              getScmUrlOrHomePage(project.info) match {
-                case Some(url) => F.pure(Some(url))
-                case None =>
-                  getParentDependency(project).traverseFilter(getArtifactUrlImpl(_, repositories))
+              val metadata = {
+                val current = metadataFrom(project)
+                acc.fold(current)(_.enrichWith(current))
               }
+              if (metadata.homePage.isEmpty || metadata.scmUrl.isEmpty) {
+                parentOf(project) match {
+                  case Some(parent) => getMetadataImpl(parent, repositories, Some(metadata))
+                  case None         => F.pure(Some(metadata))
+                }
+              } else F.pure(Some(metadata))
             }
         }
       }
 
       override def getVersions(dependency: Dependency, resolver: Resolver): F[List[Version]] =
+        convertResolver(resolver).flatMap { repository =>
+          val module = toCoursierModule(dependency)
+          repository.versions(module, cacheNoTtl.fetch).run.flatMap {
+            case Left(message) =>
+              logger.debug(message) >> F.raiseError[List[Version]](new Throwable(message))
+            case Right((versions, _)) =>
+              F.pure(versions.available.map(Version.apply).sorted)
+          }
+        }
+
+      private def convertResolver(resolver: Resolver): F[coursier.Repository] =
         toCoursierRepository(resolver) match {
+          case Right(repository) => F.pure(repository)
           case Left(message) =>
-            logger.error(message) >> F.raiseError(new Throwable(message))
-          case Right(repository) =>
-            val module = toCoursierModule(dependency)
-            repository.versions(module, cacheNoTtl.fetch).run.flatMap {
-              case Left(message) =>
-                logger.debug(message) >> F.raiseError(new Throwable(message))
-              case Right((versions, _)) => F.pure(versions.available.map(Version.apply).sorted)
-            }
-        }
-
-      private def convertToCoursierTypes(
-          dependency: Scope.Dependency
-      ): F[(coursier.Dependency, List[coursier.Repository])] =
-        dependency.resolvers.traverseFilter(convertResolver).map { repositories =>
-          (toCoursierDependency(dependency.value), repositories)
-        }
-
-      private def convertResolver(resolver: Resolver): F[Option[coursier.Repository]] =
-        toCoursierRepository(resolver) match {
-          case Right(repository) => F.pure(Some(repository))
-          case Left(message)     => logger.error(s"Failed to convert $resolver: $message").as(None)
+            logger.error(s"Failed to convert $resolver: $message") >>
+              F.raiseError[coursier.Repository](new Throwable(message))
         }
     }
   }
@@ -127,40 +127,40 @@ object CoursierAlg {
   private def toCoursierRepository(resolver: Resolver): Either[String, coursier.Repository] =
     resolver match {
       case Resolver.MavenRepository(_, location, creds, headers) =>
-        Right(
-          coursier.maven.MavenRepository
-            .apply(location, toCoursierAuthentication(creds, headers))
-        )
+        val authentication = toCoursierAuthentication(creds, headers)
+        Right(coursier.maven.MavenRepository.apply(location, authentication))
       case Resolver.IvyRepository(_, pattern, creds, headers) =>
-        coursier.ivy.IvyRepository
-          .parse(pattern, authentication = toCoursierAuthentication(creds, headers))
+        val authentication = toCoursierAuthentication(creds, headers)
+        coursier.ivy.IvyRepository.parse(pattern, authentication = authentication)
     }
 
   private def toCoursierAuthentication(
       credentials: Option[Credentials],
       headers: List[Resolver.Header]
   ): Option[Authentication] =
-    if (credentials.isEmpty && headers.isEmpty) {
-      None
-    } else {
-      Some(
-        new Authentication(
-          credentials.fold("")(_.user),
-          credentials.map(_.pass),
-          headers.map(h => (h.key, h.value)),
-          optional = false,
-          None,
-          httpsOnly = true,
-          passOnRedirect = false
-        )
+    Option.when(credentials.nonEmpty || headers.nonEmpty) {
+      new Authentication(
+        credentials.fold("")(_.user),
+        credentials.map(_.pass),
+        headers.map(h => (h.key, h.value)),
+        optional = false,
+        realmOpt = None,
+        httpsOnly = true,
+        passOnRedirect = false
       )
     }
 
-  private def getParentDependency(project: Project): Option[coursier.Dependency] =
+  private def metadataFrom(project: Project): DependencyMetadata =
+    DependencyMetadata(
+      homePage = uri.fromStringWithScheme(project.info.homePage),
+      scmUrl = project.info.scm.flatMap(_.url).flatMap(uri.fromStringWithScheme),
+      releaseNotesUrl = project.properties
+        .collectFirst { case ("releaseNotesUrl", value) => value }
+        .flatMap(uri.fromStringWithScheme)
+    )
+
+  private def parentOf(project: Project): Option[coursier.Dependency] =
     project.parent.map { case (module, version) =>
       coursier.Dependency(module, version).withTransitive(false)
     }
-
-  private def getScmUrlOrHomePage(info: Info): Option[Uri] =
-    uri.findBrowsableUrl(info.scm.flatMap(_.url).toList :+ info.homePage)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.coursier
+
+import cats.Monad
+import cats.syntax.all._
+import org.http4s.Uri
+import org.scalasteward.core.util.uri
+
+final case class DependencyMetadata(
+    homePage: Option[Uri],
+    scmUrl: Option[Uri],
+    releaseNotesUrl: Option[Uri]
+) {
+  def enrichWith(other: DependencyMetadata): DependencyMetadata =
+    DependencyMetadata(
+      homePage = homePage.orElse(other.homePage),
+      scmUrl = scmUrl.orElse(other.scmUrl),
+      releaseNotesUrl = releaseNotesUrl.orElse(other.releaseNotesUrl)
+    )
+
+  def filterUrls[F[_]](f: Uri => F[Boolean])(implicit F: Monad[F]): F[DependencyMetadata] =
+    for {
+      homePage <- homePage.filterA(f)
+      scmUrl <- scmUrl.filterA(f)
+      releaseNotesUrl <- releaseNotesUrl.filterA(f)
+    } yield DependencyMetadata(homePage, scmUrl, releaseNotesUrl)
+
+  def repoUrl: Option[Uri] = {
+    val urls = scmUrl.toList ++ homePage.toList
+    urls.find(_.scheme.exists(uri.httpSchemes)).orElse(urls.headOption)
+  }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
@@ -41,11 +41,9 @@ object uri {
   val withUserInfo: Optional[Uri, UserInfo] =
     authorityWithUserInfo.compose(withAuthority)
 
-  private val httpSchemes: Set[Scheme] =
-    Set(Scheme.https, Scheme.http)
+  def fromStringWithScheme(s: String): Option[Uri] =
+    Uri.fromString(s).toOption.filter(_.scheme.isDefined)
 
-  def findBrowsableUrl(xs: List[String]): Option[Uri] = {
-    val urls = xs.flatMap(Uri.fromString(_).toList).filter(_.scheme.isDefined)
-    urls.find(_.scheme.exists(httpSchemes)).orElse(urls.headOption)
-  }
+  val httpSchemes: Set[Scheme] =
+    Set(Scheme.https, Scheme.http)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -27,6 +27,7 @@ import org.scalasteward.core.vcs
 trait VCSExtraAlg[F[_]] {
   def getReleaseRelatedUrls(
       repoUrl: Uri,
+      releaseNotesUrl: Option[Uri],
       currentVersion: Version,
       nextVersion: Version
   ): F[List[ReleaseRelatedUrl]]
@@ -40,17 +41,18 @@ object VCSExtraAlg {
     new VCSExtraAlg[F] {
       override def getReleaseRelatedUrls(
           repoUrl: Uri,
+          releaseNotesUrl: Option[Uri],
           currentVersion: Version,
           nextVersion: Version
       ): F[List[ReleaseRelatedUrl]] =
-        vcs
-          .possibleReleaseRelatedUrls(
+        (releaseNotesUrl.toList.map(ReleaseRelatedUrl.CustomReleaseNotes.apply) ++
+          vcs.possibleReleaseRelatedUrls(
             config.tpe,
             config.apiHost,
             repoUrl,
             currentVersion,
             nextVersion
-          )
+          ))
           .filterA(releaseRelatedUrl => urlChecker.exists(releaseRelatedUrl.url))
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -5,19 +5,17 @@ import org.scalasteward.core.data._
 import org.scalasteward.core.util.Nel
 
 object TestSyntax {
+  val sbtPluginReleases: IvyRepository =
+    IvyRepository(
+      "sbt-plugin-releases",
+      "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/[defaultPattern]",
+      None,
+      Nil
+    )
+
   implicit class GenericOps[A](val self: A) extends AnyVal {
     def withMavenCentral: Scope[A] =
       Scope(self, List(Resolver.mavenCentral))
-
-    def withSbtPluginReleases: Scope[A] = {
-      val sbtPluginReleases = IvyRepository(
-        "sbt-plugin-releases",
-        "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/[defaultPattern]",
-        None,
-        Nil
-      )
-      Scope(self, List(sbtPluginReleases))
-    }
   }
 
   implicit class StringOps(private val self: String) extends AnyVal {

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -4,88 +4,100 @@ import munit.CatsEffectSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
+import org.scalasteward.core.data.Resolver
 import org.scalasteward.core.mock.MockContext.context.coursierAlg
 import org.scalasteward.core.mock.MockState
 
 class CoursierAlgTest extends CatsEffectSuite {
-  test("getArtifactUrl: library") {
+  private val resolvers = List(Resolver.mavenCentral)
+
+  private val emptyMetadata = DependencyMetadata(None, None, None)
+
+  test("getMetadata: with homePage and scmUrl") {
     val dep = "org.typelevel".g % ("cats-effect", "cats-effect_2.12").a % "1.0.0"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://github.com/typelevel/cats-effect"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(
+      emptyMetadata.copy(
+        homePage = Some(uri"https://typelevel.org/cats-effect/"),
+        scmUrl = Some(uri"https://github.com/typelevel/cats-effect")
+      )
+    )
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: defaults to homepage") {
+  test("getMetadata: homePage only") {
     val artifactId = ("play-ws-standalone-json", "play-ws-standalone-json_2.12").a
     val dep = "com.typesafe.play".g % artifactId % "2.1.0-M7"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://github.com/playframework/play-ws"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected =
+      Some(emptyMetadata.copy(homePage = Some(uri"https://github.com/playframework/play-ws")))
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: URL with no or invalid scheme 1") {
+  test("getMetadata: scmUrl without scheme") {
     val dep = "org.msgpack".g % "msgpack-core".a % "0.8.20"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"http://msgpack.org/"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(emptyMetadata.copy(homePage = Some(uri"http://msgpack.org/")))
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: URL with no or invalid scheme 2") {
+  test("getMetadata: scmUrl with git scheme") {
     val dep = "org.xhtmlrenderer".g % "flying-saucer-parent".a % "9.0.1"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"http://code.google.com/p/flying-saucer/"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(
+      emptyMetadata.copy(
+        homePage = Some(uri"http://code.google.com/p/flying-saucer/"),
+        scmUrl = Some(uri"git://github.com/flyingsaucerproject/flyingsaucer.git")
+      )
+    )
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: from parent") {
+  test("getMetadata: homePage from parent") {
     val dep = "net.bytebuddy".g % "byte-buddy".a % "1.10.5"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://bytebuddy.net"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(emptyMetadata.copy(homePage = Some(uri"https://bytebuddy.net")))
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: minimal pom") {
+  test("getMetadata: minimal POM") {
     val dep = "altrmi".g % "altrmi-common".a % "0.9.6"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, None)
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(emptyMetadata)
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: sbt plugin on Maven Central") {
+  test("getMetadata: sbt plugin on Maven Central") {
     val dep = ("org.xerial.sbt".g % "sbt-sonatype".a % "3.8")
       .copy(sbtVersion = Some(SbtVersion("1.0")), scalaVersion = Some(ScalaVersion("2.12")))
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://github.com/xerial/sbt-sonatype"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(
+      emptyMetadata.copy(
+        homePage = Some(uri"https://github.com/xerial/sbt-sonatype"),
+        scmUrl = Some(uri"https://github.com/xerial/sbt-sonatype")
+      )
+    )
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: sbt plugin on sbt-plugin-releases") {
+  test("getMetadata: sbt plugin on sbt-plugin-releases") {
     val dep = ("com.github.gseitz".g % "sbt-release".a % "1.0.12")
       .copy(sbtVersion = Some(SbtVersion("1.0")), scalaVersion = Some(ScalaVersion("2.12")))
-    coursierAlg.getArtifactUrl(dep.withSbtPluginReleases).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://github.com/sbt/sbt-release"))
-    }
+    val obtained = coursierAlg.getMetadata(dep, List(sbtPluginReleases)).runA(MockState.empty)
+    val expected =
+      Some(emptyMetadata.copy(homePage = Some(uri"https://github.com/sbt/sbt-release")))
+    assertIO(obtained, expected)
   }
 
-  test("getArtifactUrl: invalid scm URL but valid homepage") {
+  test("getMetadata: scmUrl with github scheme") {
     val dep = "com.github.japgolly.scalajs-react".g % ("core", "core_sjs1_2.13").a % "2.0.0-RC5"
-    coursierAlg.getArtifactUrl(dep.withMavenCentral).runA(MockState.empty).map { obtained =>
-      assertEquals(obtained, Some(uri"https://github.com/japgolly/scalajs-react"))
-    }
-  }
-
-  test("getArtifactIdUrlMapping") {
-    val deps = List(
-      "org.typelevel".g % ("cats-core", "cats-core_2.12").a % "1.6.0",
-      "org.typelevel".g % ("cats-effect", "cats-effect_2.12").a % "1.0.0"
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = Some(
+      emptyMetadata.copy(
+        homePage = Some(uri"https://github.com/japgolly/scalajs-react"),
+        scmUrl = Some(uri"github.com:japgolly/scalajs-react.git")
+      )
     )
-    coursierAlg.getArtifactIdUrlMapping(deps.withMavenCentral).runA(MockState.empty).map {
-      obtained =>
-        val expected = Map(
-          "cats-core" -> uri"https://github.com/typelevel/cats",
-          "cats-effect" -> uri"https://github.com/typelevel/cats-effect"
-        )
-        assertEquals(obtained, expected)
-    }
+    assertIO(obtained, expected)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -11,6 +11,7 @@ import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.VCSCfg
 import org.scalasteward.core.data.ReleaseRelatedUrl
+import org.scalasteward.core.data.ReleaseRelatedUrl.CustomReleaseNotes
 import org.scalasteward.core.mock.MockConfig
 import org.scalasteward.core.util._
 
@@ -19,6 +20,7 @@ class VCSExtraAlgTest extends FunSuite {
     HttpRoutes.of[IO] {
       case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
       case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
+      case HEAD -> Root / "foo" / "buz" / "README.md"                   => Ok("exist")
       case _                                                            => NotFound()
     }
 
@@ -38,6 +40,7 @@ class VCSExtraAlgTest extends FunSuite {
       vcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.com/foo/foo",
+          releaseNotesUrl = None,
           currentVersion = updateFoo.currentVersion,
           nextVersion = updateFoo.nextVersion
         )
@@ -49,6 +52,7 @@ class VCSExtraAlgTest extends FunSuite {
       vcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.com/foo/bar",
+          releaseNotesUrl = None,
           currentVersion = updateBar.currentVersion,
           nextVersion = updateBar.nextVersion
         )
@@ -62,11 +66,24 @@ class VCSExtraAlgTest extends FunSuite {
       vcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.com/foo/buz",
+          releaseNotesUrl = None,
           currentVersion = updateBuz.currentVersion,
           nextVersion = updateBuz.nextVersion
         )
         .unsafeRunSync(),
       List.empty
+    )
+
+    assertEquals(
+      vcsExtraAlg
+        .getReleaseRelatedUrls(
+          repoUrl = uri"https://github.com/foo/buz",
+          releaseNotesUrl = Some(uri"https://github.com/foo/buz/README.md#changelog"),
+          currentVersion = updateBuz.currentVersion,
+          nextVersion = updateBuz.nextVersion
+        )
+        .unsafeRunSync(),
+      List(CustomReleaseNotes(uri"https://github.com/foo/buz/README.md#changelog"))
     )
   }
 
@@ -84,6 +101,7 @@ class VCSExtraAlgTest extends FunSuite {
       githubOnPremVcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.on-prem.com/foo/foo",
+          releaseNotesUrl = None,
           currentVersion = updateFoo.currentVersion,
           nextVersion = updateFoo.nextVersion
         )
@@ -95,6 +113,7 @@ class VCSExtraAlgTest extends FunSuite {
       githubOnPremVcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.on-prem.com/foo/bar",
+          releaseNotesUrl = None,
           currentVersion = updateBar.currentVersion,
           nextVersion = updateBar.nextVersion
         )
@@ -110,6 +129,7 @@ class VCSExtraAlgTest extends FunSuite {
       githubOnPremVcsExtraAlg
         .getReleaseRelatedUrls(
           repoUrl = uri"https://github.on-prem.com/foo/buz",
+          releaseNotesUrl = None,
           currentVersion = updateFoo.currentVersion,
           nextVersion = updateFoo.nextVersion
         )


### PR DESCRIPTION
This PR shows a release notes URL from the POM in the body of PRs.

Currently, Scala Steward uses the [project.scm.url](https://maven.apache.org/pom.html#scm) or [project.url](https://maven.apache.org/pom.html#More_Project_Information) and tries to find release notes / change logs / version diffs from these URLs by constructing common URLs and checking if they exist. These are then added to the PRs.

With this change, Scala Steward also reads a release notes URL from a [`project.properties.releaseNotesUrl`](https://maven.apache.org/pom.html#Properties) element in the POM and shows it in the PR body. It allows library maintainers to have their release notes anywhere they want them to be and still have Scala Steward show them in PRs. Note that I just made up the name `releaseNotesUrl` for this feature.

This has been partly motivated by https://github.com/com-lihaoyi/requests-scala/pull/122. The changes in `CoursierAlg` also allow to extract more metadata in the future to maybe implement the idea @lefou mentioned in https://github.com/scala-steward-org/scala-steward/issues/2708#issuecomment-1240653195.

/ping @ckipp01 and @lefou since I mentioned this the other day on [Discord](https://discord.com/channels/632150470000902164/940067748103487558/1056877426929573909).

Open questions:
 - Is there prior art of adding release notes or changelog URLs to the POM? Maybe we can reuse some convention of adding URLs to the POM that other projects already use.
 - If not, is it okay to use `releaseNotesUrl` or should the element name be prefixed with `scalasteward.` or something like that?