### PR TITLE
Optimize regexes in VersionPositionScanner

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
@@ -1,0 +1,33 @@
+package org.scalasteward.benchmark
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import org.scalasteward.core.data.Version
+import org.scalasteward.core.edit.update.VersionPositionScanner
+import org.scalasteward.core.io.FileData
+
+@BenchmarkMode(Array(Mode.AverageTime))
+class VersionPositionScannerBenchmark {
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def findPositionsBench(myState: MyState): Any =
+    VersionPositionScanner.findPositions(Version("1.0.0"), myState.fileData)
+}
+
+@State(Scope.Benchmark)
+class MyState {
+  val fileData: FileData =
+    FileData(
+      "",
+      """ val name: String = "foo"
+        | val version: String = "1.0.0"
+        | "groupId:artifactId:1.0.0"
+        | 1.0.0
+        | "foo" % "bar" % "1.0.0"
+        | "foo-bar-baz" :
+        | "" : "1.0.0"
+        |  // val version = "1.0.0"
+        |""".stripMargin
+    )
+}

--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2022 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalasteward.benchmark
 
 import java.util.concurrent.TimeUnit

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/VersionPositionScanner.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/VersionPositionScanner.scala
@@ -44,8 +44,9 @@ object VersionPositionScanner {
     }
 
   private def sbtModuleIdRegex(version: Version): Regex = {
+    val ident = """[^\s]+"""
     val v = Regex.quote(version.value)
-    raw"""(.*)"(.*)"\s*%+\s*"(.*)"\s*%+\s*"$v"""".r
+    raw"""(.*)"($ident)"\s*%+\s*"($ident)"\s*%+\s*"$v"""".r
   }
 
   private def findMillDependency(version: Version, fileData: FileData): Iterator[MillDependency] =
@@ -58,7 +59,7 @@ object VersionPositionScanner {
     }
 
   private def millDependencyRegex(version: Version): Regex = {
-    val ident = """[^:]*"""
+    val ident = """[^:\s]+"""
     val v = Regex.quote(version.value)
     raw"""(.*)["`]($ident):+($ident):+$v["`;]""".r
   }
@@ -72,7 +73,7 @@ object VersionPositionScanner {
     }
 
   private def mavenDependencyRegex(version: Version): Regex = {
-    val ident = """[^<]*"""
+    val ident = """[^<]+"""
     val v = Regex.quote(version.value)
     raw"""<groupId>($ident)</groupId>\s*<artifactId>($ident)</artifactId>\s*<version>$v</version>""".r
   }


### PR DESCRIPTION
I played with using `VersionPositionScanner` instead of `GitAlg#findFilesContaining` in `RepoCacheAlg` and noticed that the regex used in `findMillDependency` is quite slow since it allows whitespace (including newlines) in the groupId and artifactId identifiers.

This change disallows whitespace in those identifiers and requires that they are not empty. It increases performance significantly even with the toy example in the added benchmark.