### PR TITLE
Fuse stream transformations in `FileAlg#findFiles`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,8 @@ lazy val commonSettings = Def.settings(
 
 lazy val compileSettings = Def.settings(
   scalaVersion := Scala213,
+  // Uncomment for local development:
+  // scalacOptions -= "-Xfatal-warnings",
   doctestTestFramework := DoctestTestFramework.Munit
 )
 


### PR DESCRIPTION
This fuses the `evalFilter(...).evalMapFilter(...)` calls in `FileAlg#findFiles`. In my experiments this resulted in a 5-10% performance improvement.