### PR TITLE
Add more validation to vcs specific arguments

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -117,7 +117,14 @@ object Cli {
     ).orFalse
 
   private val vcsCfg: Opts[VCSCfg] =
-    (vcsType, vcsApiHost, vcsLogin, doNotFork, addPrLabels).mapN(VCSCfg.apply)
+    (vcsType, vcsApiHost, vcsLogin, doNotFork, addPrLabels)
+      .mapN(VCSCfg.apply)
+      .validate(
+        s"${VCSType.allNot(_.supportsForking)} do not support fork mode"
+      )(cfg => cfg.tpe.supportsForking || cfg.doNotFork)
+      .validate(
+        s"${VCSType.allNot(_.supportsLabels)} do not support pull request labels"
+      )(cfg => cfg.tpe.supportsLabels || !cfg.addLabels)
 
   private val ignoreOptsFiles: Opts[Boolean] =
     flag(

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSType.scala
@@ -24,6 +24,8 @@ import org.scalasteward.core.vcs.VCSType._
 
 sealed trait VCSType extends Product with Serializable {
   def publicWebHost: Option[String]
+  def supportsForking: Boolean = true
+  def supportsLabels: Boolean = true
 
   val asString: String = this match {
     case AzureRepos      => "azure-repos"
@@ -37,15 +39,19 @@ sealed trait VCSType extends Product with Serializable {
 object VCSType {
   case object AzureRepos extends VCSType {
     override val publicWebHost: Option[String] = Some("dev.azure.com")
+    override def supportsForking: Boolean = false
   }
 
   case object Bitbucket extends VCSType {
     override val publicWebHost: Some[String] = Some("bitbucket.org")
+    override def supportsLabels: Boolean = false
     val publicApiBaseUrl = uri"https://api.bitbucket.org/2.0"
   }
 
   case object BitbucketServer extends VCSType {
     override val publicWebHost: None.type = None
+    override def supportsForking: Boolean = false
+    override def supportsLabels: Boolean = false
   }
 
   case object GitHub extends VCSType {
@@ -59,6 +65,9 @@ object VCSType {
   }
 
   val all = List(AzureRepos, Bitbucket, BitbucketServer, GitHub, GitLab)
+
+  def allNot(f: VCSType => Boolean): String =
+    VCSType.all.filterNot(f).map(_.asString).mkString(", ")
 
   def parse(s: String): Either[String, VCSType] =
     all.find(_.asString === s) match {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -183,6 +183,42 @@ class CliTest extends FunSuite {
     assertEquals(file, File("file.conf"))
   }
 
+  test("parseArgs: validate fork mode disabled") {
+    val params = minimumRequiredParams ++ List(
+      List("--vcs-type", "azure-repos"),
+      List("--do-not-fork")
+    )
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    assert(obtained.vcsCfg.doNotFork)
+  }
+
+  test("parseArgs: validate fork mode enabled") {
+    val params = minimumRequiredParams ++ List(
+      List("--vcs-type", "azure-repos")
+    )
+    val Error(errorMsg) = Cli.parseArgs(params.flatten)
+    assert(clue(errorMsg).startsWith("azure-repos, bitbucket-server do not support fork mode"))
+  }
+
+  test("parseArgs: validate pull request labeling disabled") {
+    val params = minimumRequiredParams ++ List(
+      List("--vcs-type", "bitbucket")
+    )
+    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    assert(!obtained.vcsCfg.addLabels)
+  }
+
+  test("parseArgs: validate pull request labeling enabled") {
+    val params = minimumRequiredParams ++ List(
+      List("--vcs-type", "bitbucket"),
+      List("--add-labels")
+    )
+    val Error(errorMsg) = Cli.parseArgs(params.flatten)
+    assert(
+      clue(errorMsg).startsWith("bitbucket, bitbucket-server do not support pull request labels")
+    )
+  }
+
   test("envVarArgument: env-var without equals sign") {
     assert(clue(Cli.envVarArgument.read("SBT_OPTS")).isInvalid)
   }


### PR DESCRIPTION
* ensure that `--do-not-fork` is given for azure-repos and bitbucket-server
* ensure that `--add-labels` is not given for bitbucket and bitbucket-server