### PR TITLE
Add pre-determined HTTP responses to `MockState`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -77,6 +77,8 @@ final class Context[F[_]](implicit
     val scalafmtAlg: ScalafmtAlg[F],
     val stewardAlg: StewardAlg[F],
     val updateAlg: UpdateAlg[F],
+    val urlChecker: UrlChecker[F],
+    val vcsExtraAlg: VCSExtraAlg[F],
     val vcsRepoAlg: VCSRepoAlg[F],
     val workspaceAlg: WorkspaceAlg[F]
 )

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,8 +1,9 @@
 package org.scalasteward.core.mock
 
 import better.files.File
+import cats.data.Kleisli
+import cats.effect.kernel.Resource
 import cats.effect.unsafe.implicits.global
-import org.http4s.HttpApp
 import org.http4s.client.Client
 import org.scalasteward.core.application.Context
 import org.scalasteward.core.application.Context.StewardContext
@@ -16,7 +17,19 @@ import org.scalasteward.core.util.UrlCheckerClient
 import org.typelevel.log4cats.Logger
 
 object MockContext {
-  implicit private val client: Client[MockEff] = Client.fromHttpApp(HttpApp.notFound)
+  implicit private val client: Client[MockEff] =
+    Client[MockEff] { mockRequest =>
+      Resource.eval {
+        Kleisli { mockCtx =>
+          mockCtx.get.flatMap { mockState =>
+            val ioRequest = mockRequest.mapK(mockEffToIo(mockCtx))
+            val ioResponse = mockState.clientResponses.run(ioRequest)
+            ioResponse.map(_.mapK(ioToMockEff))
+          }
+        }
+      }
+    }
+
   implicit private val urlCheckerClient: UrlCheckerClient[MockEff] = UrlCheckerClient(client)
   implicit private val fileAlg: FileAlg[MockEff] = new MockFileAlg
   implicit private val logger: Logger[MockEff] = new MockLogger

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -18,13 +18,11 @@ import org.typelevel.log4cats.Logger
 
 object MockContext {
   implicit private val client: Client[MockEff] =
-    Client[MockEff] { mockRequest =>
+    Client[MockEff] { request =>
       Resource.eval {
         Kleisli { mockCtx =>
           mockCtx.get.flatMap { mockState =>
-            val ioRequest = mockRequest.mapK(mockEffToIo(mockCtx))
-            val ioResponse = mockState.clientResponses.run(ioRequest)
-            ioResponse.map(_.mapK(ioToMockEff))
+            mockState.clientResponses.run(request).run(mockCtx)
           }
         }
       }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -13,7 +13,7 @@ final case class MockState(
     commandOutputs: Map[List[String], List[String]],
     files: Map[File, String],
     uris: Map[Uri, String],
-    clientResponses: HttpApp[IO]
+    clientResponses: HttpApp[MockEff]
 ) {
   def addFiles(newFiles: (File, String)*): IO[MockState] =
     newFiles.toList

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.mock
 import better.files.File
 import cats.effect.{IO, Ref}
 import cats.syntax.all._
-import org.http4s.Uri
+import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
@@ -12,7 +12,8 @@ final case class MockState(
     trace: Vector[TraceEntry],
     commandOutputs: Map[List[String], List[String]],
     files: Map[File, String],
-    uris: Map[Uri, String]
+    uris: Map[Uri, String],
+    clientResponses: HttpApp[IO]
 ) {
   def addFiles(newFiles: (File, String)*): IO[MockState] =
     newFiles.toList
@@ -41,7 +42,8 @@ object MockState {
       trace = Vector.empty,
       commandOutputs = Map.empty,
       files = Map.empty,
-      uris = Map.empty
+      uris = Map.empty,
+      clientResponses = HttpApp.notFound
     )
 
   sealed trait TraceEntry extends Product with Serializable

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -14,10 +14,6 @@ package object mock {
     override def apply[A](fa: IO[A]): MockEff[A] = Kleisli(_ => fa)
   }
 
-  def mockEffToIo(ctx: MockCtx): ~>[MockEff, IO] = new ~>[MockEff, IO] {
-    override def apply[A](fa: MockEff[A]): IO[A] = fa.run(ctx)
-  }
-
   implicit class MockEffOps[A](private val fa: MockEff[A]) extends AnyVal {
     def runA(state: MockState): IO[A] =
       state.toRef.flatMap(fa.run)
@@ -29,6 +25,6 @@ package object mock {
       state.toRef.flatMap(ref => fa.run(ref).flatMap(a => ref.get.map(s => (s, a))))
   }
 
-  def getFlatMapSet[F[_], A, B](f: A => F[A])(ref: Ref[F, A])(implicit F: FlatMap[F]): F[Unit] =
+  def getFlatMapSet[F[_], A](f: A => F[A])(ref: Ref[F, A])(implicit F: FlatMap[F]): F[Unit] =
     ref.get.flatMap(f).flatMap(ref.set)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -14,6 +14,10 @@ package object mock {
     override def apply[A](fa: IO[A]): MockEff[A] = Kleisli(_ => fa)
   }
 
+  def mockEffToIo(ctx: MockCtx): ~>[MockEff, IO] = new ~>[MockEff, IO] {
+    override def apply[A](fa: MockEff[A]): IO[A] = fa.run(ctx)
+  }
+
   implicit class MockEffOps[A](private val fa: MockEff[A]) extends AnyVal {
     def runA(state: MockState): IO[A] =
       state.toRef.flatMap(fa.run)

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -3,118 +3,82 @@ package org.scalasteward.core.vcs
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.http4s.HttpRoutes
-import org.http4s.client.Client
+import org.http4s.HttpApp
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.scalasteward.core.TestInstances.ioLogger
-import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.VCSCfg
-import org.scalasteward.core.data.ReleaseRelatedUrl
-import org.scalasteward.core.mock.MockConfig
-import org.scalasteward.core.util._
+import org.scalasteward.core.data.ReleaseRelatedUrl._
+import org.scalasteward.core.data.Version
+import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.{MockEff, MockState}
 
 class VCSExtraAlgTest extends FunSuite {
-  val routes: HttpRoutes[IO] =
-    HttpRoutes.of[IO] {
-      case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
-      case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
-      case _                                                            => NotFound()
-    }
+  private val state = MockState.empty.copy(clientResponses = HttpApp[IO] {
+    case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
+    case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
+    case _                                                            => NotFound()
+  })
 
-  implicit val client: UrlCheckerClient[IO] =
-    UrlCheckerClient[IO](Client.fromHttpApp[IO](routes.orNotFound))
-  implicit val urlChecker: UrlChecker[IO] =
-    UrlChecker.create[IO](MockConfig.config).unsafeRunSync()
+  private val v1 = Version("0.1.0")
+  private val v2 = Version("0.2.0")
 
-  private val updateFoo = ("com.example".g % "foo".a % "0.1.0" %> "0.2.0").single
-  private val updateBar = ("com.example".g % "bar".a % "0.1.0" %> "0.2.0").single
-  private val updateBuz = ("com.example".g % "buz".a % "0.1.0" %> "0.2.0").single
-
-  test("getBranchCompareUrl: std vsc") {
-    val vcsExtraAlg = VCSExtraAlg.create[IO](MockConfig.config.vcsCfg)
-
-    assertEquals(
-      vcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.com/foo/foo",
-          currentVersion = updateFoo.currentVersion,
-          nextVersion = updateFoo.nextVersion
-        )
-        .unsafeRunSync(),
-      List.empty
-    )
-
-    assertEquals(
-      vcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.com/foo/bar",
-          currentVersion = updateBar.currentVersion,
-          nextVersion = updateBar.nextVersion
-        )
-        .unsafeRunSync(),
-      List(
-        ReleaseRelatedUrl.VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
-      )
-    )
-
-    assertEquals(
-      vcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.com/foo/buz",
-          currentVersion = updateBuz.currentVersion,
-          nextVersion = updateBuz.nextVersion
-        )
-        .unsafeRunSync(),
-      List.empty
-    )
+  test("getReleaseRelatedUrls: repoUrl not found") {
+    val obtained = vcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.com/foo/foo", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    assertEquals(obtained, List.empty)
   }
 
-  test("getBranchCompareUrl: github on prem") {
-    val config = VCSCfg(
-      VCSType.GitHub,
-      uri"https://github.on-prem.com/",
-      "",
-      doNotFork = false,
-      addLabels = false
-    )
-    val githubOnPremVcsExtraAlg = VCSExtraAlg.create[IO](config)
+  test("getReleaseRelatedUrls: repoUrl ok") {
+    val obtained = vcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.com/foo/bar", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    val expected = List(VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0"))
+    assertEquals(obtained, expected)
+  }
 
-    assertEquals(
-      githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.on-prem.com/foo/foo",
-          currentVersion = updateFoo.currentVersion,
-          nextVersion = updateFoo.nextVersion
-        )
-        .unsafeRunSync(),
-      List.empty
-    )
+  test("getReleaseRelatedUrls: repoUrl permanent redirect") {
+    val obtained = vcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.com/foo/buz", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    assertEquals(obtained, List.empty)
+  }
 
-    assertEquals(
-      githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.on-prem.com/foo/bar",
-          currentVersion = updateBar.currentVersion,
-          nextVersion = updateBar.nextVersion
-        )
-        .unsafeRunSync(),
-      List(
-        ReleaseRelatedUrl.VersionDiff(
-          uri"https://github.on-prem.com/foo/bar/compare/v0.1.0...v0.2.0"
-        )
-      )
-    )
+  private val config = VCSCfg(
+    VCSType.GitHub,
+    uri"https://github.on-prem.com/",
+    "",
+    doNotFork = false,
+    addLabels = false
+  )
+  private val githubOnPremVcsExtraAlg = VCSExtraAlg.create[MockEff](config)
 
-    assertEquals(
-      githubOnPremVcsExtraAlg
-        .getReleaseRelatedUrls(
-          repoUrl = uri"https://github.on-prem.com/foo/buz",
-          currentVersion = updateFoo.currentVersion,
-          nextVersion = updateFoo.nextVersion
-        )
-        .unsafeRunSync(),
-      List.empty
-    )
+  test("getReleaseRelatedUrls: on-prem, repoUrl not found") {
+    val obtained = githubOnPremVcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/foo", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    assertEquals(obtained, List.empty)
+  }
+
+  test("getReleaseRelatedUrls: on-prem, repoUrl ok") {
+    val obtained = githubOnPremVcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/bar", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    val expected =
+      List(VersionDiff(uri"https://github.on-prem.com/foo/bar/compare/v0.1.0...v0.2.0"))
+    assertEquals(obtained, expected)
+  }
+
+  test("getReleaseRelatedUrls: on-prem, repoUrl permanent redirect") {
+    val obtained = githubOnPremVcsExtraAlg
+      .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/buz", v1, v2)
+      .runA(state)
+      .unsafeRunSync()
+    assertEquals(obtained, List.empty)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -1,8 +1,7 @@
 package org.scalasteward.core.vcs
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import munit.FunSuite
+import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.dsl.io._
 import org.http4s.implicits._
@@ -12,7 +11,7 @@ import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.{MockEff, MockState}
 
-class VCSExtraAlgTest extends FunSuite {
+class VCSExtraAlgTest extends CatsEffectSuite {
   private val state = MockState.empty.copy(clientResponses = HttpApp[IO] {
     case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
     case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
@@ -23,28 +22,22 @@ class VCSExtraAlgTest extends FunSuite {
   private val v2 = Version("0.2.0")
 
   test("getReleaseRelatedUrls: repoUrl not found") {
-    val obtained = vcsExtraAlg
-      .getReleaseRelatedUrls(uri"https://github.com/foo/foo", v1, v2)
-      .runA(state)
-      .unsafeRunSync()
-    assertEquals(obtained, List.empty)
+    val obtained =
+      vcsExtraAlg.getReleaseRelatedUrls(uri"https://github.com/foo/foo", v1, v2).runA(state)
+    assertIO(obtained, List.empty)
   }
 
   test("getReleaseRelatedUrls: repoUrl ok") {
-    val obtained = vcsExtraAlg
-      .getReleaseRelatedUrls(uri"https://github.com/foo/bar", v1, v2)
-      .runA(state)
-      .unsafeRunSync()
+    val obtained =
+      vcsExtraAlg.getReleaseRelatedUrls(uri"https://github.com/foo/bar", v1, v2).runA(state)
     val expected = List(VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0"))
-    assertEquals(obtained, expected)
+    assertIO(obtained, expected)
   }
 
   test("getReleaseRelatedUrls: repoUrl permanent redirect") {
-    val obtained = vcsExtraAlg
-      .getReleaseRelatedUrls(uri"https://github.com/foo/buz", v1, v2)
-      .runA(state)
-      .unsafeRunSync()
-    assertEquals(obtained, List.empty)
+    val obtained =
+      vcsExtraAlg.getReleaseRelatedUrls(uri"https://github.com/foo/buz", v1, v2).runA(state)
+    assertIO(obtained, List.empty)
   }
 
   private val config = VCSCfg(
@@ -60,25 +53,22 @@ class VCSExtraAlgTest extends FunSuite {
     val obtained = githubOnPremVcsExtraAlg
       .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/foo", v1, v2)
       .runA(state)
-      .unsafeRunSync()
-    assertEquals(obtained, List.empty)
+    assertIO(obtained, List.empty)
   }
 
   test("getReleaseRelatedUrls: on-prem, repoUrl ok") {
     val obtained = githubOnPremVcsExtraAlg
       .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/bar", v1, v2)
       .runA(state)
-      .unsafeRunSync()
     val expected =
       List(VersionDiff(uri"https://github.on-prem.com/foo/bar/compare/v0.1.0...v0.2.0"))
-    assertEquals(obtained, expected)
+    assertIO(obtained, expected)
   }
 
   test("getReleaseRelatedUrls: on-prem, repoUrl permanent redirect") {
     val obtained = githubOnPremVcsExtraAlg
       .getReleaseRelatedUrls(uri"https://github.on-prem.com/foo/buz", v1, v2)
       .runA(state)
-      .unsafeRunSync()
-    assertEquals(obtained, List.empty)
+    assertIO(obtained, List.empty)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -1,9 +1,8 @@
 package org.scalasteward.core.vcs
 
-import cats.effect.IO
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
-import org.http4s.dsl.io._
+import org.http4s.dsl.Http4sDsl
 import org.http4s.implicits._
 import org.scalasteward.core.application.Config.VCSCfg
 import org.scalasteward.core.data.ReleaseRelatedUrl._
@@ -11,8 +10,8 @@ import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.{MockEff, MockState}
 
-class VCSExtraAlgTest extends CatsEffectSuite {
-  private val state = MockState.empty.copy(clientResponses = HttpApp[IO] {
+class VCSExtraAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
+  private val state = MockState.empty.copy(clientResponses = HttpApp {
     case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
     case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
     case _                                                            => NotFound()


### PR DESCRIPTION
This adds a `clientResponses: HttpApp[MockEff]` field to `MockState`. It is used by the http4s client in `MockContext` and allows to have different pre-determined responses in the different tests without constructing a new client in each test.

The changes in `VCSExtraAlgTest` demonstrate that this works.