### PR TITLE
Remove sbt-crossproject workaround

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -261,15 +261,6 @@ def myCrossProject(name: String): CrossProject =
       moduleRootPkg := s"$rootPkg.${name.replace('-', '.')}"
     )
     .settings(commonSettings)
-    // workaround for https://github.com/portable-scala/sbt-crossproject/issues/74
-    .settings(Seq(Compile, Test).flatMap(inConfig(_) {
-      unmanagedResourceDirectories ++= {
-        unmanagedSourceDirectories.value
-          .map(src => (src / ".." / "resources").getCanonicalFile)
-          .filterNot(unmanagedResourceDirectories.value.contains)
-          .distinct
-      }
-    }))
 
 ThisBuild / dynverSeparator := "-"
 


### PR DESCRIPTION
`unmanagedResourceDirectories` now contains the shared resource directory `modules/core/src/main/resources` without this workaround.