### PR TITLE
Log the update when scala-steward is unable to bump a version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -51,7 +51,7 @@ final class EditAlg[F[_]](implicit
       preCommit: F[Unit] = F.unit
   ): F[List[EditAttempt]] =
     findUpdateReplacements(data.repo, data.config, update).flatMap {
-      case Nil => logger.warn("Unable to bump version").as(Nil)
+      case Nil => logger.warn(s"Unable to bump version for update ${update.show}").as(Nil)
       case updateReplacements =>
         for {
           _ <- preCommit


### PR DESCRIPTION
Sometimes scala-steward fails to bump a version.

When this happens, the logs just show:

```
WARN Unable to bump version
```

This PR adds the name of the update to that warning. This will look something like:

```
WARN Unable to bump version for update com.foo:library : 1.2.3 -> 1.3.0
```
