### PR TITLE
Rename `WorkspaceAlg#cleanWorkspace`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -92,7 +92,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
     logger.infoTotalTime("run") {
       for {
         _ <- selfCheckAlg.checkAll
-        _ <- workspaceAlg.cleanWorkspace
+        _ <- workspaceAlg.cleanReposDir
         exitCode <-
           (config.githubApp.map(getGitHubAppRepos).getOrElse(Stream.empty) ++
             readRepos(config.reposFile))

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -43,8 +43,11 @@ object WorkspaceAlg {
       private val reposDir: File =
         config.workspace / "repos"
 
-      private def mkRepoDir(repo: Repo): File =
+      private def toFile(repo: Repo): File =
         reposDir / repo.owner / repo.repo
+
+      private def toFile(buildRoot: BuildRoot): File =
+        toFile(buildRoot.repo) / buildRoot.relativePath
 
       override def cleanReposDir: F[Unit] =
         logger.info(s"Clean $reposDir") >> fileAlg.deleteForce(reposDir)
@@ -53,9 +56,9 @@ object WorkspaceAlg {
         fileAlg.ensureExists(config.workspace)
 
       override def repoDir(repo: Repo): F[File] =
-        fileAlg.ensureExists(mkRepoDir(repo))
+        fileAlg.ensureExists(toFile(repo))
 
       override def buildRootDir(buildRoot: BuildRoot): F[File] =
-        fileAlg.ensureExists(mkRepoDir(buildRoot.repo) / buildRoot.relativePath)
+        fileAlg.ensureExists(toFile(buildRoot))
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.mock.{MockConfig, MockEff}
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
-  override def cleanWorkspace: MockEff[Unit] =
+  override def cleanReposDir: MockEff[Unit] =
     Kleisli.pure(())
 
   override def rootDir: MockEff[File] =


### PR DESCRIPTION
This renames `WorkspaceAlg#cleanWorkspace` to `cleanReposDir` since this is what this method actually does. The log message is also changed from "Clean workspace" to "Clean $reposDir". The former message is misleading since the workspace needs to be persisted between runs for certain features to work, but Scala Steward says on every run that it is cleaning this workspace.