### PR TITLE
Issue #2877: Fix "Unable to bump version" when using a val version in libraryDependencies ++= Seq(...)

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/ModulePosition.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/ModulePosition.scala
@@ -29,5 +29,5 @@ final case class ModulePosition(
     version: Substring.Position
 ) {
   def unwrappedVersion: String =
-    version.value.dropWhile(Set('"', '$', '{')).reverse.dropWhile(Set('"', '}')).reverse
+    version.value.dropWhile(Set('"', '$', '{')).reverse.dropWhile(Set('"', '}', ',')).reverse
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -840,7 +840,7 @@ class RewriteTest extends FunSuite {
     runApplyUpdate(update, original, expected)
   }
 
-  test("issue-2877: sbt using same version in a val and a literal using a Seq addition".fail) {
+  test("issue-2877: sbt using same version in a val and a literal using a Seq addition") {
     val update = ("org.scalatest".g % Nel.of(
       "scalatest".a,
       "scalactic".a

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -840,7 +840,7 @@ class RewriteTest extends FunSuite {
     runApplyUpdate(update, original, expected)
   }
 
-  test("issue-2877: sbt using same version in a val and a literal".fail) {
+  test("issue-2877: sbt using same version in a val and a literal using a Seq addition".fail) {
     val update = ("org.scalatest".g % Nel.of(
       "scalatest".a,
       "scalactic".a
@@ -863,6 +863,30 @@ class RewriteTest extends FunSuite {
           |  "org.scalatest" %% "scalatest" % ScalaTestVersion,
           |  "org.scalatest" %% "scalactic" % "3.2.14"
           |)
+          |""".stripMargin
+    )
+    runApplyUpdate(update, original, expected)
+  }
+
+  test("issue-2877: sbt using same version in a val and a literal using individual additions") {
+    val update = ("org.scalatest".g % Nel.of(
+      "scalatest".a,
+      "scalactic".a
+    ) % "3.2.13" %> "3.2.14").group
+    val original = Map(
+      "build.sbt" ->
+        """
+          |val ScalaTestVersion = "3.2.13"
+          |libraryDependencies += "org.scalatest" %% "scalatest" % ScalaTestVersion
+          |libraryDependencies += "org.scalatest" %% "scalactic" % "3.2.13"
+          |""".stripMargin
+    )
+    val expected = Map(
+      "build.sbt" ->
+        """
+          |val ScalaTestVersion = "3.2.14"
+          |libraryDependencies += "org.scalatest" %% "scalatest" % ScalaTestVersion
+          |libraryDependencies += "org.scalatest" %% "scalactic" % "3.2.14"
           |""".stripMargin
     )
     runApplyUpdate(update, original, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -840,6 +840,31 @@ class RewriteTest extends FunSuite {
     runApplyUpdate(update, original, expected)
   }
 
+  test("issue-2877: sbt using same version in a val and a literal".fail) {
+    val update = ("org.scalatest".g % "scalatest".a % "3.2.13" %> "3.2.14").single
+    val original = Map(
+      "build.sbt" ->
+        """
+          |val ScalaTestVersion = "3.2.13"
+          |libraryDependencies ++= Seq(
+          |  "org.scalatest" %% "scalatest" % ScalaTestVersion,
+          |  "org.scalatest" %% "scalactic" % "3.2.13"
+          |)
+          |""".stripMargin
+    )
+    val expected = Map(
+      "build.sbt" ->
+        """
+          |val ScalaTestVersion = "3.2.14"
+          |libraryDependencies ++= Seq(
+          |  "org.scalatest" %% "scalatest" % ScalaTestVersion,
+          |  "org.scalatest" %% "scalactic" % "3.2.14"
+          |)
+          |""".stripMargin
+    )
+    runApplyUpdate(update, original, expected)
+  }
+
   private def runApplyUpdate(
       update: Update.Single,
       files: Map[String, String],

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -841,7 +841,10 @@ class RewriteTest extends FunSuite {
   }
 
   test("issue-2877: sbt using same version in a val and a literal".fail) {
-    val update = ("org.scalatest".g % "scalatest".a % "3.2.13" %> "3.2.14").single
+    val update = ("org.scalatest".g % Nel.of(
+      "scalatest".a,
+      "scalactic".a
+    ) % "3.2.13" %> "3.2.14").group
     val original = Map(
       "build.sbt" ->
         """


### PR DESCRIPTION
This is a fix and tests for the issue I raised in #2877.

Prior to this fix, scala-steward was failing to properly update this example:

```scala
val ScalaTestVersion = "3.2.13"
libraryDependencies ++= Seq(
  "org.scalatest" %% "scalatest" % ScalaTestVersion,
  "org.scalatest" %% "scalactic" % "3.2.13"
)
````

due to the trailing comma in `ScalaTestVersion,`.