### PR TITLE
Replacing deprecated http4s-okhttp-client with http4s-jdk-http-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val core = myCrossProject("core")
       Dependencies.http4sCirce,
       Dependencies.http4sClient,
       Dependencies.http4sCore,
-      Dependencies.http4sOkhttpClient,
+      Dependencies.http4sJdkhttpClient,
       Dependencies.jjwtApi,
       Dependencies.jjwtImpl % Runtime,
       Dependencies.jjwtJackson % Runtime,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -119,7 +119,7 @@ object Context {
         middleware
       )
       urlCheckerClient <- ClientConfiguration.build(
-        ClientConfiguration.disableFollowRedirect[F],
+        ClientConfiguration.disableFollowRedirect,
         middleware
       )
       fileAlg0 = FileAlg.create(logger0, F)

--- a/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
@@ -41,7 +41,7 @@ object ClientConfiguration {
     Resource
       .eval(defaultHttpClient[F](bmw).map(JdkHttpClient[F](_)))
       .map(cmw)
-
+  // Copied from https://github.com/http4s/http4s-jdk-http-client/blob/b9655b90549319fbe999069e7c95ab1752efecb9/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala#L257-L275 to support BuilderMiddleware
   private def defaultHttpClient[F[_]: Async](bmw: BuilderMiddleware): F[HttpClient] =
     Async[F].executor.flatMap { exec =>
       Async[F].delay {

--- a/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
@@ -39,7 +39,7 @@ object ClientConfiguration {
 
   def build[F[_]: Async](bmw: BuilderMiddleware, cmw: Middleware[F]): Resource[F, Client[F]] =
     Resource
-      .make(defaultHttpClient[F](bmw).map(JdkHttpClient[F](_)))(_ => Async[F].unit)
+      .eval(defaultHttpClient[F](bmw).map(JdkHttpClient[F](_)))
       .map(cmw)
 
   private def defaultHttpClient[F[_]: Async](bmw: BuilderMiddleware): F[HttpClient] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val http4sClient = "org.http4s" %% "http4s-client" % http4sCore.revision
   val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sCore.revision
   val http4sBlazeServer = "org.http4s" %% "http4s-blaze-server" % "1.0.0-M38"
-  val http4sOkhttpClient = "org.http4s" %% "http4s-okhttp-client" % "1.0.0-M32"
+  val http4sJdkhttpClient = "org.http4s" %% "http4s-jdk-http-client" % "1.0.0-M8"
   val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % "2.5.0"
   val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.4.5"
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.11.5"


### PR DESCRIPTION
As per title, I swapped the client implementation.
There are a few things to note by the way:
- As you can see [here](https://github.com/http4s/http4s-jdk-http-client/blob/main/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala#L257) JdkHttpClient doesn't expose a builder that let you operate over the `java.net.HttpClient.Builder` so I had to copy some of the default logic from the lib (this might be a nice addition to the upstream lib btw)
- the default `BuilderMiddleware` is no more an identity as the default for HttpClient is to do not follow redirects
- There's no way to "destroy" the HttpClient instance so the Resource.release is a F.unit

Closes https://github.com/scala-steward-org/scala-steward/issues/2887