### PR TITLE
Use releaseNotesUrl even if repoUrl is empty

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -214,17 +214,10 @@ final class NurtureAlg[F[_]](config: VCSCfg)(implicit
       }.toMap
       releaseRelatedUrls <- dependenciesWithNextVersion.flatTraverse {
         case (currentVersion, dependency) =>
-          dependencyToMetadata.get(dependency).toList.flatTraverse { metadata =>
-            metadata.repoUrl.toList.traverse { uri =>
-              vcsExtraAlg
-                .getReleaseRelatedUrls(
-                  uri,
-                  metadata.releaseNotesUrl,
-                  currentVersion,
-                  dependency.version
-                )
-                .tupleLeft(dependency.artifactId.name)
-            }
+          dependencyToMetadata.get(dependency).toList.traverse { metadata =>
+            vcsExtraAlg
+              .getReleaseRelatedUrls(metadata, currentVersion, dependency.version)
+              .tupleLeft(dependency.artifactId.name)
           }
       }
       filesWithOldVersion <-


### PR DESCRIPTION
This is a follow-up to #2863. Before this change, the `info.releaseNotesUrl` property from the POM was ignored if `project.scm.url` and `project.url` were not set (since `DependencyMetadata#repoUrl` is then empty too). With this change the `releaseNotesUrl` is added to the PR even if the other two are not set.