### PR TITLE
Use WorkspaceAlg#repoDir in tests

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -4,8 +4,7 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
-import org.scalasteward.core.mock.MockConfig.config
-import org.scalasteward.core.mock.MockContext.context.buildToolDispatcher
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{BuildRootConfig, RepoConfig}
@@ -19,7 +18,7 @@ class BuildToolDispatcherTest extends FunSuite {
     val repoConfig = RepoConfig.empty.copy(buildRoots =
       Some(List(BuildRootConfig("."), BuildRootConfig("mvn-build")))
     )
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val initial = MockState.empty
       .addFiles(
         repoDir / "mvn-build" / "pom.xml" -> "",

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -2,16 +2,16 @@ package org.scalasteward.core.buildtool.maven
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.scalasteward.core.mock.MockContext.context.mavenAlg
+import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.mock.{MockConfig, MockState}
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
 
 class MavenAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("namespace", "repo-name")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = MockConfig.config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
 
     val state = mavenAlg.getDependencies(buildRoot).runS(MockState.empty).unsafeRunSync()
     val expected = MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -4,8 +4,7 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
 import org.scalasteward.core.data.Version
-import org.scalasteward.core.mock.MockConfig.config
-import org.scalasteward.core.mock.MockContext.context.millAlg
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
@@ -14,7 +13,7 @@ class MillAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("lihaoyi", "fastparse")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val predef = s"$repoDir/scala-steward.sc"
     val millCmd = List(
       "firejail",

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -8,8 +8,8 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.{sbtArtifactId, sbtGroupId}
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.scalafix.ScalafixCli.scalafixBinary
-import org.scalasteward.core.mock.MockConfig.{config, gitCmd}
-import org.scalasteward.core.mock.MockContext.context.editAlg
+import org.scalasteward.core.mock.MockConfig.gitCmd
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.RepoConfig
@@ -24,7 +24,7 @@ class EditAlgTest extends FunSuite {
   test("applyUpdate") {
     val repo = Repo("edit-alg", "test-1")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single
     val file1 = repoDir / "build.sbt"
     val file2 = repoDir / "project/Dependencies.scala"
@@ -64,7 +64,7 @@ class EditAlgTest extends FunSuite {
       List(List(DependencyInfo(scalafmtDependency(Version("2.0.0")), Nil)).withMavenCentral)
     )
     val data = RepoData(repo, cache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val update = ("org.scalameta".g % "scalafmt-core".a % "2.0.0" %> "2.1.0").single
     val scalafmtConf = repoDir / scalafmtConfName
     val scalafmtConfContent = """maxColumn = 100
@@ -120,7 +120,7 @@ class EditAlgTest extends FunSuite {
   test("applyUpdate with build Scalafix") {
     val repo = Repo("edit-alg", "test-3-1")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val update = (sbtGroupId % sbtArtifactId % "1.4.9" %> "1.5.5").single
 
     val state = MockState.empty

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -5,8 +5,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{RepoData, Update}
-import org.scalasteward.core.mock.MockConfig.config
-import org.scalasteward.core.mock.MockContext.context.editAlg
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtConfName
@@ -847,7 +846,7 @@ class RewriteTest extends FunSuite {
   ): Unit = {
     val repo = Repo("edit-alg", s"runApplyUpdate-${nextInt()}")
     val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-    val repoDir = config.workspace / repo.toPath
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val filesInRepoDir = files.map { case (file, content) => repoDir / file -> content }
     val obtained = MockState.empty
       .addFiles(filesInRepoDir.toSeq: _*)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -20,7 +20,7 @@ import org.scalasteward.core.vcs.data.Repo
 class HookExecutorTest extends CatsEffectSuite {
   private val repo = Repo("scala-steward-org", "scala-steward")
   private val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
-  private val repoDir = workspaceAlg.repoDir(repo).runA(MockState.empty).unsafeRunSync()
+  private val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
 
   test("no hook") {
     val update = ("org.typelevel".g % "cats-core".a % "1.2.0" %> "1.3.0").single

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -23,6 +23,9 @@ package object mock {
 
     def runSA(state: MockState): IO[(MockState, A)] =
       state.toRef.flatMap(ref => fa.run(ref).flatMap(a => ref.get.map(s => (s, a))))
+
+    def unsafeRunSync(): A =
+      runA(MockState.empty).unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   def getFlatMapSet[F[_], A](f: A => F[A])(ref: Ref[F, A])(implicit F: FlatMap[F]): F[Unit] =

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -7,9 +7,9 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, SemVer, Update}
-import org.scalasteward.core.mock.MockContext.context.repoConfigAlg
+import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
-import org.scalasteward.core.mock.{MockConfig, MockState}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
@@ -28,7 +28,7 @@ class RepoConfigAlgTest extends FunSuite {
 
   test("config with all fields set") {
     val repo = Repo("fthomas", "scala-steward")
-    val configFile = MockConfig.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
+    val configFile = workspaceAlg.repoDir(repo).unsafeRunSync() / ".scala-steward.conf"
     val content =
       """|updates.allow  = [ { groupId = "eu.timepit" } ]
          |updates.pin  = [
@@ -247,7 +247,7 @@ class RepoConfigAlgTest extends FunSuite {
 
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
-    val configFile = MockConfig.config.workspace / "fthomas/scala-steward/.scala-steward.conf"
+    val configFile = workspaceAlg.repoDir(repo).unsafeRunSync() / ".scala-steward.conf"
     val initialState =
       MockState.empty.addFiles(configFile -> """updates.ignore = [ "foo """).unsafeRunSync()
     val (state, config) = repoConfigAlg.readRepoConfig(repo).runSA(initialState).unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -3,8 +3,7 @@ package org.scalasteward.core.scalafmt
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.data.Version
-import org.scalasteward.core.mock.MockConfig.config
-import org.scalasteward.core.mock.MockContext.context.scalafmtAlg
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
@@ -13,7 +12,7 @@ class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on unquoted version") {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.owner / repo.repo
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val scalafmtConf = repoDir / scalafmtConfName
     val initialState = MockState.empty
       .addFiles(scalafmtConf -> """maxColumn = 100
@@ -34,7 +33,7 @@ class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on quoted version") {
     val repo = Repo("fthomas", "scala-steward")
     val buildRoot = BuildRoot(repo, ".")
-    val repoDir = config.workspace / repo.owner / repo.repo
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val scalafmtConf = repoDir / scalafmtConfName
     val initialState = MockState.empty
       .addFiles(scalafmtConf -> """maxColumn = 100

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -4,14 +4,14 @@ import munit.CatsEffectSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockConfig.{config, gitCmd}
-import org.scalasteward.core.mock.MockContext.context.{gitAlg, logger, vcsRepoAlg}
+import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.mock.{MockConfig, MockEff, MockState}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 
 class VCSRepoAlgTest extends CatsEffectSuite {
   private val repo = Repo("fthomas", "datapackage")
-  private val repoDir = config.workspace / repo.toPath
+  private val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
   private val parentRepoOut = RepoOut(
     "datapackage",
     UserOut("fthomas"),


### PR DESCRIPTION
... instead of manually constructing the repoDir from the workspace config. This makes the tests independent of the actual implementation of `WorkspaceAlg#repoDir` so that they don't break if the implementation is changed.