### PR TITLE
Prefer GitHub release notes over custom release notes

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrl.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrl.scala
@@ -16,6 +16,7 @@
 
 package org.scalasteward.core.nurture
 
+import cats.Order
 import org.http4s.Uri
 
 /** A URL of a resource that provides additional information for an update. */
@@ -28,4 +29,12 @@ object UpdateInfoUrl {
   final case class CustomReleaseNotes(url: Uri) extends UpdateInfoUrl
   final case class GitHubReleaseNotes(url: Uri) extends UpdateInfoUrl
   final case class VersionDiff(url: Uri) extends UpdateInfoUrl
+
+  implicit val updateInfoUrlOrder: Order[UpdateInfoUrl] =
+    Order.by {
+      case GitHubReleaseNotes(url) => (0, url)
+      case CustomReleaseNotes(url) => (1, url)
+      case CustomChangelog(url)    => (2, url)
+      case VersionDiff(url)        => (3, url)
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinder.scala
@@ -43,7 +43,10 @@ final class UpdateInfoUrlFinder[F[_]](config: VCSCfg)(implicit
           possibleUpdateInfoUrls(config.tpe, config.apiHost, repoUrl, currentVersion, nextVersion)
         }
 
-    updateInfoUrls.distinctBy(_.url).filterA(updateInfoUrl => urlChecker.exists(updateInfoUrl.url))
+    updateInfoUrls
+      .sorted(UpdateInfoUrl.updateInfoUrlOrder.toOrdering)
+      .distinctBy(_.url)
+      .filterA(updateInfoUrl => urlChecker.exists(updateInfoUrl.url))
   }
 }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -21,6 +21,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0"      => Ok()
     case HEAD -> Root / "foo" / "bar1" / "blob" / "master" / "RELEASES.md" => Ok()
     case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0"      => PermanentRedirect()
+    case HEAD -> Root / "foo" / "bar2" / "releases" / "tag" / "v0.2.0"     => Ok()
     case _                                                                 => NotFound()
   })
 
@@ -50,6 +51,16 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       CustomReleaseNotes(metadata.releaseNotesUrl.get),
       VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
     )
+    assertIO(obtained, expected)
+  }
+
+  test("findUpdateInfoUrls: GitHubReleaseNotes and CustomReleaseNotes with the same URL".fail) {
+    val metadata = DependencyMetadata.empty.copy(
+      scmUrl = uri"https://github.com/foo/bar2".some,
+      releaseNotesUrl = uri"https://github.com/foo/bar2/releases/tag/v0.2.0".some
+    )
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val expected = List(GitHubReleaseNotes(metadata.releaseNotesUrl.get))
     assertIO(obtained, expected)
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -54,7 +54,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     assertIO(obtained, expected)
   }
 
-  test("findUpdateInfoUrls: GitHubReleaseNotes and CustomReleaseNotes with the same URL".fail) {
+  test("findUpdateInfoUrls: GitHubReleaseNotes and CustomReleaseNotes with the same URL") {
     val metadata = DependencyMetadata.empty.copy(
       scmUrl = uri"https://github.com/foo/bar2".some,
       releaseNotesUrl = uri"https://github.com/foo/bar2/releases/tag/v0.2.0".some


### PR DESCRIPTION
If `DependencyMetadata#releaseNotesUrl` contains the same URL that `possibleUpdateInfoUrls` returns in a `GitHubReleaseNotes`, we currently discard the `GitHubReleaseNotes` in favor of the `CustomReleaseNotes` coming from the `DependencyMetadata#releaseNotesUrl`. In the PR body we would then present that URL as `Release Notes` instead of `GitHub Release Notes` although it points to the GitHub release notes. With this change, we prefer `GitHubReleaseNotes` over `CustomReleaseNotes` regardless where the GitHub release notes URL is coming from.