### PR TITLE
Add a How-to section to CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,15 @@
+
+## Reference
+
 ### Helpful resources about writing and structuring documentation
 
 * [What nobody tells you about documentation](https://www.divio.com/blog/documentation/)
+
+## How-to
+
+### Debug a case of "Unable to bump version"
+
+1. Write a representative test in `RewriteTest.scala`.
+2. Optionally, print the logs by adding `state.trace.foreach(println)` in the `runApplyUpdate` method.
+3. Optionally, create a test that intentionally fails by using the `test("...".fail) { ... }` construct.
+4. Optionally, open a PR to get input from the maintainers and community.


### PR DESCRIPTION
Based on discussion in https://github.com/scala-steward-org/scala-steward/issues/2903

I added Reference and How-to based on my own interpretation of the "Documentation System". I really like it as a framework, but I have struggled on where to put links. I usually put them under the Reference section, but I could also see links interpreted as an Explanation.