### PR TITLE
HttpJsonClient: unify client calls

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -84,10 +84,9 @@ final class HttpJsonClient[F[_]](implicit
       d: EntityDecoder[F, A]
   ): F[(A, Headers)] =
     modify(Request[F](method, uri)).flatMap { req =>
-      val r = if (d.consumes.nonEmpty) {
-        val m = d.consumes.toList.map(MediaRangeAndQValue(_))
-        req.addHeader(Accept(Nel.fromListUnsafe(m)))
-      } else req
+      val r = Nel
+        .fromList(d.consumes.toList.map(MediaRangeAndQValue(_)))
+        .fold(req)(m => req.addHeader(Accept(m)))
 
       client.run(r).use {
         case Successful(resp) =>

--- a/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
@@ -34,7 +34,8 @@ class HttpJsonClientTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       .map(_.leftMap(_.getMessage))
     val expected = Left("""uri: https://example.org
                           |method: GET
-                          |message: Malformed message body: Invalid JSON""".stripMargin)
+                          |message: Malformed message body: Invalid JSON
+                          |body:  "1 """.stripMargin)
     assertIO(obtained, expected)
   }
 


### PR DESCRIPTION
This unifies the client calls in `HttpJsonClient`. There is now only one method that calls the underlying client that works for all other methods. The nice thing about this is that we only need to handle decoding failures and unexpected responses in one place.