### PR TITLE
Implement HttpJsonClient#getAll as fs2.Stream

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.util
 
 import cats.effect.Concurrent
 import cats.syntax.all._
+import fs2.Stream
 import io.circe.{Decoder, Encoder}
 import org.http4s.Method.{GET, PATCH, POST, PUT}
 import org.http4s.Status.Successful
@@ -36,20 +37,18 @@ final class HttpJsonClient[F[_]](implicit
   def get[A: Decoder](uri: Uri, modify: ModReq): F[A] =
     request[A](GET, uri, modify)
 
-  def getAll[A: Decoder](uri: Uri, modify: ModReq): F[List[A]] =
-    all[A](GET, uri, modify, Nil)
-
-  private def all[A: Decoder](
-      method: Method,
-      uri: Uri,
-      modify: ModReq,
-      xs: List[A]
-  ): F[List[A]] =
-    requestWithHeaders[A](method, uri, modify)(jsonOf).flatMap { case (a, headers) =>
-      headers.get[Link].flatMap(_.values.find(_.rel.contains("next"))) match {
-        case Some(linkValue) => all(method, linkValue.uri, modify, a :: xs)
-        case None            => F.pure(a :: xs)
+  /** Retrieves all values via pagination.
+    * @see
+    *   [[https://tools.ietf.org/html/rfc8288]]
+    *   [[https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api]]
+    */
+  def getAll[A: Decoder](uri: Uri, modify: ModReq): Stream[F, A] =
+    Stream.eval(requestWithHeaders[A](GET, uri, modify)(jsonOf)).flatMap { case (a, headers) =>
+      val next = headers.get[Link].flatMap(_.values.find(_.rel.contains("next"))) match {
+        case Some(linkValue) => getAll(linkValue.uri, modify)
+        case None            => Stream.empty
       }
+      Stream.emit(a) ++ next
     }
 
   def post[A: Decoder](uri: Uri, modify: ModReq): F[A] =

--- a/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
@@ -18,8 +18,8 @@ class HttpJsonClientTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       case GET -> Root / "2" => Ok("2", Link(LinkValue(url1, Some("prev"))))
       case _                 => NotFound()
     })
-    val obtained = httpJsonClient.getAll[Int](url1, _.pure[MockEff]).runA(state)
-    assertIO(obtained, List(2, 1))
+    val obtained = httpJsonClient.getAll[Int](url1, _.pure[MockEff]).compile.toList.runA(state)
+    assertIO(obtained, List(1, 2))
   }
 
   test("get with malformed JSON") {


### PR DESCRIPTION
This implements `HttpJsonClient#getAll` as `fs2.Stream`. The nice thing about this is that the consumer of the stream has control over how many requests are made independent of how many pages exists in total.

`GitHubAppApiAlg` still accumulates all values into a list, so this change does not make a difference in practice but I think it is a nicer foundation.

I should also note that the values returned by `getAll` are now in the same order is in the pages. This means Scala Steward as GitHub App will work on repos in the same order as in the `/installation/repositories` responses.