### PR TITLE
Move `Repo` and `BuildRoot`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,6 @@ lazy val core = myCrossProject("core")
       import ${moduleRootPkg.value}._
       import ${moduleRootPkg.value}.data._
       import ${moduleRootPkg.value}.util._
-      import ${moduleRootPkg.value}.vcs.data._
       import better.files.File
       import cats.effect.IO
       import org.http4s.client.Client
@@ -202,7 +201,7 @@ lazy val core = myCrossProject("core")
            |  // prevent warnings
            |  intellijThisImportIsUsed(Client); intellijThisImportIsUsed(File);
            |  intellijThisImportIsUsed(Nel); intellijThisImportIsUsed(Repo);
-           |  intellijThisImportIsUsed(Version); intellijThisImportIsUsed(data.Version);
+           |  intellijThisImportIsUsed(Main);
            |}""".stripMargin
       IO.write(file, content)
       Seq(file)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -32,6 +32,7 @@ import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.client.ClientConfiguration
 import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.edit.hooks.HookExecutor
 import org.scalasteward.core.edit.scalafix._
@@ -47,7 +48,6 @@ import org.scalasteward.core.update.artifact.{ArtifactMigrationsFinder, Artifact
 import org.scalasteward.core.update.{FilterAlg, PruningAlg, UpdateAlg}
 import org.scalasteward.core.util._
 import org.scalasteward.core.util.uri._
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.vcs.github.{GitHubAppApiAlg, GitHubAuthAlg}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg, VCSSelection}
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -20,6 +20,7 @@ import better.files.File
 import cats.effect.{ExitCode, Sync}
 import cats.syntax.all._
 import fs2.Stream
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
@@ -28,7 +29,6 @@ import org.scalasteward.core.update.PruningAlg
 import org.scalasteward.core.util
 import org.scalasteward.core.util.DateTimeAlg
 import org.scalasteward.core.util.logger.LoggerOps
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.vcs.github.{GitHubApp, GitHubAppApiAlg, GitHubAuthAlg}
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration._

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.data
+package org.scalasteward.core.buildtool
+
+import org.scalasteward.core.vcs.data.Repo
 
 final case class BuildRoot(repo: Repo, relativePath: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
@@ -16,6 +16,6 @@
 
 package org.scalasteward.core.buildtool
 
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.data.Repo
 
 final case class BuildRoot(repo: Repo, relativePath: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
-import org.scalasteward.core.vcs.data.BuildRoot
 
 trait BuildToolAlg[F[_]] {
   def name: String

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -25,7 +25,7 @@ import org.scalasteward.core.data.Scope
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class BuildToolDispatcher[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -21,11 +21,10 @@ import cats.syntax.all._
 import org.scalasteward.core.buildtool.maven.MavenAlg
 import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.SbtAlg
-import org.scalasteward.core.data.Scope
+import org.scalasteward.core.data.{Repo, Scope}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class BuildToolDispatcher[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -20,12 +20,11 @@ import better.files.File
 import cats.effect.{MonadCancelThrow, Resource}
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildtool.BuildToolAlg
+import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.BuildRoot
 import org.typelevel.log4cats.Logger
 
 final class MavenAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -19,14 +19,13 @@ package org.scalasteward.core.buildtool.mill
 import better.files.File
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
-import org.scalasteward.core.buildtool.BuildToolAlg
+import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.buildtool.mill.MillAlg._
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.BuildRoot
 import org.typelevel.log4cats.Logger
 
 final class MillAlg[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -19,8 +19,8 @@ package org.scalasteward.core.buildtool.mill
 import better.files.File
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
-import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.buildtool.mill.MillAlg._
+import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.scalafix.ScalafixMigration

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
@@ -16,13 +16,11 @@
 
 package org.scalasteward.core.buildtool.mill
 
-import cats.syntax.all._
-import io.circe.{Decoder, DecodingFailure}
-import org.scalasteward.core.data.{Dependency, Resolver, Version}
 import cats.parse.Parser
 import cats.parse.Rfc5234.sp
-import org.scalasteward.core.data.GroupId
-import org.scalasteward.core.data.ArtifactId
+import cats.syntax.all._
+import io.circe.{Decoder, DecodingFailure}
+import org.scalasteward.core.data._
 import scala.util.Try
 
 object parser {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -21,8 +21,8 @@ import cats.data.OptionT
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.coursier.VersionsCache
 import org.scalasteward.core.data.{Dependency, Scope, Version}
 import org.scalasteward.core.edit.scalafix.{ScalafixCli, ScalafixMigration}

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -21,14 +21,13 @@ import cats.data.OptionT
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildtool.BuildToolAlg
+import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.coursier.VersionsCache
 import org.scalasteward.core.data.{Dependency, Scope, Version}
 import org.scalasteward.core.edit.scalafix.{ScalafixCli, ScalafixMigration}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.BuildRoot
 
 final class SbtAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Repo.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.vcs.data
+package org.scalasteward.core.data
 
 import cats.Eq
 import io.circe.KeyEncoder

--- a/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/RepoData.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.data
 
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.vcs.data.Repo
 
 final case class RepoData(
     repo: Repo,

--- a/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
@@ -19,7 +19,6 @@ package org.scalasteward.core.data
 import cats.syntax.all._
 import io.circe.{Codec, Decoder, Encoder}
 import org.scalasteward.core.data.SemVer.Change._
-
 import scala.annotation.tailrec
 
 final case class SemVer(

--- a/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/UpdateData.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.data
 
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.vcs.data.Repo
 
 final case class UpdateData(
     repoData: RepoData,

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.edit
 import cats.MonadThrow
 import cats.syntax.all._
 import org.scalasteward.core.buildtool.BuildToolDispatcher
-import org.scalasteward.core.data.{RepoData, Update}
+import org.scalasteward.core.data.{Repo, RepoData, Update}
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.hooks.HookExecutor
 import org.scalasteward.core.edit.scalafix.{ScalafixMigration, ScalafixMigrationsFinder}
@@ -30,7 +30,6 @@ import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.{scalafmtModule, ScalafmtAlg}
 import org.scalasteward.core.util.logger._
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class EditAlg[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -34,7 +34,6 @@ import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.logger._
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class HookExecutor[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
@@ -19,12 +19,11 @@ package org.scalasteward.core.edit.update
 import better.files.File
 import cats.effect.Concurrent
 import fs2.Stream
-import org.scalasteward.core.data.{Dependency, Version}
+import org.scalasteward.core.data.{Dependency, Repo, Version}
 import org.scalasteward.core.edit.update.data.{ModulePosition, VersionPosition}
 import org.scalasteward.core.io.{FileAlg, FileData, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 
 /** Scans all files that Scala Steward is allowed to edit for version and module positions. */
 final class ScannerAlg[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -16,9 +16,8 @@
 
 package org.scalasteward.core
 
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.repoconfig.CommitsConfig
-import org.scalasteward.core.vcs.data.Repo
 
 package object git {
   type GitAlg[F[_]] = GenGitAlg[F, Repo]

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -21,7 +21,7 @@ import cats.FlatMap
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.data.Repo
 import org.typelevel.log4cats.Logger
 
 trait WorkspaceAlg[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -20,7 +20,8 @@ import better.files.File
 import cats.FlatMap
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.buildtool.BuildRoot
+import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 trait WorkspaceAlg[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -21,14 +21,14 @@ import cats.{Id, Monad}
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.http4s.Uri
-import org.scalasteward.core.data.{CrossDependency, GroupId, Update, Version}
+import org.scalasteward.core.data._
 import org.scalasteward.core.git
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.nurture.PullRequestRepository.Entry
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.update.UpdateAlg
 import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
-import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState, Repo}
+import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState}
 
 final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri, Entry]])(implicit
     dateTimeAlg: DateTimeAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -20,11 +20,11 @@ import cats.MonadThrow
 import cats.syntax.all._
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.repocache.RefreshErrorAlg.Entry
 import org.scalasteward.core.util.dateTime.showDuration
 import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
-import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -20,10 +20,10 @@ import cats.syntax.all._
 import cats.{MonadThrow, Parallel}
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildToolDispatcher
-import org.scalasteward.core.data.{Dependency, DependencyInfo, RepoData}
+import org.scalasteward.core.data.{Dependency, DependencyInfo, Repo, RepoData}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
-import org.scalasteward.core.vcs.data.{Repo, RepoOut}
+import org.scalasteward.core.vcs.data.RepoOut
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 import org.typelevel.log4cats.Logger
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.repocache
 
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.persistence.KeyValueStore
-import org.scalasteward.core.vcs.data.Repo
 
 final class RepoCacheRepository[F[_]](kvStore: KeyValueStore[F, Repo, RepoCache]) {
   def findCache(repo: Repo): F[Option[RepoCache]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.repoconfig
 
 import cats.Eq
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto._
 import cats.data.NonEmptyList
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Update
 
 case class PullRequestGroup(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
@@ -21,7 +21,6 @@ import cats.syntax.all._
 import io.circe._
 import io.circe.syntax._
 import org.scalasteward.core.data.{SemVer, Update}
-
 import scala.util.matching.Regex
 
 final case class PullRequestUpdateFilter private (

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -16,12 +16,11 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.{Eq, Monoid}
 import cats.implicits._
+import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
-
 import java.util.regex.PatternSyntaxException
 import scala.util.matching.Regex
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -20,10 +20,9 @@ import better.files.File
 import cats.syntax.all._
 import cats.{Functor, MonadThrow}
 import io.circe.config.parser
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfigAlg._
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -21,11 +21,12 @@ import cats.data.OptionT
 import cats.syntax.all._
 import io.circe.ParsingFailure
 import org.scalasteward.core.application.Config
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.{Scope, Version}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.{opts, parseScalafmtConf}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class ScalafmtAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -22,11 +22,10 @@ import cats.syntax.all._
 import io.circe.ParsingFailure
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.data.{Scope, Version}
+import org.scalasteward.core.data.{Repo, Scope, Version}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.{opts, parseScalafmtConf}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 
 final class ScalafmtAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -27,7 +27,6 @@ import org.scalasteward.core.update.data.UpdateState
 import org.scalasteward.core.update.data.UpdateState._
 import org.scalasteward.core.util
 import org.scalasteward.core.util.{dateTime, DateTimeAlg, Nel, Timestamp}
-import org.scalasteward.core.vcs.data.Repo
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration._
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.vcs
 
 import cats.syntax.all._
 import cats.{ApplicativeThrow, MonadThrow}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.vcs.data._
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -21,11 +21,12 @@ import cats.syntax.all._
 import org.http4s.Uri
 import org.http4s.Uri.UserInfo
 import org.scalasteward.core.application.Config
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.{updateBranchPrefix, Branch, GitAlg}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.logger._
 import org.scalasteward.core.vcs.VCSType.GitHub
-import org.scalasteward.core.vcs.data.{Repo, RepoOut}
+import org.scalasteward.core.vcs.data.RepoOut
 import org.typelevel.log4cats.Logger
 
 final class VCSRepoAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/azurerepos/AzureReposApiAlg.scala
@@ -22,11 +22,12 @@ import io.circe.Json
 import io.circe.syntax.KeyOps
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config.AzureReposConfig
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg
+import org.scalasteward.core.vcs.azurerepos.JsonCodec._
 import org.scalasteward.core.vcs.data._
-import JsonCodec._
 
 final class AzureReposApiAlg[F[_]](
     azureAPiHost: Uri,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/azurerepos/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/azurerepos/Url.scala
@@ -17,8 +17,9 @@
 package org.scalasteward.core.vcs.azurerepos
 
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 class Url(apiHost: Uri, organization: String) {
   private val apiVersion = "7.1-preview.1"

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlg.scala
@@ -19,14 +19,14 @@ package org.scalasteward.core.vcs.bitbucket
 import cats.MonadThrow
 import cats.syntax.all._
 import org.http4s.{Request, Status}
-import org.scalasteward.core.application.Config.VCSCfg
+import org.scalasteward.core.application.Config.{BitbucketCfg, VCSCfg}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.{HttpJsonClient, UnexpectedResponse}
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.bitbucket.json._
 import org.scalasteward.core.vcs.data._
 import org.typelevel.log4cats.Logger
-import org.scalasteward.core.application.Config.BitbucketCfg
 
 /** https://developer.atlassian.com/bitbucket/api/2/reference/ */
 class BitbucketApiAlg[F[_]](

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreatePullRequestRequest.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/CreatePullRequestRequest.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.vcs.bitbucket
 
 import io.circe.{Encoder, Json}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.Repo
 
 private[bitbucket] case class CreatePullRequestRequest(
     title: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/RepositoryResponse.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/RepositoryResponse.scala
@@ -19,9 +19,10 @@ package org.scalasteward.core.vcs.bitbucket
 import cats.syntax.all._
 import io.circe.{ACursor, Decoder, DecodingFailure, Json}
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.uri._
-import org.scalasteward.core.vcs.data.{Repo, UserOut}
+import org.scalasteward.core.vcs.data.UserOut
 import scala.annotation.tailrec
 
 final private[bitbucket] case class RepositoryResponse(

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucket/Url.scala
@@ -17,8 +17,9 @@
 package org.scalasteward.core.vcs.bitbucket
 
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 private[bitbucket] class Url(apiHost: Uri) {
   def forks(rep: Repo): Uri =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlg.scala
@@ -20,6 +20,7 @@ import cats.MonadThrow
 import cats.syntax.all._
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config.BitbucketServerCfg
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/bitbucketserver/Url.scala
@@ -17,8 +17,9 @@
 package org.scalasteward.core.vcs.bitbucketserver
 
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 final class Url(apiHost: Uri) {
   private val api: Uri = apiHost / "rest" / "api" / "1.0"

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
@@ -20,6 +20,7 @@ import cats.ApplicativeThrow
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.intellijThisImportIsUsed
 import org.scalasteward.core.util.uri.uriDecoder

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubApiAlg.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.vcs.github
 import cats.MonadThrow
 import cats.syntax.all._
 import org.http4s.{Request, Uri}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubException.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/GitHubException.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.vcs.github
 
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.util.UnexpectedResponse
-import org.scalasteward.core.vcs.data.Repo
 import scala.util.control.NoStackTrace
 
 sealed trait GitHubException extends RuntimeException with NoStackTrace

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/github/Url.scala
@@ -17,8 +17,9 @@
 package org.scalasteward.core.vcs.github
 
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 class Url(apiHost: Uri) {
   def branches(repo: Repo, branch: Branch): Uri =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlg.scala
@@ -23,6 +23,7 @@ import io.circe.generic.semiauto._
 import io.circe.syntax._
 import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.application.Config.{GitLabCfg, VCSCfg}
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.util.{intellijThisImportIsUsed, HttpJsonClient, UnexpectedResponse}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/gitlab/Url.scala
@@ -17,8 +17,9 @@
 package org.scalasteward.core.vcs.gitlab
 
 import org.http4s.Uri
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 class Url(apiHost: Uri) {
   def encodedProjectId(repo: Repo): String = s"${repo.owner}%2F${repo.repo}"

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core
 
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.vcs.VCSType._
-import org.scalasteward.core.vcs.data.Repo
 
 package object vcs {
 

--- a/modules/core/src/test/scala/org/scalasteward/core/BuiltinConfigFilesTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/BuiltinConfigFilesTest.scala
@@ -14,7 +14,6 @@ import org.scalasteward.core.mock.MockContext.context.{
 import org.scalasteward.core.mock.MockContext.mockState
 import org.scalasteward.core.repoconfig.RepoConfigLoader
 import org.scalasteward.core.update.artifact.ArtifactMigrationsLoader
-
 import scala.util.{Failure, Success, Try}
 
 class BuiltinConfigFilesTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -6,10 +6,9 @@ import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.Cli.ParseResult._
+import org.scalasteward.core.application.Config.StewardUsage
 import org.scalasteward.core.vcs.VCSType
 import org.scalasteward.core.vcs.github.GitHubApp
-import org.scalasteward.core.application.Config.StewardUsage
-
 import scala.concurrent.duration._
 
 class CliTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -3,14 +3,13 @@ package org.scalasteward.core.buildtool
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
-import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
+import org.scalasteward.core.data._
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{BuildRootConfig, RepoConfig}
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.scalafmt.scalafmtConfName
-import org.scalasteward.core.vcs.data.Repo
 
 class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -3,10 +3,10 @@ package org.scalasteward.core.buildtool.maven
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.Repo
 
 class MavenAlgTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -2,10 +2,11 @@ package org.scalasteward.core.buildtool.maven
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 
 class MavenAlgTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -4,11 +4,10 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
-import org.scalasteward.core.data.Version
+import org.scalasteward.core.data.{Repo, Version}
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.Repo
 
 class MillAlgTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -2,12 +2,13 @@ package org.scalasteward.core.buildtool.mill
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 
 class MillAlgTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -4,13 +4,12 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.sbt.command._
-import org.scalasteward.core.data.{GroupId, Version}
+import org.scalasteward.core.data.{GroupId, Repo, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 
 class SbtAlgTest extends FunSuite {
   private val workspace = workspaceAlg.rootDir.unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -2,6 +2,7 @@ package org.scalasteward.core.buildtool.sbt
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
@@ -9,7 +10,7 @@ import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 
 class SbtAlgTest extends FunSuite {
   private val workspace = workspaceAlg.rootDir.unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
@@ -2,15 +2,14 @@ package org.scalasteward.core.client
 
 import cats.effect._
 import cats.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
 import munit.CatsEffectSuite
 import org.http4s.HttpRoutes
 import org.http4s.client._
 import org.http4s.headers.{`Retry-After`, `User-Agent`, Location}
 import org.http4s.implicits._
 import org.typelevel.ci._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.PosInt
-
 import scala.concurrent.duration._
 
 class ClientConfigurationTest extends CatsEffectSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -2,8 +2,8 @@ package org.scalasteward.core.data
 
 import cats.data.NonEmptyList
 import cats.implicits.catsSyntaxOptionId
-import org.scalasteward.core.TestSyntax._
 import munit.FunSuite
+import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.repoconfig.{PullRequestGroup, PullRequestUpdateFilter}
 
 class GroupedUpdateTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -15,7 +15,6 @@ import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtBinary, scalafmtConfName, scalafmtDependency}
-import org.scalasteward.core.vcs.data.Repo
 
 class EditAlgTest extends FunSuite {
   private def gitStatus(repoDir: File): List[String] =

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -4,13 +4,12 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{RepoData, Update}
+import org.scalasteward.core.data.{Repo, RepoData, Update}
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtConfName
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 
 class RewriteTest extends FunSuite {
   test("all on one line") {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -4,7 +4,7 @@ import cats.syntax.all._
 import munit.CatsEffectSuite
 import org.scalasteward.core.TestInstances.{dummyRepoCache, dummySha1}
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.RepoData
+import org.scalasteward.core.data.{Repo, RepoData}
 import org.scalasteward.core.git.{gitBlameIgnoreRevsName, FileGitAlg}
 import org.scalasteward.core.io.FileAlgTest
 import org.scalasteward.core.mock.MockConfig.gitCmd
@@ -15,7 +15,6 @@ import org.scalasteward.core.repoconfig.{PostUpdateHookConfig, RepoConfig, Scala
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 
 class HookExecutorTest extends CatsEffectSuite {
   private val repo = Repo("scala-steward-org", "scala-steward")

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -2,8 +2,9 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.data.Kleisli
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.mock.{MockConfig, MockEff}
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
   override def cleanReposDir: MockEff[Unit] =

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -3,8 +3,8 @@ package org.scalasteward.core.io
 import better.files.File
 import cats.data.Kleisli
 import org.scalasteward.core.buildtool.BuildRoot
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.{MockConfig, MockEff}
-import org.scalasteward.core.vcs.data.Repo
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
   override def cleanReposDir: MockEff[Unit] =

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -5,13 +5,13 @@ import org.http4s.HttpApp
 import org.http4s.dsl.Http4sDsl
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{DependencyInfo, RepoData, UpdateData}
+import org.scalasteward.core.data.{DependencyInfo, Repo, RepoData, UpdateData}
 import org.scalasteward.core.edit.EditAttempt.UpdateEdit
 import org.scalasteward.core.git.{Branch, Commit}
 import org.scalasteward.core.mock.MockContext.context.nurtureAlg
 import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
+import org.scalasteward.core.vcs.data.NewPullRequestData
 
 class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("preparePullRequest") {

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
@@ -15,7 +15,7 @@ import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.PullRequestState.Open
-import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState, Repo}
+import org.scalasteward.core.vcs.data.{PullRequestNumber, PullRequestState}
 
 class PullRequestRepositoryTest extends FunSuite {
   private def checkTrace(state: MockState, trace: Vector[TraceEntry]): Unit =

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
@@ -2,9 +2,9 @@ package org.scalasteward.core.repocache
 
 import cats.syntax.all._
 import munit.CatsEffectSuite
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context.refreshErrorAlg
 import org.scalasteward.core.mock.{MockEff, MockState}
-import org.scalasteward.core.vcs.data.Repo
 
 class RefreshErrorAlgTest extends CatsEffectSuite {
   test("skipIfFailedRecently: not failed") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
@@ -9,12 +9,12 @@ import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.syntax.all._
 import org.scalasteward.core.TestInstances.dummySha1
-import org.scalasteward.core.data.RepoData
+import org.scalasteward.core.data.{Repo, RepoData}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.util.intellijThisImportIsUsed
-import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
+import org.scalasteward.core.vcs.data.{RepoOut, UserOut}
 
 class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   intellijThisImportIsUsed(encodeUri)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -6,12 +6,11 @@ import cats.syntax.all._
 import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{GroupId, SemVer, Update}
+import org.scalasteward.core.data.{GroupId, Repo, SemVer, Update}
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
 
 class RepoConfigAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -3,10 +3,9 @@ package org.scalasteward.core.repoconfig
 import better.files.File
 import cats.effect.ExitCode
 import cats.effect.unsafe.implicits.global
-import org.scalasteward.core.mock.{MockContext, MockState}
-
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import org.scalasteward.core.mock.{MockContext, MockState}
 
 class ValidateRepoConfigAlgTest extends munit.FunSuite {
 

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -3,11 +3,10 @@ package org.scalasteward.core.scalafmt
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.data.Version
+import org.scalasteward.core.data.{Repo, Version}
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.Repo
 
 class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on unquoted version") {

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -2,11 +2,12 @@ package org.scalasteward.core.scalafmt
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
+import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.vcs.data.{BuildRoot, Repo}
+import org.scalasteward.core.vcs.data.Repo
 
 class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on unquoted version") {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -2,20 +2,18 @@ package org.scalasteward.core.update
 
 import cats.effect.unsafe.implicits.global
 import io.circe.parser.decode
+import java.time.Instant
 import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Resolver.MavenRepository
-import org.scalasteward.core.data.{DependencyInfo, RepoData, Scope}
+import org.scalasteward.core.data.{DependencyInfo, Repo, RepoData, Scope}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.pruningAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.vcs.data.Repo
-
-import java.time.Instant
 
 class PruningAlgTest extends FunSuite {
   test("needsAttention") {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.util
 
 import munit.FunSuite
-import org.http4s.{Header, Headers, Method, Status, Uri}
+import org.http4s._
 import org.typelevel.ci.CIString
 
 class UnexpectedResponseTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -1,13 +1,12 @@
 package org.scalasteward.core.util
 
 import munit.CatsEffectSuite
+import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockEff, MockState}
-import org.scalasteward.core.util.logger.LoggerOps
-import org.scalasteward.core.util.logger.showUpdates
-import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.util.logger.{showUpdates, LoggerOps}
 
 class loggerTest extends CatsEffectSuite {
   test("attemptError.label_") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -2,10 +2,9 @@ package org.scalasteward.core.vcs
 
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.git
 import org.scalasteward.core.vcs.VCSType.{GitHub, GitLab}
-import org.scalasteward.core.vcs.data.Repo
 
 class VCSPackageTest extends FunSuite {
   private val repo = Repo("foo", "bar")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSRepoAlgTest.scala
@@ -2,12 +2,13 @@ package org.scalasteward.core.vcs
 
 import munit.CatsEffectSuite
 import org.http4s.syntax.literals._
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockConfig.{config, gitCmd}
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.mock.{MockConfig, MockEff, MockState}
-import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
+import org.scalasteward.core.vcs.data.{RepoOut, UserOut}
 
 class VCSRepoAlgTest extends CatsEffectSuite {
   private val repo = Repo("fthomas", "datapackage")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/azurerepos/AzureReposApiAlgTest.scala
@@ -8,6 +8,7 @@ import org.http4s.implicits._
 import org.http4s.{BasicCredentials, HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.AzureReposConfig
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/azurerepos/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/azurerepos/UrlTest.scala
@@ -1,9 +1,10 @@
 package org.scalasteward.core.vcs.azurerepos
 
-import org.http4s.syntax.literals._
 import munit.FunSuite
+import org.http4s.syntax.literals._
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.{PullRequestNumber, Repo}
+import org.scalasteward.core.vcs.data.PullRequestNumber
 
 class UrlTest extends FunSuite {
   private val url = new Url(uri"https://dev.azure.com", "my-azure-org")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucket/BitbucketApiAlgTest.scala
@@ -10,6 +10,7 @@ import org.http4s.headers.Authorization
 import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketCfg
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git._
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -8,6 +8,7 @@ import org.http4s.implicits._
 import org.http4s.{BasicCredentials, HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketServerCfg
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -7,7 +7,7 @@ import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data.{RepoData, Update, UpdateData, Version}
+import org.scalasteward.core.data._
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.git.{Branch, Commit}

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoOutTest.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.implicits.global
 import io.circe.parser
 import munit.FunSuite
 import org.http4s.syntax.literals._
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import scala.io.Source
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoTest.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.vcs.data
 
 import munit.FunSuite
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 
 class RepoTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/GitHubApiAlgTest.scala
@@ -9,6 +9,7 @@ import org.http4s.headers.Authorization
 import org.http4s.implicits._
 import org.http4s.{BasicCredentials, HttpApp}
 import org.scalasteward.core.TestInstances.ioLogger
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/github/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/github/UrlTest.scala
@@ -2,8 +2,8 @@ package org.scalasteward.core.vcs.github
 
 import munit.FunSuite
 import org.http4s.syntax.literals._
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data.Repo
 
 class UrlTest extends FunSuite {
   private val url = new Url(uri"https://api.github.com")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/gitlab/GitLabApiAlgTest.scala
@@ -13,7 +13,7 @@ import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.{dummyRepoCache, ioLogger}
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg
-import org.scalasteward.core.data.{RepoData, UpdateData}
+import org.scalasteward.core.data.{Repo, RepoData, UpdateData}
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config


### PR DESCRIPTION
While preparing a PR for #2912, I noticed that a lot of files are changed because `Repo` and `BuildRoot` are in the `vcs.data` package. This means these types are often used outside of the `vcs` package and are therefore misplaced there. A more precise inspection shows that `BuildRoot` is almost exclusively used in the `buildtool` package while `Repo` is so central that it is used all over the place. This PR therefore moves `Repo` into the top-level `data` package and `BuildRoot` into the `buildtool` package.