### PR TITLE
Simplify implementation of `findArtifactChange`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
@@ -21,19 +21,11 @@ import org.scalasteward.core.data.Dependency
 
 final class ArtifactMigrationsFinder(migrations: List[ArtifactChange]) {
   def findArtifactChange(dependency: Dependency): Option[ArtifactChange] =
-    migrations
-      .find { migration =>
-        (migration.groupIdBefore, migration.artifactIdBefore) match {
-          case (Some(groupId), Some(artifactId)) =>
-            groupId === dependency.groupId &&
-            artifactId === dependency.artifactId.name
-          case (Some(groupId), None) =>
-            groupId === dependency.groupId &&
-            migration.artifactIdAfter === dependency.artifactId.name
-          case (None, Some(artifactId)) =>
-            migration.groupIdAfter === dependency.groupId &&
-            artifactId === dependency.artifactId.name
-          case (None, None) => false
-        }
+    migrations.find { migration =>
+      val groupId = migration.groupIdBefore.getOrElse(migration.groupIdAfter)
+      groupId === dependency.groupId && {
+        val artifactId = migration.artifactIdBefore.getOrElse(migration.artifactIdAfter)
+        artifactId === dependency.artifactId.name
       }
+    }
 }


### PR DESCRIPTION
This collapses the first three cases into one by comparing the groupId/artifactId with the `before` value if it exists or the `after` value if not. The case where both `before` are `None` is prevented by https://github.com/scala-steward-org/scala-steward/blob/73a360c1dc9ff5d37545ce06862390627cdb13e2/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactChange.scala#L37-L40