### PR TITLE
Support Maven dependencies with a property for the Scala binary suffix

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/ModulePositionScanner.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/ModulePositionScanner.scala
@@ -72,13 +72,13 @@ object ModulePositionScanner {
     mavenDependencyRegex(dependency).findAllIn(fileData.content).matchData.map { m =>
       val groupId = Substring.Position.fromMatch(fileData.path, m, dependency.groupId.value)
       val artifactId = Substring.Position.fromMatch(fileData.path, m, dependency.artifactId.name)
-      val version = Substring.Position.fromMatch(fileData.path, m, m.group(1))
+      val version = Substring.Position.fromMatch(fileData.path, m, m.group(2))
       ModulePosition(groupId, artifactId, version)
     }
 
   private def mavenDependencyRegex(dependency: Dependency): Regex = {
     val g = Regex.quote(dependency.groupId.value)
     val a = Regex.quote(dependency.artifactId.name)
-    raw"""<groupId>$g</groupId>\s*<artifactId>$a</artifactId>\s*<version>(.*)</version>""".r
+    raw"""<groupId>$g</groupId>\s*<artifactId>$a(|_[^<]+)</artifactId>\s*<version>(.*)</version>""".r
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
@@ -75,8 +75,9 @@ object Selector {
         case _                 => true
       }
       .filter { p =>
+        val artifactIdNames = Set(p.artifactId, p.artifactId.takeWhile(_ =!= '_'))
         dependencies.exists { d =>
-          d.groupId.value === p.groupId && d.artifactId.names.contains_(p.artifactId)
+          d.groupId.value === p.groupId && d.artifactId.names.exists(artifactIdNames)
         }
       }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -419,6 +419,18 @@ class RewriteTest extends FunSuite {
     runApplyUpdate(update, original, expected)
   }
 
+  test("artifactId and version change of Maven dependency with binary suffix") {
+    val update = ("org.foo".g % ("log4cats", "log4cats_2.13").a % "1.1.1" %> "1.2.0").single
+      .copy(newerArtifactId = Some("log4dogs"))
+    val original = Map("pom.xml" -> s"""<groupId>org.foo</groupId>
+                                       |<artifactId>log4cats_$${scala.binary.version}</artifactId>
+                                       |<version>1.1.1</version>""".stripMargin)
+    val expected = Map("pom.xml" -> s"""<groupId>org.foo</groupId>
+                                       |<artifactId>log4dogs_$${scala.binary.version}</artifactId>
+                                       |<version>1.2.0</version>""".stripMargin)
+    runApplyUpdate(update, original, expected)
+  }
+
   // https://github.com/scala-steward-org/scala-steward/pull/566
   test("prevent exception: named capturing group is missing trailing '}'") {
     val update =


### PR DESCRIPTION
This allows updating Maven dependencies that use a property for the Scala binary suffix:
```xml
<groupId>org.foo</groupId>
<artifactId>log4cats_${scala.binary.version}</artifactId>
<version>1.1.1</version>

<!-- instead of -->

<groupId>org.foo</groupId>
<artifactId>log4cats_2.13</artifactId>
<version>1.1.1</version>
```