### PR TITLE
Update GitLab example

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -230,17 +230,18 @@ check:
     - mkdir --parents "$CI_PROJECT_DIR/.sbt" "$CI_PROJECT_DIR/.ivy2"
     - ln -sfT "$CI_PROJECT_DIR/.sbt"  "$HOME/.sbt"
     - ln -sfT "$CI_PROJECT_DIR/.ivy2" "$HOME/.ivy2"
-    - >-
-      /opt/docker/bin/scala-steward
-        --workspace  "$CI_PROJECT_DIR/workspace"
-        --process-timeout 30min
-        --do-not-fork
-        --repos-file "$CI_PROJECT_DIR/repos.md"
-        --repo-config "$CI_PROJECT_DIR/default.scala-steward.conf"
-        --git-author-email "${EMAIL}"
-        --forge-type "gitlab"
-        --forge-api-host "${CI_API_V4_URL}"
-        --forge-login "${LOGIN}"
+    - chmod +x "$CI_PROJECT_DIR/askpass.sh"
+    - >
+      /opt/docker/bin/scala-steward \
+        --workspace "$CI_PROJECT_DIR/workspace" \
+        --process-timeout "30min" \
+        --do-not-fork \
+        --repos-file "$CI_PROJECT_DIR/repos.md" \
+        --repo-config "$CI_PROJECT_DIR/default.scala-steward.conf" \
+        --git-author-email "${EMAIL}" \
+        --forge-type "gitlab" \
+        --forge-api-host "${CI_API_V4_URL}" \
+        --forge-login "${LOGIN}" \
         --git-ask-pass "$CI_PROJECT_DIR/askpass.sh"
   cache:
     key: scala-steward

--- a/modules/docs/mdoc/running.md
+++ b/modules/docs/mdoc/running.md
@@ -230,17 +230,18 @@ check:
     - mkdir --parents "$CI_PROJECT_DIR/.sbt" "$CI_PROJECT_DIR/.ivy2"
     - ln -sfT "$CI_PROJECT_DIR/.sbt"  "$HOME/.sbt"
     - ln -sfT "$CI_PROJECT_DIR/.ivy2" "$HOME/.ivy2"
-    - >-
-      /opt/docker/bin/scala-steward
-        --workspace  "$CI_PROJECT_DIR/workspace"
-        --process-timeout 30min
-        --do-not-fork
-        --repos-file "$CI_PROJECT_DIR/repos.md"
-        --repo-config "$CI_PROJECT_DIR/default.scala-steward.conf"
-        --git-author-email "${EMAIL}"
-        --forge-type "gitlab"
-        --forge-api-host "${CI_API_V4_URL}"
-        --forge-login "${LOGIN}"
+    - chmod +x "$CI_PROJECT_DIR/askpass.sh"
+    - >
+      /opt/docker/bin/scala-steward \
+        --workspace "$CI_PROJECT_DIR/workspace" \
+        --process-timeout "30min" \
+        --do-not-fork \
+        --repos-file "$CI_PROJECT_DIR/repos.md" \
+        --repo-config "$CI_PROJECT_DIR/default.scala-steward.conf" \
+        --git-author-email "${EMAIL}" \
+        --forge-type "gitlab" \
+        --forge-api-host "${CI_API_V4_URL}" \
+        --forge-login "${LOGIN}" \
         --git-ask-pass "$CI_PROJECT_DIR/askpass.sh"
   cache:
     key: scala-steward


### PR DESCRIPTION
Unfortunately, the current example does not work out of the box. 

### 1) Not enough permissions without `chmod +x "$CI_PROJECT_DIR/askpass.sh"`

```
java.io.IOException: Cannot run program "/builds/xxx/scala-steward/askpass.sh" (in directory "/builds/xxx/scala-steward/workspace"): error=13, Permission denied
```

### 2) Without trailing `\` the script line is not formatted correctly

```
/opt/docker/bin/scala-steward  # collapsed multi-line command
Missing expected flag --forge-login, or command (validate-repo-config)!
Usage:
  ....
```