### PR TITLE
Add sbt-circe-org to the list of modules that depend on sbt-typelevel

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -117,6 +117,7 @@ object HookExecutor {
   )
 
   private val sbtTypelevelModules = List(
+    (GroupId("io.circe"), ArtifactId("sbt-circe-org")),
     (GroupId("org.typelevel"), ArtifactId("sbt-typelevel")),
     (GroupId("org.http4s"), ArtifactId("sbt-http4s-org")),
     (GroupId("edu.gemini"), ArtifactId("sbt-lucuma")),


### PR DESCRIPTION
[sbt-circe-org](https://github.com/circe/sbt-circe-org) is similar to [sbt-htt4s-org](https://github.com/scala-steward-org/scala-steward/pull/2492#issuecomment-1026053287).