### PR TITLE
Add `Sha1.unsafeFrom`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/Sha1.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Sha1.scala
@@ -38,6 +38,9 @@ object Sha1 {
   def from(s: String): Either[Throwable, Sha1] =
     HexString.from(s).bimap(new Throwable(_), Sha1.apply)
 
+  def unsafeFrom(s: String): Sha1 =
+    from(s).fold(throw _, identity)
+
   implicit val sha1Eq: Eq[Sha1] =
     Eq.by(_.value.value)
 

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -7,7 +7,6 @@ import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data._
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
 import org.scalasteward.core.repoconfig._
@@ -17,7 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 
 object TestInstances {
   val dummySha1: Sha1 =
-    Sha1(HexString.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709"))
+    Sha1.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709")
 
   val dummyRepoCache: RepoCache =
     RepoCache(dummySha1, List.empty, Option.empty, Option.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
@@ -11,7 +11,6 @@ import org.scalasteward.core.application.Config.AzureReposCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
@@ -196,7 +195,7 @@ class AzureReposApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val obtained = azureReposApiAlg.getBranch(repo, Branch("refs/heads/main")).runA(state)
     val expected = BranchOut(
       Branch("main"),
-      CommitOut(Sha1(HexString.unsafeFrom("f55c9900528e548511fbba6874c873d44c5d714c")))
+      CommitOut(Sha1.unsafeFrom("f55c9900528e548511fbba6874c873d44c5d714c"))
     )
     assertIO(obtained, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
@@ -13,7 +13,6 @@ import org.scalasteward.core.application.Config.BitbucketCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git._
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
@@ -228,12 +227,12 @@ class BitbucketApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
   private val defaultBranch = BranchOut(
     master,
-    CommitOut(Sha1(HexString.unsafeFrom("07eb2a203e297c8340273950e98b2cab68b560c1")))
+    CommitOut(Sha1.unsafeFrom("07eb2a203e297c8340273950e98b2cab68b560c1"))
   )
 
   private val defaultCustomBranch = BranchOut(
     custom,
-    CommitOut(Sha1(HexString.unsafeFrom("12ea4559063c74184861afece9eeff5ca9d33db3")))
+    CommitOut(Sha1.unsafeFrom("12ea4559063c74184861afece9eeff5ca9d33db3"))
   )
 
   private val pullRequest =

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -11,7 +11,6 @@ import org.scalasteward.core.application.Config.BitbucketServerCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
@@ -206,7 +205,7 @@ class BitbucketServerApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] 
     val obtained = bitbucketServerApiAlg.getBranch(repo, main).runA(state)
     val expected = BranchOut(
       main,
-      CommitOut(Sha1(HexString.unsafeFrom("8d51122def5632836d1cb1026e879069e10a1e13")))
+      CommitOut(Sha1.unsafeFrom("8d51122def5632836d1cb1026e879069e10a1e13"))
     )
     assertIO(obtained, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/BranchOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/BranchOutTest.scala
@@ -2,7 +2,6 @@ package org.scalasteward.core.forge.data
 
 import io.circe.parser
 import munit.FunSuite
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import scala.io.Source
 
@@ -12,7 +11,7 @@ class BranchOutTest extends FunSuite {
     val expected = Right(
       BranchOut(
         Branch("master"),
-        CommitOut(Sha1(HexString.unsafeFrom("7fd1a60b01f91b314f59955a4e4d4e80d8edf11d")))
+        CommitOut(Sha1.unsafeFrom("7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"))
       )
     )
     assertEquals(parser.decode[BranchOut](input), expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
@@ -83,9 +83,7 @@ class GiteaApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
   test("getBranch") {
     val branch = Branch("main")
-    val sha1 = Sha1
-      .from("6b5ec7e2b6eaf45ecb654a9187e1f5874210fca3")
-      .getOrElse(throw new RuntimeException("impossible"))
+    val sha1 = Sha1.unsafeFrom("6b5ec7e2b6eaf45ecb654a9187e1f5874210fca3")
     giteaAlg
       .getBranch(repo, branch)
       .runA(state)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -13,7 +13,6 @@ import org.scalasteward.core.application.Config.GitHubCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
@@ -172,12 +171,12 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
   private val defaultBranch = BranchOut(
     Branch("master"),
-    CommitOut(Sha1(HexString("07eb2a203e297c8340273950e98b2cab68b560c1")))
+    CommitOut(Sha1.unsafeFrom("07eb2a203e297c8340273950e98b2cab68b560c1"))
   )
 
   private val defaultCustomBranch = BranchOut(
     Branch("custom"),
-    CommitOut(Sha1(HexString("12ea4559063c74184861afece9eeff5ca9d33db3")))
+    CommitOut(Sha1.unsafeFrom("12ea4559063c74184861afece9eeff5ca9d33db3"))
   )
 
   test("createForkOrGetRepo") {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
@@ -17,7 +17,6 @@ import org.scalasteward.core.data.{Repo, RepoData, UpdateData}
 import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.gitlab.GitLabJsonCodec._
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
@@ -135,7 +134,7 @@ class GitLabApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     Repo("scala-steward", "bar"),
     ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
     Branch("master"),
-    Sha1(Sha1.HexString.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
+    Sha1.unsafeFrom("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433"),
     Branch("update/logback-classic-1.2.3")
   )
   private val newPRData =
@@ -169,7 +168,7 @@ class GitLabApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val branchOut = gitlabApiAlg.getBranch(Repo("foo", "bar"), Branch("master")).runA(state)
     val expected = BranchOut(
       Branch("master"),
-      CommitOut(Sha1(HexString("07eb2a203e297c8340273950e98b2cab68b560c1")))
+      CommitOut(Sha1.unsafeFrom("07eb2a203e297c8340273950e98b2cab68b560c1"))
     )
     assertIO(branchOut, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -8,7 +8,6 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.forge.data.PullRequestState.Open
 import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestState}
-import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.pullRequestRepository
@@ -28,7 +27,7 @@ class PullRequestRepositoryTest extends FunSuite {
     ("org.typelevel".g % "cats-core".a % "1.0.0" %> "1.0.1").single
 
   private val url = uri"https://github.com/typelevel/cats/pull/3291"
-  private val sha1 = Sha1(HexString.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))
+  private val sha1 = Sha1.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8")
   private val number = PullRequestNumber(3291)
   private val branch = Branch("update")
 


### PR DESCRIPTION
`Sha1.unsafeFrom` makes it easier to create `Sha1`s in the tests.