### PR TITLE
Add simple instance-wide PR throttle

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ All command line arguments for the `scala-steward` application.
 ```
 Usage:
     scala-steward validate-repo-config
-    scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
+    scala-steward --workspace <file> --repos-file <file> [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>] [--pr-throttle-skip <duration>] [--pr-throttle-wait <duration>]
 
 
 
@@ -92,6 +92,10 @@ Options and flags:
         default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>
         Period of time a failed build won't be triggered again; default: 0days
+    --pr-throttle-skip <duration>
+        Skips creating PRs for the given duration after the last PR
+    --pr-throttle-wait <duration>
+        Waits for the given duration between creating two consequent PRs
 
 Subcommands:
     validate-repo-config

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -324,12 +324,12 @@ object Cli {
   }
 
   private val prThrottleSkip = {
-    val help = "" // TODO
+    val help = "Skips creating PRs for the given duration after the last PR"
     option[FiniteDuration]("pr-throttle-skip", help).orNone
   }
 
   private val prThrottleWait = {
-    val help = "" // TODO
+    val help = "Waits for the given duration between creating two consequent PRs"
     option[FiniteDuration]("pr-throttle-wait", help).orNone
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -323,6 +323,19 @@ object Cli {
       .withDefault(default)
   }
 
+  private val prThrottleSkip = {
+    val help = "" // TODO
+    option[FiniteDuration]("pr-throttle-skip", help).orNone
+  }
+
+  private val prThrottleWait = {
+    val help = "" // TODO
+    option[FiniteDuration]("pr-throttle-wait", help).orNone
+  }
+
+  private val pullRequestThrottleCfg: Opts[PullRequestThrottleCfg] =
+    (prThrottleSkip, prThrottleWait).mapN(PullRequestThrottleCfg.apply)
+
   private val configFile: Opts[File] =
     Opts.argument[File]()
 
@@ -350,7 +363,8 @@ object Cli {
     gitHubApp,
     urlCheckerTestUrls,
     defaultMavenRepo,
-    refreshBackoffPeriod
+    refreshBackoffPeriod,
+    pullRequestThrottleCfg
   ).mapN(Config.apply)
 
   val command: Command[StewardUsage] =

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -69,7 +69,8 @@ final case class Config(
     githubApp: Option[GitHubApp],
     urlCheckerTestUrls: Nel[Uri],
     defaultResolver: Resolver,
-    refreshBackoffPeriod: FiniteDuration
+    refreshBackoffPeriod: FiniteDuration,
+    pullRequestThrottleCfg: PullRequestThrottleCfg
 ) {
   def forgeUser[F[_]](implicit
       processAlg: ProcessAlg[F],
@@ -137,6 +138,11 @@ object Config {
   final case class ArtifactCfg(
       migrations: List[Uri],
       disableDefaults: Boolean
+  )
+
+  final case class PullRequestThrottleCfg(
+      skipFor: Option[FiniteDuration],
+      waitFor: Option[FiniteDuration]
   )
 
   sealed trait ForgeSpecificCfg extends Product with Serializable

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -42,6 +42,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     gitAlg: GitAlg[F],
     logger: Logger[F],
     pullRequestRepository: PullRequestRepository[F],
+    pullRequestThrottle: PullRequestThrottle[F],
     updateInfoUrlFinder: UpdateInfoUrlFinder[F],
     urlChecker: UrlChecker[F],
     F: Concurrent[F]
@@ -252,6 +253,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       _ <- forgeApiAlg
         .labelPullRequest(data.repo, pr.number, requestData.labels)
         .whenA(config.addLabels && requestData.labels.nonEmpty)
+      _ <- pullRequestThrottle.hit
       prData = PullRequestData[Id](
         pr.html_url,
         data.baseSha1,

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestThrottle.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestThrottle.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.nurture
+
+import cats.Monad
+import cats.effect.Async
+import cats.syntax.all._
+import org.scalasteward.core.application.Config.PullRequestThrottleCfg
+import org.scalasteward.core.util.{dateTime, DateTimeAlg, SimpleTimer}
+import org.typelevel.log4cats.Logger
+import scala.concurrent.duration.FiniteDuration
+
+final class PullRequestThrottle[F[_]](config: PullRequestThrottleCfg, timer: SimpleTimer[F])(
+    implicit
+    logger: Logger[F],
+    F: Monad[F]
+) {
+  def hit: F[Unit] =
+    config.skipFor.orElse(config.waitFor).fold(F.unit)(timer.start)
+
+  def throttle(f: F[Unit]): F[Unit] =
+    timer.remaining.flatMap {
+      case Some(remaining) if config.skipFor.isDefined =>
+        log("skipping", remaining)
+      case Some(remaining) if config.waitFor.isDefined =>
+        log("waiting", remaining) >> timer.await >> f
+      case _ => f
+    }
+
+  private def log(action: String, remaining: FiniteDuration): F[Unit] =
+    logger.info(s"PR throttle is active: $action for ${dateTime.showDuration(remaining)}")
+}
+
+object PullRequestThrottle {
+  def create[F[_]](config: PullRequestThrottleCfg)(implicit
+      dateTimeAlg: DateTimeAlg[F],
+      logger: Logger[F],
+      F: Async[F]
+  ): F[PullRequestThrottle[F]] =
+    SimpleTimer.create.map(new PullRequestThrottle(config, _))
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/SimpleTimer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/SimpleTimer.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.util
+
+import cats.data.OptionT
+import cats.effect.{Async, Ref}
+import cats.syntax.all._
+import scala.concurrent.duration.FiniteDuration
+
+final class SimpleTimer[F[_]](
+    currentDuration: Ref[F, Option[FiniteDuration]],
+    lastStart: Ref[F, Option[Timestamp]]
+)(implicit dateTimeAlg: DateTimeAlg[F], F: Async[F]) {
+  def start(duration: FiniteDuration): F[Unit] =
+    currentDuration.set(duration.some) >>
+      dateTimeAlg.currentTimestamp.map(Some.apply).flatMap(lastStart.set)
+
+  def remaining: F[Option[FiniteDuration]] =
+    OptionT(currentDuration.get).flatMap { duration =>
+      OptionT(lastStart.get).flatMapF { setTimestamp =>
+        dateTimeAlg.currentTimestamp.flatMap { now =>
+          val elapsed = setTimestamp.until(now)
+          if (elapsed < duration) F.pure((duration - elapsed).some)
+          else currentDuration.set(None).as(none[FiniteDuration])
+        }
+      }
+    }.value
+
+  def await: F[Unit] =
+    remaining.flatMap(_.fold(F.unit)(F.sleep))
+
+  def expired: F[Boolean] =
+    remaining.map(_.isEmpty)
+}
+
+object SimpleTimer {
+  def create[F[_]](implicit dateTimeAlg: DateTimeAlg[F], F: Async[F]): F[SimpleTimer[F]] =
+    for {
+      currentDuration <- Ref[F].of(Option.empty[FiniteDuration])
+      lastStart <- Ref[F].of(Option.empty[Timestamp])
+    } yield new SimpleTimer(currentDuration, lastStart)
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/util/SimpleTimerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/SimpleTimerTest.scala
@@ -1,0 +1,57 @@
+package org.scalasteward.core.util
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import scala.concurrent.duration._
+
+class SimpleTimerTest extends CatsEffectSuite {
+  implicit private val dateTimeAlg: DateTimeAlg[IO] = DateTimeAlg.create[IO]
+
+  test("'expired' is true without 'start'") {
+    for {
+      t <- SimpleTimer.create[IO]
+      expired <- t.expired
+      _ = assert(expired)
+    } yield ()
+  }
+
+  test("'expired' is true after 'start' if 'duration' is zero") {
+    for {
+      t <- SimpleTimer.create[IO]
+      _ <- t.start(0.seconds)
+      expired <- t.expired
+      _ = assert(expired)
+    } yield ()
+  }
+
+  test("'expired' is false after 'start' if 'duration' is non-zero") {
+    for {
+      t <- SimpleTimer.create[IO]
+      _ <- t.start(1.second)
+      expired <- t.expired
+      _ = assert(!expired)
+    } yield ()
+  }
+
+  test("'expired' is true after 'start' if 'duration' elapsed") {
+    for {
+      t <- SimpleTimer.create[IO]
+      d = 50.millis
+      _ <- t.start(d)
+      _ <- IO.sleep(d)
+      expired <- t.expired
+      _ = assert(expired)
+    } yield ()
+  }
+
+  test("'await' sleeps for 'duration' after 'start'") {
+    for {
+      t <- SimpleTimer.create[IO]
+      d = 50.millis
+      res <- dateTimeAlg.timed(t.start(d) >> t.await >> t.expired)
+      (expired, duration) = res
+      _ = assert(expired)
+      _ = assert(clue(duration) >= d)
+    } yield ()
+  }
+}


### PR DESCRIPTION
This adds a simple instance-wide PR throttle. It can be activated by adding the `--pr-throttle-skip=$duration` or `--pr-throttle-wait=$duration` command-line options. With `--pr-throttle-skip=$duration` Scala Steward will skip creating PRs for `$duration` after the last PR. With `--pr-throttle-wait=$duration` it actively waits until `$duration` is elapsed before creating the next PR.

Closes #2934, closes #2355