### PR TITLE
Use adoptopenjdk replacement temurin base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val dockerSettings = Def.settings(
   dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE"))
-    .getOrElse("adoptopenjdk/openjdk11:alpine"),
+    .getOrElse("eclipse-temurin:11-alpine"),
   dockerCommands ++= {
     val binDir = "/usr/local/bin"
     val sbtVer = sbtVersion.value

--- a/build.sbt
+++ b/build.sbt
@@ -348,13 +348,8 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
-      Cmd(
-        "COPY",
-        "--from=debian:stable-slim /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1"
-      ),
-      Cmd("RUN", "curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh"),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
-      Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
+      Cmd("RUN", s"$coursierBin install --install-dir $binDir scala-cli scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")
     )
   },

--- a/build.sbt
+++ b/build.sbt
@@ -343,12 +343,18 @@ lazy val dockerSettings = Def.settings(
     val millUrl =
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
+    val installScalaCliSteps = Seq(
+      "wget -q  https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli",
+      "chmod +x ./scala-cli",
+      "./scala-cli install-home --scala-cli-binary-path ./scala-cli",
+      "rm ./scala-cli"
+    )
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
-      Cmd("RUN", "curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh"),
+      Cmd("RUN", installScalaCliSteps.mkString(" && ")),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")

--- a/build.sbt
+++ b/build.sbt
@@ -344,7 +344,7 @@ lazy val dockerSettings = Def.settings(
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
     val installScalaCliStep = Seq(
-      "wget -q -O scala-cli.gz  https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
+      "wget -q -O scala-cli.gz https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
       "gunzip scala-cli.gz",
       "chmod +x scala-cli",
       "mv scala-cli /usr/bin/"

--- a/build.sbt
+++ b/build.sbt
@@ -343,18 +343,13 @@ lazy val dockerSettings = Def.settings(
     val millUrl =
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
-    val installScalaCliSteps = Seq(
-      "wget -q  https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli",
-      "chmod +x ./scala-cli",
-      "./scala-cli install-home --scala-cli-binary-path ./scala-cli",
-      "rm ./scala-cli"
-    )
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
-      Cmd("RUN", installScalaCliSteps.mkString(" && ")),
+      Cmd("COPY", "--from=debian:stable-slim /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1"),
+      Cmd("RUN", "curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh"),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")

--- a/build.sbt
+++ b/build.sbt
@@ -343,13 +343,20 @@ lazy val dockerSettings = Def.settings(
     val millUrl =
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
+    val installScalaCliStep = Seq(
+      "wget -q -O scala-cli.gz  https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
+      "gunzip scala-cli.gz",
+      "chmod +x scala-cli",
+      "mv scala-cli /usr/bin/"
+    ).mkString(" && ")
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
+      Cmd("RUN", installScalaCliStep),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
-      Cmd("RUN", s"$coursierBin install --install-dir $binDir scala-cli scalafix scalafmt"),
+      Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")
     )
   },

--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,10 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
-      Cmd("COPY", "--from=debian:stable-slim /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1"),
+      Cmd(
+        "COPY",
+        "--from=debian:stable-slim /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1"
+      ),
       Cmd("RUN", "curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh"),
       Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),


### PR DESCRIPTION
This changes the base image being used from [adoptopenjdk](https://hub.docker.com/r/adoptopenjdk/openjdk11) which has been [deprecated](https://github.com/AdoptOpenJDK/openjdk-docker) to it's replacement [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin).

This new base image will help get updates and resolve some security vulnerabilities.