### PR TITLE
github: add dedicated model for create PR body

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -17,8 +17,6 @@
 package org.scalasteward.core.forge.data
 
 import cats.syntax.all._
-import io.circe.Encoder
-import io.circe.generic.semiauto._
 import org.http4s.Uri
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.EditAttempt
@@ -43,9 +41,6 @@ final case class NewPullRequestData(
 )
 
 object NewPullRequestData {
-  implicit val newPullRequestDataEncoder: Encoder[NewPullRequestData] =
-    deriveEncoder
-
   def bodyFor(
       update: Update,
       edits: List[EditAttempt],

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -46,8 +46,9 @@ final class GitHubApiAlg[F[_]](
 
   /** https://developer.github.com/v3/pulls/#create-a-pull-request */
   override def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut] = {
+    val payload = PullRequestPayload.from(data)
     val create = client
-      .postWithBody[PullRequestOut, NewPullRequestData](url.pulls(repo), data, modify(repo))
+      .postWithBody[PullRequestOut, PullRequestPayload](url.pulls(repo), payload, modify(repo))
       .adaptErr(SecondaryRateLimitExceeded.fromThrowable)
 
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/PullRequestPayload.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/PullRequestPayload.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.forge.github
+
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import org.scalasteward.core.forge.data.NewPullRequestData
+import org.scalasteward.core.git.Branch
+
+final case class PullRequestPayload(
+    title: String,
+    body: String,
+    head: String,
+    base: Branch,
+    draft: Boolean
+)
+object PullRequestPayload {
+  implicit val encoder: Encoder[PullRequestPayload] = deriveEncoder
+
+  def from(newPullRequestData: NewPullRequestData): PullRequestPayload =
+    PullRequestPayload(
+      title = newPullRequestData.title,
+      body = newPullRequestData.body,
+      head = newPullRequestData.head,
+      base = newPullRequestData.base,
+      draft = newPullRequestData.draft
+    )
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -622,4 +622,89 @@ class NewPullRequestDataTest extends FunSuite {
 
     assertEquals(obtained, expected)
   }
+
+  test("from() should construct NewPullRequestData for groupped update") {
+    val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
+    val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
+    val update = Update.Grouped("my-group", None, List(update1, update2))
+
+    val data = UpdateData(
+      repoData = RepoData(
+        repo = Repo("foo", "bar"),
+        cache = dummyRepoCache,
+        config = RepoConfig(assignees = List("foo"), reviewers = List("bar"))
+      ),
+      fork = Repo("scala-steward", "bar"),
+      update = update,
+      baseBranch = Branch("main"),
+      baseSha1 = dummySha1,
+      updateBranch = Branch("update/logback-classic-1.2.3")
+    )
+    val obtained = from(
+      data,
+      "scala-steward:update/logback-classic-1.2.3",
+      labels = labelsFor(data.update)
+    )
+
+    val expectedBody =
+      s"""|Updates:
+          |
+          |* ch.qos.logback:logback-classic from 1.2.0 to 1.2.3
+          |* com.example:foo from 1.0.0 to 2.0.0
+          |
+          |
+          |I'll automatically update this PR to resolve conflicts as long as you don't change it yourself.
+          |
+          |If you have any feedback, just mention me in the comments below.
+          |
+          |Configure Scala Steward for your repository with a [`.scala-steward.conf`](https://github.com/scala-steward-org/scala-steward/blob/${org.scalasteward.core.BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.
+          |
+          |Have a fantastic day writing Scala!
+          |
+          |<details>
+          |<summary>Adjust future updates</summary>
+          |
+          |Add these to your `.scala-steward.conf` file to ignore future updates of these dependencies:
+          |```
+          |updates.ignore = [
+          |  { groupId = "ch.qos.logback", artifactId = "logback-classic" },
+          |  { groupId = "com.example", artifactId = "foo" }
+          |]
+          |```
+          |Or, add these to slow down future updates of these dependencies:
+          |```
+          |dependencyOverrides = [
+          |  {
+          |    pullRequests = { frequency = "30 days" },
+          |    dependency = { groupId = "ch.qos.logback", artifactId = "logback-classic" }
+          |  },
+          |  {
+          |    pullRequests = { frequency = "30 days" },
+          |    dependency = { groupId = "com.example", artifactId = "foo" }
+          |  }
+          |]
+          |```
+          |</details>
+          |
+          |labels: library-update, early-semver-patch, semver-spec-patch, early-semver-major, semver-spec-major, commit-count:0""".stripMargin
+
+    val expected = NewPullRequestData(
+      title = "Update for group my-group",
+      body = expectedBody,
+      head = "scala-steward:update/logback-classic-1.2.3",
+      base = Branch("main"),
+      labels = List(
+        "library-update",
+        "early-semver-patch",
+        "semver-spec-patch",
+        "early-semver-major",
+        "semver-spec-major",
+        "commit-count:0"
+      ),
+      assignees = List("foo"),
+      reviewers = List("bar")
+    )
+
+    assertEquals(obtained, expected)
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.forge.github
 import munit.FunSuite
 import io.circe.literal._
 import io.circe.syntax._
+import org.scalasteward.core.git.Branch
 
 class JsonCodecTest extends FunSuite {
   test("GitHubAssignees") {
@@ -35,5 +36,24 @@ class JsonCodecTest extends FunSuite {
       }"""
 
     assertEquals(reviewers, expected)
+  }
+
+  test("PullRequestPayload") {
+    val payload = PullRequestPayload(
+      title = "Update logback-classic to 1.2.3",
+      body = "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3",
+      head = "scala-steward:update/logback-classic-1.2.3",
+      base = Branch("main"),
+      draft = false
+    ).asJson
+    val expected =
+      json"""{
+        "title" : "Update logback-classic to 1.2.3",
+        "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3",
+        "head" : "scala-steward:update/logback-classic-1.2.3",
+        "base" : "main",
+        "draft" : false
+      }"""
+    assertEquals(payload, expected)
   }
 }


### PR DESCRIPTION
this refactoring replaces `NewPullRequestData` that was serialized into Json and used as a payload for POST /repos/{owner}/{repo}/pulls (creating PR on GitHub) because `NewPullRequestData` contains fields that are not processed by GitHub API (such as labels, assignees, reviewers). New model only has fields that are expected by GitHub API.