### PR TITLE
Check up to 5 nested project folders

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -54,7 +54,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
   private def metaBuildsCount(buildRootDir: File): F[Int] =
     fs2.Stream
       .iterate(buildRootDir / project)(_ / project)
-      .take(5L) // Use an upper bound for the meta-builds count to prevent DOS attacks.
+      .take(5L) // Use an upper bound for the meta-builds count to prevent DoS attacks.
       .evalMap(fileAlg.isDirectory)
       .takeWhile(identity)
       .compile

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -55,6 +55,8 @@ class BuildToolDispatcherTest extends FunSuite {
         ),
         Log("Get dependencies in . from sbt"),
         Cmd("read", s"$repoDir/project/build.properties"),
+        Cmd("test", "-d", s"$repoDir/project"),
+        Cmd("test", "-d", s"$repoDir/project/project"),
         Cmd("read", "classpath:StewardPlugin_1_0_0.scala"),
         Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin_1_0_0.scala"),
         Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin_1_0_0.scala"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -15,15 +15,18 @@ class SbtAlgTest extends FunSuite {
   private val workspace = workspaceAlg.rootDir.unsafeRunSync()
 
   test("getDependencies") {
-    val repo = Repo("typelevel", "cats")
+    val repo = Repo("sbt-alg", "test-1")
     val buildRoot = BuildRoot(repo, ".")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
-    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.3.6")
-    val initial = MockState.empty.copy(files = files)
+    val initial = MockState.empty
+      .addFiles(repoDir / "project" / "build.properties" -> "sbt.version=1.3.11")
+      .unsafeRunSync()
     val state = sbtAlg.getDependencies(buildRoot).runS(initial).unsafeRunSync()
     val expected = initial.copy(
       trace = Vector(
         Cmd("read", s"$repoDir/project/build.properties"),
+        Cmd("test", "-d", s"$repoDir/project"),
+        Cmd("test", "-d", s"$repoDir/project/project"),
         Cmd("read", "classpath:StewardPlugin_1_3_11.scala"),
         Cmd("write", s"$repoDir/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd("write", s"$repoDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -49,9 +49,9 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           repoDir.toString
         ),
         Cmd("read", s"$sbtBuildDir/project/build.properties"),
+        Cmd("test", "-d", s"$sbtBuildDir/project"),
         Cmd("read", "classpath:StewardPlugin_1_3_11.scala"),
         Cmd("write", s"$sbtBuildDir/project/scala-steward-StewardPlugin_1_3_11.scala"),
-        Cmd("write", s"$sbtBuildDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd(
           sbtBuildDir.toString,
           "firejail",
@@ -63,9 +63,8 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
-          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";$crossStewardDependencies"
         ),
-        Cmd("rm", "-rf", s"$sbtBuildDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd("rm", "-rf", s"$sbtBuildDir/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd("rm", "-rf", s"$sbtBuildDir")
       )


### PR DESCRIPTION
Some projects set up plugins in `project/project/plugins.sbt` and even in `project/project/project/plugins.sbt` (I worked on such a private project, so I can't share details, but such things do exists :wink:)

For example, Play and the sbt-web-build-base project put [sbt-buildinfo](https://github.com/sbt/sbt-buildinfo) in their `project/project/plugins.sbt` files:
* https://github.com/playframework/playframework/blob/main/project/project/buildinfo.sbt
* https://github.com/sbt/sbt-web-build-base/blob/master/project/project/buildinfo.sbt

However, as you can see, even though scala-steward is enabled and visiting those repos, that plugin never gets updated ([latest release is 0.11.0](https://github.com/sbt/sbt-buildinfo/releases), also see [maven central](https://repo1.maven.org/maven2/com/eed3si9n/sbt-buildinfo_2.12_1.0/0.11.0/))

Making scala-steward check and update those dependencies is actually pretty easy and straight forward:
We just need to set up the special `scala-steward-StewardPlugin_<version>.scala` plugin in the corresponding `project/project/project/project/` and `project/project/project/` folders so they are available as plugins for the parent "build" and then just enter those sub "build" projects via `reloadPlugins` again and also run `stewardDependencies` which also logs the dependencies of those projects.
Nothing special, just a couple of more lines logged and parsed by scala steward.
I also think the test that I adjusted in this pull request explains everything.

To make sure everything works 100% I set up following test repo:
 * https://github.com/mkurz/three-level-sbt-plugins-project

As you can see it has three levels of `project` folders including `plugins.sbt`:
* https://github.com/mkurz/three-level-sbt-plugins-project/tree/main/project/project/project
* https://github.com/mkurz/three-level-sbt-plugins-project/tree/main/project/project
* https://github.com/mkurz/three-level-sbt-plugins-project/tree/main/project

So I added outdated plugins to each `plugins.sbt` and the `build.sbt` and ran scala steward with this pull request applied [locally](https://github.com/scala-steward-org/scala-steward/blob/main/docs/running.md#running-scala-steward) and voilà, scala steward opened all expected pull requests:
* https://github.com/mkurz/three-level-sbt-plugins-project/pull/3/files
* https://github.com/mkurz/three-level-sbt-plugins-project/pull/4/files
* https://github.com/mkurz/three-level-sbt-plugins-project/pull/1/files
* https://github.com/mkurz/three-level-sbt-plugins-project/pull/2/files

BTW:
If you want to test out what the output of the sbt command ran by sbt looks like, you can check out the [`steward-plugin-file` branch](https://github.com/mkurz/three-level-sbt-plugins-project/tree/steward-plugin-file) of my test repo and ran the sbt command I show in the README. It is [exactly what scala steward runs](https://github.com/scala-steward-org/scala-steward/blob/f8bc50b768b371be40ba07799333ad631e881c55/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala#L139-L143) to [figure out the versions](https://github.com/scala-steward-org/scala-steward/blob/f8bc50b768b371be40ba07799333ad631e881c55/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala#L59-L60). (For this to `stewardDependencies` command to work I [manually added](https://github.com/mkurz/three-level-sbt-plugins-project/commit/3f1d38431c81e60622b064cfc609377e0f543d03) the `StewardPlugin_1_3_11.scala` files myself, see the README again).