### PR TITLE
Make sure remote is always called "origin" when cloning git repo

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -55,7 +55,9 @@ final class FileGitAlg[F[_]](config: GitCfg)(implicit
   override def clone(repo: File, url: Uri): F[Unit] =
     for {
       rootDir <- workspaceAlg.rootDir
-      _ <- git_("clone", url.toString, repo.pathAsString)(rootDir)
+      _ <- git_("clone", "-c", "clone.defaultRemoteName=origin", url.toString, repo.pathAsString)(
+        rootDir
+      )
     } yield ()
 
   override def cloneExists(repo: File): F[Boolean] =

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
@@ -37,7 +37,14 @@ class ForgeRepoAlgTest extends CatsEffectSuite {
     val expected = MockState.empty.copy(
       trace = Vector(
         Log("Clone scala-steward/datapackage"),
-        Cmd(gitCmd(config.workspace), "clone", forkUrl, repoDir.toString),
+        Cmd(
+          gitCmd(config.workspace),
+          "clone",
+          "-c",
+          "clone.defaultRemoteName=origin",
+          forkUrl,
+          repoDir.toString
+        ),
         Cmd(gitCmd(repoDir), "config", "user.email", "bot@example.org"),
         Cmd(gitCmd(repoDir), "config", "user.name", "Bot Doe"),
         Log("Synchronize with fthomas/datapackage"),
@@ -64,7 +71,14 @@ class ForgeRepoAlgTest extends CatsEffectSuite {
     val expected = MockState.empty.copy(
       trace = Vector(
         Log("Clone fthomas/datapackage"),
-        Cmd(gitCmd(config.workspace), "clone", parentUrl, repoDir.toString),
+        Cmd(
+          gitCmd(config.workspace),
+          "clone",
+          "-c",
+          "clone.defaultRemoteName=origin",
+          parentUrl,
+          repoDir.toString
+        ),
         Cmd(gitCmd(repoDir), "config", "user.email", "bot@example.org"),
         Cmd(gitCmd(repoDir), "config", "user.name", "Bot Doe"),
         Cmd(gitCmd(repoDir), "submodule", "update", "--init", "--recursive")


### PR DESCRIPTION
While working on #2995 I ran into a problem that prevented me from running scala steward locally on my machine.
That's because in my `~/.gitconfig` I configured that the default remote of a freshly cloned git repo should always be called `upstream`:
```
[clone]
        defaultRemoteName = upstream
```

However, if you grep through the scala-steward source code, you will see that scala-stewared heavily and basically everywhere and always relies on the remote's name to be `origin`.

So this pull requests make sure that when scala-steward clones a git repository the name of the remote is always called "origin" by overriding global git config (user) setting directly at the git-clone command.
With this fix I was able to run scala-steward locally, without it it always failed (or better: the git commands scala-steward calls failed in their sub-processes).

BTW, I had the same issue already with pacman (package manager for arch linux), where I applied the same fix:
* https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/19 (you can read more details about why I use `-c clone.defaultRemoteName=origin` in that merge request)
* that merge request of mine :point_up: is now be incorporated into https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/56

I am 100% sure this fix is correct (since I tested it locally :wink:). Thanks!