### PR TITLE
Allow to execute commands in MockEff

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
@@ -24,7 +24,9 @@ import org.scalasteward.core.io.process.{Args, SlurpOption, SlurpOptions}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class ProcessAlg[F[_]](config: ProcessCfg)(execImpl: Args => F[List[String]]) {
+final class ProcessAlg[F[_]](config: ProcessCfg)(
+    private[io] val execImpl: Args => F[List[String]]
+) {
   def exec(
       command: Nel[String],
       workingDirectory: File,

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -11,6 +11,7 @@ import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 final case class MockState(
     trace: Vector[TraceEntry],
     commandOutputs: Map[List[String], Either[Throwable, List[String]]],
+    execCommands: Boolean,
     files: Map[File, String],
     uris: Map[Uri, String],
     clientResponses: HttpApp[MockEff]
@@ -41,6 +42,7 @@ object MockState {
     MockState(
       trace = Vector.empty,
       commandOutputs = Map.empty,
+      execCommands = false,
       files = Map.empty,
       uris = Map.empty,
       clientResponses = HttpApp.notFound


### PR DESCRIPTION
This actually executes commands in `MockProcessAlg` (in addition to recording them in `MockState#trace`) if `MockState#execCommands` is `true` and there is no predefined output in `MockState#commandOutputs`.

This can be useful if certain tests should actually run external processes. For example if we want to execute `git grep` in `RewriteTest` as mentioned in https://github.com/scala-steward-org/scala-steward/pull/2994#issuecomment-1455174931.