### PR TITLE
Added --power to scala-cli export command

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
@@ -55,6 +55,7 @@ final class ScalaCliAlg[F[_]](implicit
         "scala-cli",
         "--power",
         "export",
+        "--power",
         "--sbt",
         "--output",
         exportDir,

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -43,6 +43,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           "scala-cli",
           "--power",
           "export",
+          "--power",
           "--sbt",
           "--output",
           "tmp-sbt-build-for-scala-steward",


### PR DESCRIPTION
I noticed [some recent failures](https://github.com/typelevel/steward/actions) in the typelevel/steward project and looking at the logs it seems that they're due to the fact that since a while ago Scala-CLI [requires power mode](https://github.com/VirtusLab/scala-cli/blob/main/website/docs/guides/intro.md#%EF%B8%8F---power-mode-guides) to export a project.
