### PR TITLE
Reformat changed files in all build roots

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -53,9 +53,6 @@ final class BuildToolDispatcher[F[_]](implicit
       buildTools.traverse_(_.runMigration(buildRoot, migration))
     })
 
-  private def getBuildRoots(repo: Repo, repoConfig: RepoConfig): List[BuildRoot] =
-    repoConfig.buildRootsOrDefault.map(buildRootCfg => BuildRoot(repo, buildRootCfg.relativePath))
-
   private val allBuildTools = List(mavenAlg, millAlg, sbtAlg, scalaCliAlg)
   private val fallbackBuildTool = List(sbtAlg)
 
@@ -69,5 +66,5 @@ final class BuildToolDispatcher[F[_]](implicit
       repo: Repo,
       repoConfig: RepoConfig
   ): F[List[(BuildRoot, List[BuildToolAlg[F]])]] =
-    getBuildRoots(repo, repoConfig).traverse(findBuildTools)
+    repoConfig.buildRootsOrDefault(repo).traverse(findBuildTools)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -118,8 +118,10 @@ final class EditAlg[F[_]](implicit
     val reformat =
       data.config.scalafmt.runAfterUpgradingOrDefault && data.cache.dependsOn(List(scalafmtModule))
     F.whenA(reformat) {
-      logger.attemptWarn.log_("Reformatting changed files failed") {
-        scalafmtAlg.reformatChanged(data.repo)
+      data.config.buildRootsOrDefault(data.repo).traverse_ { buildRoot =>
+        logger.attemptWarn.log_(s"Reformatting changed files failed in ${buildRoot.relativePath}") {
+          scalafmtAlg.reformatChanged(buildRoot)
+        }
       }
     }
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -22,6 +22,8 @@ import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.syntax._
+import org.scalasteward.core.buildtool.BuildRoot
+import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.hooks.PostUpdateHook
 
 final case class RepoConfig(
@@ -36,10 +38,11 @@ final case class RepoConfig(
     reviewers: List[String] = List.empty,
     dependencyOverrides: List[GroupRepoConfig] = List.empty
 ) {
-  def buildRootsOrDefault: List[BuildRootConfig] =
+  def buildRootsOrDefault(repo: Repo): List[BuildRoot] =
     buildRoots
       .map(_.filterNot(_.relativePath.contains("..")))
       .getOrElse(List(BuildRootConfig.repoRoot))
+      .map(cfg => BuildRoot(repo, cfg.relativePath))
 
   def postUpdateHooksOrDefault: List[PostUpdateHook] =
     postUpdateHooks.getOrElse(Nil).map(_.toHook)

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import io.circe.ParsingFailure
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.data.{Repo, Scope, Version}
+import org.scalasteward.core.data.{Scope, Version}
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.{opts, parseScalafmtConf}
@@ -52,9 +52,9 @@ final class ScalafmtAlg[F[_]](config: Config)(implicit
       .map(version => Scope(List(scalafmtDependency(version)), List(config.defaultResolver)))
       .value
 
-  def reformatChanged(repo: Repo): F[Unit] =
+  def reformatChanged(buildRoot: BuildRoot): F[Unit] =
     for {
-      repoDir <- workspaceAlg.repoDir(repo)
+      repoDir <- workspaceAlg.buildRootDir(buildRoot)
       cmd = Nel.of(scalafmtBinary, opts.nonInteractive) ++ opts.modeChanged
       _ <- processAlg.exec(cmd, repoDir, slurpOptions = SlurpOptions.ignoreBufferOverflow)
     } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -243,8 +243,9 @@ class RepoConfigAlgTest extends FunSuite {
   }
 
   test("build root with '..'") {
+    val repo = Repo("typelevel", "cats")
     val content = """buildRoots = [ "../../../etc" ]"""
-    val config = RepoConfigAlg.parseRepoConfig(content).map(_.buildRootsOrDefault)
+    val config = RepoConfigAlg.parseRepoConfig(content).map(_.buildRootsOrDefault(repo))
     assertEquals(config, Right(Nil))
   }
 


### PR DESCRIPTION
`ScalafmtAlg#reformatChanged` is working on the `Repo`-level but we're reading the Scalafmt version in `ScalafmtAlg#getScalafmtVersion` on the `BuildRoot`-level. This means we detect a dependency on Scalafmt in a build root but when we reformat changed files, we'll do it in the root directory of the repo. If the root directory contains no `.scalafmt.conf`, reformating fails with an error as shown in
https://github.com/scala-steward-org/scala-steward-action/issues/475#issuecomment-1466314269

With this change we now run Scalafmt in all build roots instead of only the root directory. This fixes the error mentioned above. In the future we could restrict running Scalafmt in only those build roots where we did changes by matching the `updateReplacements` (that have been determined in `EditAlg`) with the build roots.