### PR TITLE
Adding artifact migrations for async-utils

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -516,4 +516,24 @@ changes = [
     artifactIdBefore = mysql-connector-java
     artifactIdAfter = mysql-connector-j
   },
+  {
+    groupIdAfter = com.dwolla
+    artifactIdBefore = async-utils-finagle-ce3
+    artifactIdAfter = async-utils-finagle
+  },
+  {
+    groupIdAfter = com.dwolla
+    artifactIdBefore = async-utils-core-ce3
+    artifactIdAfter = async-utils-core
+  },
+  {
+    groupIdAfter = com.dwolla
+    artifactIdBefore = async-utils-ce3
+    artifactIdAfter = async-utils
+  },
+  {
+    groupIdAfter = com.dwolla
+    artifactIdBefore = async-utils-twitter-ce3
+    artifactIdAfter = async-utils-twitter
+  },
 ]


### PR DESCRIPTION
Changed in [this PR](https://github.com/Dwolla/async-utils-twitter/commit/ca7e954bd5d5cc07fcd1645be35f4931e5ebaf58#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91)--`cats-effect` 2 support was removed.