### PR TITLE
Check merge request status with backoff

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
@@ -16,8 +16,9 @@
 
 package org.scalasteward.core.forge
 
+import cats.effect.Temporal
 import cats.syntax.all._
-import cats.{Applicative, MonadThrow, Parallel}
+import cats.{Applicative, Parallel}
 import org.http4s.headers.Authorization
 import org.http4s.{BasicCredentials, Header, Request}
 import org.scalasteward.core.application.Config
@@ -42,7 +43,7 @@ object ForgeSelection {
   )(implicit
       httpJsonClient: HttpJsonClient[F],
       logger: Logger[F],
-      F: MonadThrow[F]
+      temporal: Temporal[F]
   ): ForgeApiAlg[F] = {
     val auth = (_: Any) => authenticate(forgeCfg.tpe, user)
     forgeSpecificCfg match {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
@@ -43,7 +43,7 @@ object ForgeSelection {
   )(implicit
       httpJsonClient: HttpJsonClient[F],
       logger: Logger[F],
-      temporal: Temporal[F]
+      F: Temporal[F]
   ): ForgeApiAlg[F] = {
     val auth = (_: Any) => authenticate(forgeCfg.tpe, user)
     forgeSpecificCfg match {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -218,7 +218,10 @@ final class GitLabApiAlg[F[_]: Parallel](
         .flatMap {
           case mr if mr.mergeStatus =!= GitLabMergeStatus.Checking => F.pure(mr)
           case _ if retries > 0 =>
-            temporal.sleep(initialDelay) >> waitForMergeRequestStatus(
+            logger.info(
+              s"Merge request is still in '${GitLabMergeStatus.Checking}' state. We will check merge request status in $initialDelay again. " +
+                s"Remaining retries count is $retries"
+            ) >> temporal.sleep(initialDelay) >> waitForMergeRequestStatus(
               number,
               retries - 1,
               initialDelay * backoffMultiplier
@@ -226,7 +229,7 @@ final class GitLabApiAlg[F[_]: Parallel](
           case other =>
             logger
               .warn(
-                s"Exhausted all retires while waiting for merge request status. Last known status is ${other.mergeStatus}"
+                s"Exhausted all retires while waiting for merge request status. Last known status is '${other.mergeStatus}'"
               )
               .as(other)
         }


### PR DESCRIPTION
I am using `--gitlab-merge-when-pipeline-succeeds` to automatically merge scala-steward merge requests, however, today scala-steward failed to merge a merge request which was `Ready to merge` state.

Only thing I could see in the logs was the following;
 ```
 Unable to automatically merge ...
 ```
 
Looking at the code, this log would only be printed when merge request status is NOT `can_be_merged`. I believe the underlying issue is that scala-steward doesn't have any sort of back-off strategy while checking merge request status. Scala-steward probably exhausted all retires in a very short period of time while merge request status was still in "Checking" state therefore scala-steward didn't even attempt to merge the merge request at the end.

In this pull request, I added basic back-off between the checks which I believe should fix the issue I had today.

Let me know what you think.

