### PR TITLE
Fixed retry and duplicated replacements

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -115,7 +115,7 @@ object Context {
       userAgent <- Resource.eval(F.fromEither(`User-Agent`.parse(1)(userAgentString)))
       middleware = ClientConfiguration
         .setUserAgent[F](userAgent)
-        .andThen(ClientConfiguration.retryAfter[F](maxAttempts = 5))
+        .andThen(ClientConfiguration.withRetry[F](maxAttempts = 5))
       defaultClient <- ClientConfiguration.build(
         ClientConfiguration.BuilderMiddleware.default,
         middleware

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -106,7 +106,7 @@ final class EditAlg[F[_]](implicit
       repoDir <- workspaceAlg.repoDir(data.repo)
       replacementsByPath = updateReplacements.groupBy(_.position.path).toList
       _ <- replacementsByPath.traverse { case (path, replacements) =>
-        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements))
+        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements.toSet))
       }
       _ <- reformatChangedFiles(data)
       msgTemplate = data.config.commits.messageOrDefault

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
@@ -41,10 +41,10 @@ object Substring {
   final case class Replacement(position: Position, replacement: String)
 
   object Replacement {
-    def applyAll(replacements: List[Replacement])(source: String): String = {
+    def applyAll(replacements: Set[Replacement])(source: String): String = {
       var start = 0
       val sb = new java.lang.StringBuilder(source.length)
-      replacements.sortBy(_.position.start).foreach { r =>
+      replacements.toSeq.sortBy(_.position.start).foreach { r =>
         val before = source.substring(start, r.position.start)
         start = r.position.start + r.position.value.length
         sb.append(before).append(r.replacement)

--- a/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
@@ -5,21 +5,28 @@ import cats.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosInt
 import munit.CatsEffectSuite
-import org.http4s.HttpRoutes
+import org.http4s._
 import org.http4s.client._
+import org.http4s.client.dsl.io._
+import org.http4s.dsl.io._
+import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.headers.{`Retry-After`, `User-Agent`, Location}
 import org.http4s.implicits._
 import org.typelevel.ci._
+
+import java.time.Instant
 import scala.concurrent.duration._
+import scala.util.Try
 
 class ClientConfigurationTest extends CatsEffectSuite {
 
+  private val previousEpochSecond = Instant.now().minusSeconds(1).getEpochSecond
+  private val nextEpochSecond = Instant.now().plusSeconds(1).getEpochSecond
   private val userAgentValue = "my-user-agent"
   private val dummyUserAgent =
     `User-Agent`.parse(1)(userAgentValue).getOrElse(fail("unable to create user agent"))
 
-  private val routes: HttpRoutes[IO] = {
-    import org.http4s.dsl.io._
+  private val routes: HttpRoutes[IO] =
     HttpRoutes.of[IO] {
       case req @ GET -> Root / "user-agent" =>
         req.headers.get(ci"user-agent") match {
@@ -45,15 +52,22 @@ class ClientConfigurationTest extends CatsEffectSuite {
           case Some(attempt) if attempt >= 2 =>
             Ok()
           case _ =>
-            Forbidden().map(_.putHeaders(`Retry-After`.fromLong(1)))
+            val resetHeader =
+              ParseResult.success(Header.Raw(ci"X-Ratelimit-Reset", s"$nextEpochSecond"))
+            Forbidden().map(_.putHeaders(`Retry-After`.fromLong(1), resetHeader))
+        }
+      case req @ GET -> Root / "rate-limit-reset" / epochSecondsParam =>
+        req.headers.get(ci"X-Attempt").flatMap(_.head.value.toIntOption) match {
+          case Some(attempt) if attempt >= 2 => Ok()
+          case _ =>
+            val seconds = Try(epochSecondsParam.toLong).getOrElse(0L)
+            val resetHeader =
+              ParseResult.success(Header.Raw(ci"X-Ratelimit-Reset", seconds.toString))
+            Forbidden().map(_.putHeaders(resetHeader))
         }
     }
-  }
 
   test("setUserAgent add a specific user agent to requests") {
-    import org.http4s.Method._
-    import org.http4s.client.dsl.io._
-
     val initialClient = Client.fromHttpApp[IO](routes.orNotFound)
     val setUserAgent = ClientConfiguration.setUserAgent[IO](dummyUserAgent)
     val newClient = setUserAgent(initialClient)
@@ -71,10 +85,6 @@ class ClientConfigurationTest extends CatsEffectSuite {
   }
 
   test("disableFollowRedirect does not follow redirect") {
-    import org.http4s.Method._
-    import org.http4s.ember.server._
-    import org.http4s.client.dsl.io._
-
     val regularClient = ClientConfiguration.build[IO](
       ClientConfiguration.BuilderMiddleware.default,
       ClientConfiguration.setUserAgent(dummyUserAgent)
@@ -101,26 +111,32 @@ class ClientConfigurationTest extends CatsEffectSuite {
     test.assertEquals((400, 302))
   }
 
-  test("retries on retry-after response header") {
-    import org.http4s.Method._
-    import org.http4s.client.dsl.io._
-
-    def clientWithMaxAttempts(maxAttempts: PosInt): Client[IO] = {
-      val initialClient = Client.fromHttpApp[IO](routes.orNotFound)
-      val retryAfter = ClientConfiguration.retryAfter[IO](maxAttempts)
-      retryAfter(initialClient)
-    }
-
-    val notEnoughRetries = clientWithMaxAttempts(1)
-      .run(GET(uri"/retry-after"))
-      .use(r => r.status.code.pure[IO])
-      .assertEquals(403)
-
-    val exactlyEnoughRetries = clientWithMaxAttempts(2)
-      .run(GET(uri"/retry-after"))
-      .use(r => r.status.code.pure[IO])
-      .assertEquals(200)
-
+  test("retries on retry-after response header even though 'X-Ratelimit-Reset' exists") {
+    val notEnoughRetries = request(uri"/retry-after", 1).assertEquals(403)
+    val exactlyEnoughRetries = request(uri"/retry-after", 2).assertEquals(200)
     notEnoughRetries.flatMap(_ => exactlyEnoughRetries)
+  }
+
+  test("retries with the value mentioned in 'X-Ratelimit-Reset' in the absense of 'Retry-After'") {
+    val uri = Uri.unsafeFromString(s"/rate-limit-reset/$nextEpochSecond")
+    val notEnoughRetries = request(uri, 1).assertEquals(403)
+    val exactlyEnoughRetries = request(uri, 2).assertEquals(200)
+    notEnoughRetries.flatMap(_ => exactlyEnoughRetries)
+  }
+
+  test("retries after 1 second when the given value in 'X-Ratelimit-Reset' elapsed") {
+    val uri: Uri = Uri.unsafeFromString(s"/rate-limit-reset/$previousEpochSecond")
+    val notEnoughRetries = request(uri, 1).assertEquals(403)
+    val exactlyEnoughRetries = request(uri, 2).assertEquals(200)
+    notEnoughRetries.flatMap(_ => exactlyEnoughRetries)
+  }
+
+  private def request(uri: Uri, attempts: PosInt): IO[Int] =
+    clientWithMaxAttempts(attempts).run(GET(uri)).use(r => r.status.code.pure[IO])
+
+  private def clientWithMaxAttempts(maxAttempts: PosInt): Client[IO] = {
+    val initialClient = Client.fromHttpApp[IO](routes.orNotFound)
+    val withRetry = ClientConfiguration.withRetry[IO](maxAttempts)
+    withRetry(initialClient)
   }
 }


### PR DESCRIPTION
For good amount of time our `scala-steward` jobs are failing. Following changes fixed in our case, so creating the PR.

#### New Retry logic is

- If `Retry-After` header present, then use the header value to retry (this was there before)
- otherwise retry request after time specified by `X-Ratelimit-Reset` header. Header value is UTC epoch seconds. Here I took some assumptions
     - if the difference between header value and current UTC epoch seconds is more than 60 seconds then I retry after `60 seconds`. That means max wait time would be `60 seconds`. 
     - if the difference is negative then I retry after 1 second. That means min wait time is `1 second` 
- if neither of the headers present, wait `1.second`

#### Another issue 

If there are duplicated replacements then the job was failing. This is relatively very easy fix, use `Set` instead of `List`