### PR TITLE
Fixed throwing StringIndexOutOfBoundsException

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -106,7 +106,7 @@ final class EditAlg[F[_]](implicit
       repoDir <- workspaceAlg.repoDir(data.repo)
       replacementsByPath = updateReplacements.groupBy(_.position.path).toList
       _ <- replacementsByPath.traverse { case (path, replacements) =>
-        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements))
+        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements.toSet))
       }
       _ <- reformatChangedFiles(data)
       msgTemplate = data.config.commits.messageOrDefault

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -106,7 +106,7 @@ final class EditAlg[F[_]](implicit
       repoDir <- workspaceAlg.repoDir(data.repo)
       replacementsByPath = updateReplacements.groupBy(_.position.path).toList
       _ <- replacementsByPath.traverse { case (path, replacements) =>
-        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements.toSet))
+        fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll(replacements))
       }
       _ <- reformatChangedFiles(data)
       msgTemplate = data.config.commits.messageOrDefault

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
@@ -41,10 +41,10 @@ object Substring {
   final case class Replacement(position: Position, replacement: String)
 
   object Replacement {
-    def applyAll(replacements: Set[Replacement])(source: String): String = {
+    def applyAll(replacements: List[Replacement])(source: String): String = {
       var start = 0
       val sb = new java.lang.StringBuilder(source.length)
-      replacements.toSeq.sortBy(_.position.start).foreach { r =>
+      replacements.distinctBy(_.position.start).sortBy(_.position.start).foreach { r =>
         val before = source.substring(start, r.position.start)
         start = r.position.start + r.position.value.length
         sb.append(before).append(r.replacement)

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
@@ -41,10 +41,10 @@ object Substring {
   final case class Replacement(position: Position, replacement: String)
 
   object Replacement {
-    def applyAll(replacements: List[Replacement])(source: String): String = {
+    def applyAll(replacements: Set[Replacement])(source: String): String = {
       var start = 0
       val sb = new java.lang.StringBuilder(source.length)
-      replacements.sortBy(_.position.start).foreach { r =>
+      replacements.toSeq.sortBy(_.position.start).foreach { r =>
         val before = source.substring(start, r.position.start)
         start = r.position.start + r.position.value.length
         sb.append(before).append(r.replacement)


### PR DESCRIPTION
Fixed the issue that is throwing StringIndexOutOfBoundsException when duplicated replacements are used to edit the file. 

In other words, trying to replace single dependency more than once which is not valid.