### PR TITLE
Use Git's `--trailer` for commit message trailers

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -74,7 +74,7 @@ final class HookExecutor[F[_]](implicit
       }
       commitMessage = hook
         .commitMessage(update)
-        .withParagraph(s"Executed command: ${hook.command.mkString_(" ")}")
+        .appendParagraph(s"Executed command: ${hook.command.mkString_(" ")}")
       maybeHookCommit <- gitAlg.commitAllIfDirty(repo, commitMessage)
       maybeBlameIgnoreCommit <-
         maybeHookCommit.flatTraverse(addToGitBlameIgnoreRevs(repo, repoDir, hook, _, commitMessage))

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -26,16 +26,14 @@ final case class CommitMsg(
     body: List[String] = Nil,
     coAuthoredBy: List[Author] = Nil
 ) {
-  def toNel: Nel[String] =
-    Nel(title, body ++ trailers)
+  def paragraphs: Nel[String] =
+    Nel(title, body)
 
-  def withParagraph(paragraph: String): CommitMsg =
+  def appendParagraph(paragraph: String): CommitMsg =
     copy(body = body :+ paragraph)
 
-  private def trailers: Option[String] = {
-    val lines = coAuthoredBy.map(author => s"Co-authored-by: ${author.show}")
-    Nel.fromList(lines).map(_.mkString_("\n"))
-  }
+  def trailers: List[(String, String)] =
+    coAuthoredBy.map(author => ("Co-authored-by", author.show))
 }
 
 object CommitMsg {

--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -64,8 +64,9 @@ final class FileGitAlg[F[_]](config: GitCfg)(implicit
     fileAlg.isDirectory(repo / ".git")
 
   override def commitAll(repo: File, message: CommitMsg): F[Commit] = {
-    val messages = message.toNel.foldMap(m => List("-m", m))
-    git_("commit" :: "--all" :: sign :: messages: _*)(repo) >>
+    val messages = message.paragraphs.foldMap(m => List("-m", m))
+    val trailers = message.trailers.foldMap { case (k, v) => List("--trailer", s"$k=$v") }
+    git_("commit" :: "--all" :: sign :: messages ++ trailers: _*)(repo) >>
       latestSha1(repo, Branch.head).map(Commit.apply)
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.edit.scalafix
 import io.circe.config.parser
 import munit.FunSuite
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.{ExecutionOrder, Target}
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.git.{Author, CommitMsg}
 
 class ScalafixMigrationTest extends FunSuite {
   test("commitMessage") {
@@ -18,11 +18,13 @@ class ScalafixMigrationTest extends FunSuite {
          |  authors: ["Jane Doe <jane@example.com>"]
          |}""".stripMargin
     )
-    val obtained = migration.map(_.commitMessage(Right(())).toNel)
-    val expected = Nel.of(
-      "Applied Scalafix rule(s) github:typelevel/cats/Cats_v2_2_0?sha=v2.2.0",
-      "See https://github.com/typelevel/cats/blob/v2.2.0/scalafix/README.md#migration-to-cats-v220 for details",
-      "Co-authored-by: Jane Doe <jane@example.com>"
+    val obtained = migration.map(_.commitMessage(Right(())))
+    val expected = CommitMsg(
+      title = "Applied Scalafix rule(s) github:typelevel/cats/Cats_v2_2_0?sha=v2.2.0",
+      body = List(
+        "See https://github.com/typelevel/cats/blob/v2.2.0/scalafix/README.md#migration-to-cats-v220 for details"
+      ),
+      coAuthoredBy = List(Author("Jane Doe", "jane@example.com"))
     )
     assertEquals(obtained, Right(expected))
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -108,10 +108,8 @@ class FileGitAlgTest extends CatsEffectSuite {
       c1 <- ioGitAlg.containsChanges(repo)
       _ <- ioFileAlg.writeFile(repo / "test.txt", "hello world")
       c2 <- ioGitAlg.containsChanges(repo)
-      _ <- ioGitAlg.commitAllIfDirty(
-        repo,
-        CommitMsg("Modify test.txt", coAuthoredBy = List(Author("name", "email")))
-      )
+      m2 = CommitMsg("Modify test.txt", coAuthoredBy = List(Author("name", "email")))
+      _ <- ioGitAlg.commitAllIfDirty(repo, m2)
       c3 <- ioGitAlg.containsChanges(repo)
       _ = assertEquals((c1, c2, c3), (false, true, false))
     } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -108,7 +108,10 @@ class FileGitAlgTest extends CatsEffectSuite {
       c1 <- ioGitAlg.containsChanges(repo)
       _ <- ioFileAlg.writeFile(repo / "test.txt", "hello world")
       c2 <- ioGitAlg.containsChanges(repo)
-      _ <- ioGitAlg.commitAllIfDirty(repo, CommitMsg("Modify test.txt"))
+      _ <- ioGitAlg.commitAllIfDirty(
+        repo,
+        CommitMsg("Modify test.txt", coAuthoredBy = List(Author("name", "email")))
+      )
       c3 <- ioGitAlg.containsChanges(repo)
       _ = assertEquals((c1, c2, c3), (false, true, false))
     } yield ()


### PR DESCRIPTION
This uses `git commit`'s [`--trailer` option](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---trailerlttokengtltvaluegt) for commit message trailers instead of formatting and appending them as last `-m` argument ourself. The advantage is that Git takes care of formatting them properly and it is aware of them now. I guess this better composes with other Git options that add trailer(s) themself ([`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) for example).

This PR also contains two renamings:
 * `toNel` -> `paragraphs`
 * `withParagraph` -> `appendParagraph`