### PR TITLE
Update to changes in coursier 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val core = myCrossProject("core")
       Dependencies.circeRefined,
       Dependencies.commonsIo,
       Dependencies.coursierCore,
+      Dependencies.coursierSbtMaven,
       Dependencies.cron4sCore,
       Dependencies.decline,
       Dependencies.fs2Core,

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -124,7 +124,7 @@ object CoursierAlg {
     resolver match {
       case Resolver.MavenRepository(_, location, creds, headers) =>
         val authentication = toCoursierAuthentication(creds, headers)
-        Right(coursier.maven.MavenRepository.apply(location, authentication))
+        Right(coursier.maven.SbtMavenRepository.apply(location, authentication))
       case Resolver.IvyRepository(_, pattern, creds, headers) =>
         val authentication = toCoursierAuthentication(creds, headers)
         coursier.ivy.IvyRepository.parse(pattern, authentication = authentication)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,9 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeGeneric.revision
   val circeRefined = "io.circe" %% "circe-refined" % circeGeneric.revision
   val commonsIo = "commons-io" % "commons-io" % "2.11.0"
-  val coursierCore = "io.get-coursier" %% "coursier" % "2.1.0-RC5"
+  val coursierCore = "io.get-coursier" %% "coursier" % "2.1.0"
+  val coursierSbtMaven =
+    "io.get-coursier" %% "coursier-sbt-maven-repository" % coursierCore.revision
   val cron4sCore = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.1"
   val decline = "com.monovore" %% "decline" % "2.4.1"
   val disciplineMunit = "org.typelevel" %% "discipline-munit" % "1.0.9"


### PR DESCRIPTION
Since https://github.com/coursier/coursier/pull/2633 handling for resolving sbt plugins from Maven repositories got extracted into `SbtMavenRepository` in the `coursier-sbt-maven-repository` module

closes: #3011 