### PR TITLE
Don't install Coursier via `git.io/coursier-cli`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -358,7 +358,7 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -fL $millUrl > $millBin && chmod +x $millBin"),
       Cmd("RUN", installScalaCliStep),
-      Cmd("RUN", s"curl -fL $coursierUrl | gzip -d > $coursierBin && chmod +x $coursierBin"),
+      Cmd("RUN", s"curl -fL $coursierUrl | gzip -cd > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")
     )

--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,7 @@ lazy val dockerSettings = Def.settings(
   dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE"))
     .getOrElse("eclipse-temurin:11-alpine"),
   dockerCommands ++= {
-    val curl = "curl -fL --no-progress-meter --output"
+    val curl = "curl -fL --output"
     val binDir = "/usr/local/bin"
     val sbtVer = sbtVersion.value
     val sbtTgz = s"sbt-$sbtVer.tgz"

--- a/build.sbt
+++ b/build.sbt
@@ -368,7 +368,8 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn"),
       // Ensure binaries are in PATH
-      Cmd("RUN", "which coursier maven mill node npm sbt scala-cli scalafix scalafmt yarn")
+      Cmd("RUN", "echo $PATH"),
+      Cmd("RUN", "which coursier mill mvn node npm sbt scala-cli scalafix scalafmt yarn")
     )
   },
   Docker / packageName := s"fthomas/${name.value}",

--- a/build.sbt
+++ b/build.sbt
@@ -346,11 +346,9 @@ lazy val dockerSettings = Def.settings(
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
     val installCoursierStep = Seq(
-      s"curl -fL --output $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz",
+      s"curl -fL --output $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux-static.gz",
       s"gunzip $coursierBin.gz",
-      s"chmod +x $coursierBin",
-      s"ls -la $coursierBin",
-      s"tail -n 30 $coursierBin"
+      s"chmod +x $coursierBin"
     ).mkString(" && ")
     val scalaCliBin = s"$binDir/scala-cli"
     val installScalaCliStep = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -374,7 +374,7 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", "npm install --global yarn"),
       // Ensure binaries are in PATH
       Cmd("RUN", "echo $PATH"),
-      Cmd("RUN", "which coursier mill mvn node npm sbt scala-cli scalafix scalafmt yarn")
+      Cmd("RUN", "which cs mill mvn node npm sbt scala-cli scalafix scalafmt yarn")
     )
   },
   Docker / packageName := s"fthomas/${name.value}",

--- a/build.sbt
+++ b/build.sbt
@@ -340,18 +340,20 @@ lazy val dockerSettings = Def.settings(
     val sbtVer = sbtVersion.value
     val sbtTgz = s"sbt-$sbtVer.tgz"
     val sbtUrl = s"https://github.com/sbt/sbt/releases/download/v$sbtVer/$sbtTgz"
-    val millBin = s"$binDir/mill"
     val millVer = Dependencies.millVersion
-    val millUrl =
-      s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
+    val millBin = s"$binDir/mill"
+    val installMill = Seq(
+      s"curl -fL --output $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer",
+      s"chmod +x $millBin"
+    ).mkString(" && ")
     val coursierBin = s"$binDir/coursier"
-    val installCoursierStep = Seq(
+    val installCoursier = Seq(
       s"curl -fL --output $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux-static.gz",
       s"gunzip $coursierBin.gz",
       s"chmod +x $coursierBin"
     ).mkString(" && ")
     val scalaCliBin = s"$binDir/scala-cli"
-    val installScalaCliStep = Seq(
+    val installScalaCli = Seq(
       s"curl -fL --output $scalaCliBin.gz https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
       s"gunzip $scalaCliBin.gz",
       s"chmod +x $scalaCliBin"
@@ -360,11 +362,13 @@ lazy val dockerSettings = Def.settings(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
-      Cmd("RUN", s"curl -fL $millUrl > $millBin && chmod +x $millBin"),
-      Cmd("RUN", installCoursierStep),
-      Cmd("RUN", installScalaCliStep),
+      Cmd("RUN", installMill),
+      Cmd("RUN", installCoursier),
+      Cmd("RUN", installScalaCli),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
-      Cmd("RUN", "npm install --global yarn")
+      Cmd("RUN", "npm install --global yarn"),
+      // Ensure binaries are in PATH
+      Cmd("RUN", "which coursier maven mill node npm sbt scala-cli scalafix scalafmt yarn")
     )
   },
   Docker / packageName := s"fthomas/${name.value}",

--- a/build.sbt
+++ b/build.sbt
@@ -345,6 +345,7 @@ lazy val dockerSettings = Def.settings(
     val millUrl =
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
+    val coursierUrl = "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz"
     val installScalaCliStep = Seq(
       "wget -q -O scala-cli.gz https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
       "gunzip scala-cli.gz",
@@ -355,9 +356,9 @@ lazy val dockerSettings = Def.settings(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
-      Cmd("RUN", s"curl -L $millUrl > $millBin && chmod +x $millBin"),
+      Cmd("RUN", s"curl -fL $millUrl > $millBin && chmod +x $millBin"),
       Cmd("RUN", installScalaCliStep),
-      Cmd("RUN", s"curl -L https://git.io/coursier-cli > $coursierBin && chmod +x $coursierBin"),
+      Cmd("RUN", s"curl -fL $coursierUrl | gzip -d > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")
     )

--- a/build.sbt
+++ b/build.sbt
@@ -351,11 +351,11 @@ lazy val dockerSettings = Def.settings(
       s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer",
       s"chmod +x $millBin"
     ).mkString(" && ")
-    val coursierBin = s"$binDir/coursier"
+    val csBin = s"$binDir/cs"
     val installCoursier = Seq(
-      s"$curl $coursierBin.gz https://github.com/coursier/coursier/releases/download/v${Dependencies.coursierCore.revision}/cs-x86_64-pc-linux-static.gz",
-      s"gunzip $coursierBin.gz",
-      s"chmod +x $coursierBin"
+      s"$curl $csBin.gz https://github.com/coursier/coursier/releases/download/v${Dependencies.coursierCore.revision}/cs-x86_64-pc-linux-static.gz",
+      s"gunzip $csBin.gz",
+      s"chmod +x $csBin"
     ).mkString(" && ")
     val scalaCliBin = s"$binDir/scala-cli"
     val installScalaCli = Seq(
@@ -370,7 +370,7 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", installMill),
       Cmd("RUN", installCoursier),
       Cmd("RUN", installScalaCli),
-      Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
+      Cmd("RUN", s"$csBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn"),
       // Ensure binaries are in PATH
       Cmd("RUN", "echo $PATH"),

--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,9 @@ lazy val dockerSettings = Def.settings(
     val installCoursierStep = Seq(
       s"curl -fL --output $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz",
       s"gunzip $coursierBin.gz",
-      s"chmod +x $coursierBin"
+      s"chmod +x $coursierBin",
+      s"ls -la $coursierBin",
+      s"tail -n 30 $coursierBin"
     ).mkString(" && ")
     val scalaCliBin = s"$binDir/scala-cli"
     val installScalaCliStep = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ lazy val dockerSettings = Def.settings(
     ).mkString(" && ")
     val coursierBin = s"$binDir/coursier"
     val installCoursier = Seq(
-      s"$curl $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux-static.gz",
+      s"$curl $coursierBin.gz https://github.com/coursier/coursier/releases/download/v${Dependencies.coursierCore.revision}/cs-x86_64-pc-linux-static.gz",
       s"gunzip $coursierBin.gz",
       s"chmod +x $coursierBin"
     ).mkString(" && ")

--- a/build.sbt
+++ b/build.sbt
@@ -345,20 +345,24 @@ lazy val dockerSettings = Def.settings(
     val millUrl =
       s"https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer"
     val coursierBin = s"$binDir/coursier"
-    val coursierUrl = "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz"
+    val installCoursierStep = Seq(
+      s"curl -fL --output $coursierBin.gz https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz",
+      s"gunzip $coursierBin.gz",
+      s"chmod +x $coursierBin"
+    ).mkString(" && ")
+    val scalaCliBin = s"$binDir/scala-cli"
     val installScalaCliStep = Seq(
-      "wget -q -O scala-cli.gz https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
-      "gunzip scala-cli.gz",
-      "chmod +x scala-cli",
-      "mv scala-cli /usr/bin/"
+      s"curl -fL --output $scalaCliBin.gz https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz",
+      s"gunzip $scalaCliBin.gz",
+      s"chmod +x $scalaCliBin"
     ).mkString(" && ")
     Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk --no-cache add bash git ca-certificates curl maven openssh nodejs npm"),
       Cmd("RUN", s"wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"),
       Cmd("RUN", s"curl -fL $millUrl > $millBin && chmod +x $millBin"),
+      Cmd("RUN", installCoursierStep),
       Cmd("RUN", installScalaCliStep),
-      Cmd("RUN", s"curl -fL $coursierUrl | gzip -cd > $coursierBin && chmod +x $coursierBin"),
       Cmd("RUN", s"$coursierBin install --install-dir $binDir scalafix scalafmt"),
       Cmd("RUN", "npm install --global yarn")
     )


### PR DESCRIPTION
Recent builds failed intermittently because Coursier could not be installed in the Docker image via `git.io/coursier-cli` (see https://github.com/coursier/coursier/issues/2724). The [current Coursier installation instructions](https://get-coursier.io/docs/cli-installation) does not mention `git.io/coursier-cli` anymore and recommends to download the appropriate binary directly.

Coursier is now installed by downloading and extracting https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux-static.gz. The installation processes of all binaries has been equalized by using `curl` and a common structure.