### PR TITLE
Migrate `org.fluentlenium` to `io.fluentlenium`

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -201,6 +201,71 @@ changes = [
     artifactIdAfter = kind-projector
   },
   {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-assertj
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-core
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-coverage-report
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-cucumber
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-integration-tests
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-junit
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-junit-jupiter
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-kotest
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-kotest-assertions
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-parent
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-spock
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-spring-testng
+  },
+  {
+    groupIdBefore = org.fluentlenium
+    groupIdAfter = io.fluentlenium
+    artifactIdAfter = fluentlenium-testng
+  },
+  {
     groupIdAfter = org.scalatestplus
     artifactIdBefore = junit-4-12
     artifactIdAfter = junit-4-13


### PR DESCRIPTION
See 
* https://github.com/FluentLenium/FluentLenium/pull/1770
* https://github.com/FluentLenium/FluentLenium/releases/tag/v6.0.0
* https://repo1.maven.org/maven2/io/fluentlenium/