### PR TITLE
Updates with migration are no longer hidden

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.update
 
 import cats.syntax.all._
-import cats.{Monad, TraverseFilter}
+import cats.Monad
 import org.scalasteward.core.data._
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.FilterAlg._
@@ -28,11 +28,11 @@ final class FilterAlg[F[_]](implicit
     logger: Logger[F],
     F: Monad[F]
 ) {
-  def localFilterMany[G[_]: TraverseFilter](
+  def localFilterSingle(
       config: RepoConfig,
-      updates: G[Update.ForArtifactId]
-  ): F[G[Update.ForArtifactId]] =
-    updates.traverseFilter(update => logIfRejected(localFilter(update, config)))
+      update: Update.ForArtifactId
+  ): F[Option[Update.ForArtifactId]] =
+    logIfRejected(localFilter(update, config))
 
   private def logIfRejected(result: FilterResult): F[Option[Update.ForArtifactId]] =
     result match {


### PR DESCRIPTION
When updates without a migration are present, but filterd out, updates with a migration are not even considered.

This fixes the behaviour.
An example is "com.dwijnand:sbt-dynver" in version 4.1.1. A bunch of later milestones are available. But the version 5.0.1 after the migration (#3026) is not considered.

```
2023-05-06 17:38:24,185 INFO  Ignore com.dwijnand:sbt-dynver : 4.1.1 -> 4.1.1+2-b4addc54 -> 4.1.1+4-b08da358 -> ... -> 5.0.0-M3+8-4d20677f -> 5.0.0-M3+10-ffae0733 -> 5.0.0-M3+12-c25bc496 (reason: no suitable next version)
```