### PR TITLE
Migration for sbt-eclipse

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -616,4 +616,10 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-sdlc
   },
+  {
+    groupIdBefore = com.typesafe.sbteclipse
+    artifactIdBefore = sbteclipse-plugin
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-eclipse
+  },
 ]


### PR DESCRIPTION
https://github.com/sbt/sbt-eclipse/releases/tag/6.0.0

Can someone please check if that entry correct, since everything changes, the groupId and the artifactId:

```sbt
// From
addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
// To
addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")
```

Also, this is a sbt-plugin. Is it necessary to add the suffix `_2.12_1.0` to the entries?
See https://repo1.maven.org/maven2/com/github/sbt/sbt-eclipse_2.12_1.0/6.0.0/

Thanks!