### PR TITLE
Migration for sbt-pom-reader

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -622,4 +622,9 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-eclipse
   },
+  {
+    groupIdBefore = com.typesafe.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-pom-reader
+  },
 ]


### PR DESCRIPTION
See: https://github.com/sbt/sbt-pom-reader/pull/76
Released in: https://github.com/sbt/sbt-pom-reader/releases/tag/v2.4.0

before: https://index.scala-lang.org/sbt/sbt-pom-reader/artifacts/sbt-pom-reader/2.2.0
after: https://index.scala-lang.org/sbt/sbt-pom-reader/artifacts/sbt-pom-reader/2.4.0