### PR TITLE
sbt-javaagent is published to the com.github.sbt group ID

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -642,4 +642,9 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-js-engine
   },
+  {
+    groupIdBefore = com.lightbend.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-javaagent
+  },
 ]


### PR DESCRIPTION
To be merged after https://github.com/sbt/sbt-javaagent/pull/26 is merged and a new release is cut.