### PR TITLE
Improve grouping feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Thanks goes to these wonderful people for contributing to Scala Steward:
 * [Stanislav Chetvertkov](https://github.com/stanislav-chetvertkov)
 * [sullis](https://github.com/sullis)
 * [TATSUNO Yasuhiro](https://github.com/exoego)
+* [Terry Hendrix](https://github.com/terryhendrix1990)
 * [Thomas Heslin](https://github.com/tjheslin1)
 * [Thomas Kaliakos](https://github.com/thomaska)
 * [Tim Steinbach](https://github.com/NeQuissimus)

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -60,14 +60,16 @@ pullRequests.frequency = "7 days"
 #
 # Every field in a `filter` is optional but at least one must be provided.
 #
-# For grouping every update togeher a filter like {group = "*"} can be # provided.
+# For grouping every update together a filter like {group = "*"} can be # provided.
 #
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+# 
 # Default: []
 pullRequests.grouping = [
   { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
   { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
   { name = "typelevel", "title" = "Typelevel updates", "filter" = [{"group" = "org.typelevel"}, {"group" = "org.http4s"}] },
-  { name = "my_libraries", "filter" = [{"artifact" = "my-library"}, {"artifact" = "my-other-library", "group" = "my-org"}] },
+  { name = "my_libraries_${hash}", "filter" = [{"artifact" = "my-library"}, {"artifact" = "my-other-library", "group" = "my-org"}] },
   { name = "all", "title" = "Dependency updates", "filter" = [{"group" = "*"}] }
 ]
 

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -52,10 +52,21 @@ object CommitMsg {
           .replace("${branchName}", baseBranch.map(_.name).orEmpty)
         CommitMsg(title = title)
       },
-      g =>
-        CommitMsg(title =
-          g.title.getOrElse(s"Update for group ${g.name}") +
-            baseBranch.fold("")(branch => s" in ${branch.name}")
-        )
+      g => {
+        val artifactsWithVersions = g.updates
+          .groupBy(_.nextVersion)
+          .map { case (version, updates) =>
+            s"${updates.map(u => s"${u.artifactId.name}").mkString(", ")} to ${version.value}"
+          }
+          .mkString(" - ")
+
+        val defaultTitle =
+          s"Update for group ${g.name} ${baseBranch.fold("")(branch => s"in ${branch.name} ")}$${artifactVersions}"
+
+        val title = g.title
+          .getOrElse(defaultTitle)
+          .replace("${artifactVersions}", artifactsWithVersions)
+        CommitMsg(title = title)
+      }
     )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -52,9 +52,7 @@ object CommitMsg {
           .replace("${branchName}", baseBranch.map(_.name).orEmpty)
         CommitMsg(title = title)
       },
-      g => {
-        CommitMsg(title = groupMessage(group = g, baseBranch))
-      }
+      g => CommitMsg(title = groupMessage(group = g, baseBranch))
     )
 
   def groupMessage(group: Update.Grouped, baseBranch: Option[Branch]): String = {

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -61,7 +61,7 @@ object CommitMsg {
           .mkString(" - ")
 
         val defaultTitle =
-          s"Update for group ${g.name} ${baseBranch.fold("")(branch => s"in ${branch.name} ")}$${artifactVersions}"
+          s"Update for group ${g.name}${baseBranch.fold("")(branch => s" in ${branch.name}")}: $${artifactVersions}"
 
         val title = g.title
           .getOrElse(defaultTitle)

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -31,8 +31,9 @@ package object git {
     update.on(
       update = u => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}"),
       grouped = g => {
-        val uniqueness = Math.abs(g.updates.map(_.nextVersion).sortBy(_.value).hashCode())
-        Branch(s"$updateBranchPrefix/$base${g.name}-${uniqueness}")
+        val hashString = Math.abs(g.updates.map(_.nextVersion).sortBy(_.value).hashCode()).toString
+        val branch = s"$updateBranchPrefix/$base${g.name}"
+        Branch(branch.replace("${hash}", hashString))
       }
     )
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -30,7 +30,10 @@ package object git {
     val base = baseBranch.fold("")(branch => s"${branch.name}/")
     update.on(
       update = u => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}"),
-      grouped = g => Branch(s"$updateBranchPrefix/$base${g.name}")
+      grouped = g => {
+        val uniqueness = Math.abs(g.updates.map(_.nextVersion).sortBy(_.value).hashCode())
+        Branch(s"$updateBranchPrefix/$base${g.name}-${uniqueness}")
+      }
     )
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgePackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgePackageTest.scala
@@ -41,11 +41,33 @@ class ForgePackageTest extends FunSuite {
     val updateBranch = git.branchFor(update, None)
 
     test("listingBranch (grouped)") {
-      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group-1164623676")
+      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group")
       assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
     }
 
     test("createBranch (grouped)") {
+      assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:update/my-group")
+      assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+  }
+
+  // Grouped updates with hash
+
+  {
+    val update = Update.Grouped(
+      name = "my-group-${hash}",
+      title = None,
+      updates = List(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
+    )
+
+    val updateBranch = git.branchFor(update, None)
+
+    test("listingBranch (grouped) with $hash") {
+      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group-1164623676")
+      assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
+    }
+
+    test("createBranch (grouped) with $hash") {
       assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:update/my-group-1164623676")
       assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgePackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgePackageTest.scala
@@ -41,12 +41,12 @@ class ForgePackageTest extends FunSuite {
     val updateBranch = git.branchFor(update, None)
 
     test("listingBranch (grouped)") {
-      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group")
+      assertEquals(listingBranch(GitHub, repo, updateBranch), s"foo/bar:update/my-group-1164623676")
       assertEquals(listingBranch(GitLab, repo, updateBranch), updateBranch.name)
     }
 
     test("createBranch (grouped)") {
-      assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:update/my-group")
+      assertEquals(createBranch(GitHub, repo, updateBranch), s"foo:update/my-group-1164623676")
       assertEquals(createBranch(GitLab, repo, updateBranch), updateBranch.name)
     }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -721,7 +721,7 @@ class NewPullRequestDataTest extends FunSuite {
           |</sup>""".stripMargin
 
     val expected = NewPullRequestData(
-      title = "Update for group my-group",
+      title = "Update for group my-group foo to 2.0.0 - logback-classic to 1.2.3",
       body = expectedBody,
       head = "scala-steward:update/logback-classic-1.2.3",
       base = Branch("main"),

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -649,7 +649,7 @@ class NewPullRequestDataTest extends FunSuite {
     assertEquals(obtained, expected)
   }
 
-  test("from() should construct NewPullRequestData for groupped update") {
+  test("from() should construct NewPullRequestData for grouped update") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
     val update = Update.Grouped("my-group", None, List(update1, update2))
@@ -721,7 +721,7 @@ class NewPullRequestDataTest extends FunSuite {
           |</sup>""".stripMargin
 
     val expected = NewPullRequestData(
-      title = "Update for group my-group foo to 2.0.0 - logback-classic to 1.2.3",
+      title = "Update for group my-group: foo to 2.0.0 - logback-classic to 1.2.3",
       body = expectedBody,
       head = "scala-steward:update/logback-classic-1.2.3",
       base = Branch("main"),

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -721,7 +721,7 @@ class NewPullRequestDataTest extends FunSuite {
           |</sup>""".stripMargin
 
     val expected = NewPullRequestData(
-      title = "Update for group my-group: foo to 2.0.0 - logback-classic to 1.2.3",
+      title = "Update for group my-group",
       body = expectedBody,
       head = "scala-steward:update/logback-classic-1.2.3",
       base = Branch("main"),

--- a/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
@@ -1,0 +1,56 @@
+package org.scalasteward.core.git
+
+import munit.FunSuite
+import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.data.Update
+
+class CommitMsgTest extends FunSuite {
+  test("Create title for Update.Grouped") {
+    val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
+    val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
+
+    val update = Update.Grouped("my-group", Some("The PR title"), List(update1, update2))
+    assertEquals(CommitMsg.replaceVariables("")(update, None).title, "The PR title")
+  }
+
+  test("Create title for Update.Grouped with ${artifactVersions}") {
+    val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
+    val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
+    val update3 = ("com.example".g % "bar".a % "1.0.0" %> "2.0.0").single
+    val update4 = ("com.example".g % "baz".a % "1.0.0" %> "2.0.0").single
+
+    val update = Update.Grouped(
+      "my-group",
+      Some("Title - ${artifactVersions}"),
+      List(update1, update2, update3, update4)
+    )
+    assertEquals(
+      CommitMsg.replaceVariables("")(update, None).title,
+      "Title - foo, bar, baz to 2.0.0 - logback-classic to 1.2.3"
+    )
+  }
+
+  test(
+    "Do not create truncated title for Update.Grouped with ${artifactVersions} when 200 characters or less"
+  ) {
+    val singles = (0 to 23).map(i => ("com.example".g % s"foo-$i".a % "1.0.0" %> "2.0.0").single)
+    val update = Update.Grouped("my-group", Some("Title ---- ${artifactVersions}"), singles.toList)
+    val title = CommitMsg.replaceVariables("")(update, None).title
+    assertEquals(
+      title,
+      "Title ---- foo-0, foo-1, foo-2, foo-3, foo-4, foo-5, foo-6, foo-7, foo-8, foo-9, foo-10, foo-11, foo-12, foo-13, foo-14, foo-15, foo-16, foo-17, foo-18, foo-19, foo-20, foo-21, foo-22, foo-23 to 2.0.0"
+    )
+    assertEquals(title.size, 200)
+  }
+
+  test(
+    "Create truncated title for Update.Grouped with ${artifactVersions} when more than 200 characters"
+  ) {
+    val singles = (0 to 23).map(i => ("com.example".g % s"foo-$i".a % "1.0.0" %> "2.0.0").single)
+    val update = Update.Grouped("my-group", Some("Title ----- ${artifactVersions}"), singles.toList)
+    assertEquals(
+      CommitMsg.replaceVariables("")(update, None).title,
+      "Title ----- foo-0 and 23 more to 2.0.0"
+    )
+  }
+}


### PR DESCRIPTION
Solves 2 issues in the `grouping` feature:
1. Failed grouping PRs (using `Update.Group`) get stuck: When a grouping PR is created by Scalasteward and the PR fails to build, then scalasteward does not create a new PR when new versions are released, because an existing PR is still open and the branch names are not unique. Solution: Introduce unique branch names in the grouping feature. This is similar to `Update.Single`
2. Commit messages are unclear. Solution: Added artifactIds and versions to the commit message. This is similar to `Update.Single`