### PR TITLE
Remove obsolete dependency on Mill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -265,7 +265,6 @@ lazy val dummy = myCrossProject("dummy")
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.millMain,
       Dependencies.scalaStewardMillPlugin
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -344,7 +344,7 @@ lazy val dockerSettings = Def.settings(
       s"tar -xf $sbtTgz",
       s"rm -f $sbtTgz"
     ).mkString(" && ")
-    val millVer = Dependencies.millVersion
+    val millVer = Dependencies.millScriptVersion
     val millBin = s"$binDir/mill"
     val installMill = Seq(
       s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer",

--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,7 @@ lazy val dockerSettings = Def.settings(
     val millVer = Dependencies.millScriptVersion
     val millBin = s"$binDir/mill"
     val installMill = Seq(
-      s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").head}/$millVer",
+      s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").takeWhile(!_.startsWith("M")).mkString("-")}/$millVer",
       s"chmod +x $millBin"
     ).mkString(" && ")
     val csBin = s"$binDir/cs"

--- a/build.sbt
+++ b/build.sbt
@@ -346,8 +346,12 @@ lazy val dockerSettings = Def.settings(
     ).mkString(" && ")
     val millVer = Dependencies.millScriptVersion
     val millBin = s"$binDir/mill"
+    val releasePageVersion = millVer.split("-") match {
+      case Array(v, m, _*) if m.startsWith("M") => s"${v}-${m}"
+      case Array(v, _*)                         => v
+    }
     val installMill = Seq(
-      s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${millVer.split("-").takeWhile(!_.startsWith("M")).mkString("-")}/$millVer",
+      s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${releasePageVersion}/$millVer",
       s"chmod +x $millBin"
     ).mkString(" && ")
     val csBin = s"$binDir/cs"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.11.5"
   val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % jjwtApi.revision
   val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % jjwtApi.revision
+  val millScriptVersion = "0.11.0"
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"
   val munit = "org.scalameta" %% "munit" % "0.7.29"
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect-3" % "1.0.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,8 +34,6 @@ object Dependencies {
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.11.5"
   val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % jjwtApi.revision
   val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % jjwtApi.revision
-  val millVersion = "0.11.0"
-  val millMain = "com.lihaoyi" % "mill-main_2.13" % millVersion
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"
   val munit = "org.scalameta" %% "munit" % "0.7.29"
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect-3" % "1.0.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.11.5"
   val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % jjwtApi.revision
   val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % jjwtApi.revision
-  val millScriptVersion = "0.11.0"
+  val millScriptVersion = "0.11.0-M11"
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"
   val munit = "org.scalameta" %% "munit" % "0.7.29"
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect-3" % "1.0.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.11.5"
   val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % jjwtApi.revision
   val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % jjwtApi.revision
-  val millScriptVersion = "0.11.0-M11"
+  val millScriptVersion = "0.11.0-M10"
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"
   val munit = "org.scalameta" %% "munit" % "0.7.29"
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect-3" % "1.0.7"


### PR DESCRIPTION
Everthing Mill specific is handled by the mill-plugin.

We only need a version to download the Mill bootstrap script. Version `0.11.0-M11` is the last one still using Github Release pages, which is required as Scala-Steward needs to support Mill versions down to `0.6`.

Fix https://github.com/scala-steward-org/scala-steward/issues/3082