### PR TITLE
Use `Option.when(cond)(value)` where appropriate

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
@@ -33,8 +33,9 @@ object parser {
     val decoder = Decoder[Dependency].either(Decoder[Resolver])
     chunks.mapFilter { chunk =>
       val (dependencies, resolvers) = chunk.toList.flatMap(decode(_)(decoder).toList).separate
-      if (dependencies.isEmpty || resolvers.isEmpty) None
-      else Some(Scope(dependencies, resolvers.sorted))
+      Option.when(dependencies.nonEmpty && resolvers.nonEmpty)(
+        Scope(dependencies, resolvers.sorted)
+      )
     }.toList
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -113,7 +113,7 @@ object FileAlg {
         Resource.make {
           F.blocking {
             val copyOptions = File.CopyOptions(overwrite = true)
-            if (file.exists) Some(file.moveTo(File.newTemporaryFile())(copyOptions)) else None
+            Option.when(file.exists)(file.moveTo(File.newTemporaryFile())(copyOptions))
           }
         } {
           case Some(tmpFile) => F.blocking(tmpFile.moveTo(file)).void
@@ -121,7 +121,7 @@ object FileAlg {
         }.void
 
       override def readFile(file: File): F[Option[String]] =
-        F.blocking(if (file.exists) Some(file.contentAsString) else None)
+        F.blocking(Option.when(file.exists)(file.contentAsString))
 
       override def readResource(resource: String): F[String] =
         readSource(F.blocking(Source.fromResource(resource)))

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -67,7 +67,7 @@ object RefreshErrorAlg {
   final case class Entry(failedAt: Timestamp, message: String) {
     def expiresIn(now: Timestamp, backoffPeriod: FiniteDuration): Option[FiniteDuration] = {
       val duration = backoffPeriod - failedAt.until(now)
-      if (duration.length > 0L) Some(duration) else None
+      Option.when(duration.length > 0L)(duration)
     }
   }
 


### PR DESCRIPTION
The [`Option.when(cond)(value)`](https://www.scala-lang.org/api/2.13.x/scala/Option$.html#when[A](cond:Boolean)(a:=%3EA):Option[A]) Option builder was added to Scala 2.13 with https://github.com/scala/scala/pull/5995, and it's a nice, slightly more concise alternative to using if/else, eg: `if (cond) Some(value) else None`.

In this change, I've just updated the Scala Steward codebase to use `Option.when` where it's appropriate.