### PR TITLE
Remove any run-specific files before starting run

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -108,7 +108,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
               case results =>
                 val runResults = RunResults(results)
                 for {
-                  summaryFile <- workspaceAlg.runSummary
+                  summaryFile <- workspaceAlg.runSummaryFile
                   _ <- fileAlg.writeFile(summaryFile, runResults.markdownSummary)
                 } yield runResults.exitCode
             }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -92,7 +92,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
     logger.infoTotalTime("run") {
       for {
         _ <- selfCheckAlg.checkAll
-        _ <- workspaceAlg.cleanReposDir
+        _ <- workspaceAlg.removeAnyRunSpecificFiles
         exitCode <-
           (config.githubApp.map(getGitHubAppRepos).getOrElse(Stream.empty) ++
             readRepos(config.reposFile))
@@ -108,7 +108,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
               case results =>
                 val runResults = RunResults(results)
                 for {
-                  summaryFile <- workspaceAlg.rootDir.map(_ / "run-summary.md")
+                  summaryFile <- workspaceAlg.runSummary
                   _ <- fileAlg.writeFile(summaryFile, runResults.markdownSummary)
                 } yield runResults.exitCode
             }

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.io
 
 import better.files.File
-import cats.FlatMap
+import cats.Monad
 import cats.syntax.all._
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
@@ -25,9 +25,11 @@ import org.scalasteward.core.data.Repo
 import org.typelevel.log4cats.Logger
 
 trait WorkspaceAlg[F[_]] {
-  def cleanReposDir: F[Unit]
+  def removeAnyRunSpecificFiles: F[Unit]
 
   def rootDir: F[File]
+
+  def runSummary: F[File]
 
   def repoDir(repo: Repo): F[File]
 
@@ -35,14 +37,25 @@ trait WorkspaceAlg[F[_]] {
 }
 
 object WorkspaceAlg {
+
+  val RunSummaryFileName: String = "run-summary.md"
+
   def create[F[_]](config: Config)(implicit
       fileAlg: FileAlg[F],
       logger: Logger[F],
-      F: FlatMap[F]
+      F: Monad[F]
   ): WorkspaceAlg[F] =
     new WorkspaceAlg[F] {
       private val reposDir: File =
         config.workspace / "repos"
+
+      private val _runSummary: File =
+        config.workspace / RunSummaryFileName
+
+      /* We don't want the `ensureExists()` side-effect for these files - here, we only want to delete them,
+       * not accidentally re-create them while trying to delete them.
+       */
+      private val runSpecificFiles: Seq[File] = Seq(_runSummary, reposDir)
 
       private def toFile(repo: Repo): File =
         reposDir / repo.owner / repo.repo
@@ -50,11 +63,16 @@ object WorkspaceAlg {
       private def toFile(buildRoot: BuildRoot): File =
         toFile(buildRoot.repo) / buildRoot.relativePath
 
-      override def cleanReposDir: F[Unit] =
-        logger.info(s"Clean $reposDir") >> fileAlg.deleteForce(reposDir)
+      override def removeAnyRunSpecificFiles: F[Unit] =
+        logger.info(s"Removing any run-specific files") >> runSpecificFiles.traverse_(
+          fileAlg.deleteForce
+        )
 
       override def rootDir: F[File] =
         fileAlg.ensureExists(config.workspace)
+
+      override def runSummary: F[File] =
+        fileAlg.ensureExists(_runSummary.parent).map(_ => _runSummary)
 
       override def repoDir(repo: Repo): F[File] =
         fileAlg.ensureExists(toFile(repo))

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -29,7 +29,7 @@ trait WorkspaceAlg[F[_]] {
 
   def rootDir: F[File]
 
-  def runSummary: F[File]
+  def runSummaryFile: F[File]
 
   def repoDir(repo: Repo): F[File]
 
@@ -49,13 +49,13 @@ object WorkspaceAlg {
       private val reposDir: File =
         config.workspace / "repos"
 
-      private val _runSummary: File =
+      private val runSummary: File =
         config.workspace / RunSummaryFileName
 
       /* We don't want the `ensureExists()` side-effect for these files - here, we only want to delete them,
        * not accidentally re-create them while trying to delete them.
        */
-      private val runSpecificFiles: Seq[File] = Seq(_runSummary, reposDir)
+      private val runSpecificFiles: Seq[File] = Seq(runSummary, reposDir)
 
       private def toFile(repo: Repo): File =
         reposDir / repo.owner / repo.repo
@@ -71,8 +71,8 @@ object WorkspaceAlg {
       override def rootDir: F[File] =
         fileAlg.ensureExists(config.workspace)
 
-      override def runSummary: F[File] =
-        fileAlg.ensureExists(_runSummary.parent).map(_ => _runSummary)
+      override def runSummaryFile: F[File] =
+        fileAlg.ensureExists(runSummary.parent).map(_ => runSummary)
 
       override def repoDir(repo: Repo): F[File] =
         fileAlg.ensureExists(toFile(repo))

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -4,10 +4,11 @@ import better.files.File
 import cats.data.Kleisli
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
+import org.scalasteward.core.io.WorkspaceAlg.RunSummaryFileName
 import org.scalasteward.core.mock.{MockConfig, MockEff}
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
-  override def cleanReposDir: MockEff[Unit] =
+  override def removeAnyRunSpecificFiles: MockEff[Unit] =
     Kleisli.pure(())
 
   override def rootDir: MockEff[File] =
@@ -18,4 +19,6 @@ class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
 
   override def buildRootDir(buildRoot: BuildRoot): MockEff[File] =
     repoDir(buildRoot.repo).map(_ / buildRoot.relativePath)
+
+  def runSummary: MockEff[File] = rootDir.map(_ / RunSummaryFileName)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -20,5 +20,5 @@ class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {
   override def buildRootDir(buildRoot: BuildRoot): MockEff[File] =
     repoDir(buildRoot.repo).map(_ / buildRoot.relativePath)
 
-  def runSummary: MockEff[File] = rootDir.map(_ / RunSummaryFileName)
+  def runSummaryFile: MockEff[File] = rootDir.map(_ / RunSummaryFileName)
 }


### PR DESCRIPTION
To ensure that its workspace is clean, and that unintended files are not held over from previous runs, Scala Steward already erases the `repos` folder before starting its run. With new `run-summary.md` file introduced by https://github.com/scala-steward-org/scala-steward/pull/3071, we again want to be careful that the summary file from a previous run isn't picked up in a subsequent run.

https://github.com/scala-steward-org/scala-steward-action/pull/503 addressed this for the particular concern of GitHub Actions, by ensuring that the file wasn't persisted to cache, but @fthomas [pointed out](https://github.com/scala-steward-org/scala-steward-action/pull/503#issuecomment-1594477950) that this additional point at the start of Scala Steward's code was also a good place for removing any run-specific files.

