### PR TITLE
Add sbt.server.forcestart option to SbtAlg to allow for sbt compatibility versions < 1.7

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -154,6 +154,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           sbtCommands.mkString_(";", ";", "")
         )
       processAlg.execSandboxed(command, repoDir, slurpOptions = slurpOptions)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -65,6 +65,7 @@ class BuildToolDispatcherTest extends FunSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_0_0.scala"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -36,6 +36,7 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
@@ -74,6 +75,7 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           s";$scalafixEnable;$scalafixAll github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
         Cmd("rm", "-rf", s"$repoDir/project/scala-steward-sbt-scalafix.sbt")
@@ -113,6 +115,7 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           s";$scalafixEnable;$scalafixAll github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"
         ),
         Cmd("rm", "-rf", s"$repoDir/scala-steward-scalafix-options.sbt"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -53,6 +53,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           "-Dsbt.color=false",
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
+          "-Dsbt.server.forcestart=true",
           s";$crossStewardDependencies"
         ),
         Cmd("rm", "-rf", s"$sbtBuildDir/project/scala-steward-StewardPlugin_1_3_11.scala"),


### PR DESCRIPTION
As discussed in the issue here: https://github.com/scala-steward-org/scala-steward/issues/3092, it appears that when running scala steward against repos that are running an sbt version less than 1.7, it will cause it to fail silently due to the following error (traces have been truncated for brevity, full trace available in issue):

```
sbt thinks that server is already booting because of this exception:
sbt.internal.ServerAlreadyBootingException: java.io.IOException: org.scalasbt.ipcsocket.NativeErrorException: [95] Not supported

Caused by: java.io.IOException: org.scalasbt.ipcsocket.NativeErrorException: [95] Not supported

Caused by: org.scalasbt.ipcsocket.NativeErrorException: [95] Not supported

Create a new server? y/n (default y)
```

It appears that this has been fixed in sbt since 1.7 as of this commit https://github.com/sbt/sbt/issues/6101, i also confirmed that by testing a project running sbt 1.8.x, which worked.

I experimented with a few flag combinations, it seems that using -sbt.server.forcestart=true in combination with the -batch flag will allow it to pass the error and function as expected on older sbt versions, this pr just adds that flag and updates the relevant tests which would expect that flag otherwise. The -batch flag has not been included due to prior discussions and removal of the flag as detailed in the issue above.