### PR TITLE
Ensure `mockRoot` test folder is always cleared before tests run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,8 +212,6 @@ lazy val core = myCrossProject("core")
     // Uncomment for remote debugging:
     // run / javaOptions += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
     Test / fork := true,
-    Test / testOptions +=
-      Tests.Cleanup(() => Path(file(Properties.tmpDir) / "scala-steward").deleteRecursively()),
     Compile / resourceGenerators += Def.task {
       val outDir = (Compile / resourceManaged).value
       def downloadPlugin(v: String): File = {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -6,6 +6,7 @@ import org.scalasteward.core.application.{Cli, Config}
 
 object MockConfig {
   val mockRoot: File = File.temp / "scala-steward"
+  mockRoot.delete(true) // Ensure folder is cleared of previous test files
   private val args: List[String] = List(
     s"--workspace=$mockRoot/workspace",
     s"--repos-file=$mockRoot/repos.md",


### PR DESCRIPTION
Several of Scala Steward's tests (eg `PullRequestRepositoryTest`) write files to the filesystem, using `MockConfig.mockRoot` as the base folder.

https://github.com/scala-steward-org/scala-steward/blob/b1de3ab58194f543f3526e013b363a52c675c769/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala#L8

However, the folder is not erased between runs, and (possibly depending on operating system or Java version) the folder _can be_ the same path for multiple runs. In that case, tests may pass first time, but fail the second (this is the case for `PullRequestRepositoryTest`), as unexpected old files are encountered.

Here's a video showing that on my machine (Java 17.0.4, macOS 12.6):

https://github.com/scala-steward-org/scala-steward/assets/52038/bd5a1317-3828-460f-8b79-936645e97e64


## Fix

This change alters the way `mockRoot` is constructed:

* OLD: `better.files.File.temp` - this was simply the value of [`java.io.tmpdir`](https://stackoverflow.com/a/1924159/438886), which could be simply `/tmp/`, or some other value, but not guaranteed to change between runs.
* NEW: `better.files.File.newTemporaryDirectory()` - uses [`java.nio.file.Files.createTempDirectory()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.lang.String,java.nio.file.attribute.FileAttribute...)), guaranteed to be a new folder each time.

...with the new method, the tests consistently pass when I run `PullRequestRepositoryTest`, whereas they would previously consistently fail, after passing once, before the change. Note that typically, where ever the temporary folders are created, they are deleted on reboot, so there's a low chance of them taking up excessive amounts of space.