### PR TITLE
Use actual default values in `.scala-steward.conf` doc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,8 +248,12 @@ lazy val docs = myCrossProject("docs")
       try git.runner.value.apply("diff", "--quiet", outDir)(rootDir, streams.value.log)
       catch {
         case t: Throwable =>
-          val msg = s"Docs in $inDir and $outDir are out of sync." +
-            " Run 'sbt docs/mdoc' and commit the changes to fix this."
+          val diff = git.runner.value.apply("diff", outDir)(rootDir, streams.value.log)
+          val msg = s"""|Docs in $inDir and $outDir are out of sync.
+                        |Run 'sbt docs/mdoc' and commit the changes to fix this.
+                        |The diff is:
+                        |$diff
+                        |""".stripMargin
           throw new Throwable(msg, t)
       }
       ()

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -25,6 +25,7 @@ import io.circe.syntax._
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.hooks.PostUpdateHook
+import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
 
 final case class RepoConfig(
     commits: CommitsConfig = CommitsConfig(),
@@ -41,7 +42,7 @@ final case class RepoConfig(
   def buildRootsOrDefault(repo: Repo): List[BuildRoot] =
     buildRoots
       .map(_.filterNot(_.relativePath.contains("..")))
-      .getOrElse(List(BuildRootConfig.repoRoot))
+      .getOrElse(defaultBuildRoots)
       .map(cfg => BuildRoot(repo, cfg.relativePath))
 
   def postUpdateHooksOrDefault: List[PostUpdateHook] =
@@ -56,6 +57,9 @@ final case class RepoConfig(
 
 object RepoConfig {
   val empty: RepoConfig = RepoConfig()
+
+  val defaultBuildRoots: List[BuildRootConfig] =
+    List(BuildRootConfig.repoRoot)
 
   implicit val repoConfigEq: Eq[RepoConfig] =
     Eq.fromUniversalEquals

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -27,6 +27,7 @@ import org.scalasteward.core.buildtool.maven.pomXmlName
 import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.buildPropertiesName
 import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.repoconfig.UpdatesConfig.defaultLimit
 import org.scalasteward.core.scalafmt.scalafmtConfName
 import org.scalasteward.core.update.FilterAlg.{
   FilterResult,
@@ -41,7 +42,7 @@ final case class UpdatesConfig(
     allow: List[UpdatePattern] = List.empty,
     allowPreReleases: List[UpdatePattern] = List.empty,
     ignore: List[UpdatePattern] = List.empty,
-    limit: Option[NonNegInt] = None,
+    limit: Option[NonNegInt] = defaultLimit,
     fileExtensions: Option[List[String]] = None
 ) {
   def fileExtensionsOrDefault: Set[String] =
@@ -88,7 +89,7 @@ final case class UpdatesConfig(
 }
 
 object UpdatesConfig {
-  private val defaultFileExtensions: Set[String] =
+  val defaultFileExtensions: Set[String] =
     Set(
       MillAlg.millVersionName,
       MillAlg.millVersionNameInConfig,
@@ -101,6 +102,8 @@ object UpdatesConfig {
       buildPropertiesName,
       pomXmlName
     )
+
+  val defaultLimit: Option[NonNegInt] = None
 
   implicit val updatesConfigEq: Eq[UpdatesConfig] =
     Eq.fromUniversalEquals

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -4,7 +4,13 @@ You can add a configuration file `.scala-steward.conf` to configure how Scala St
 The `.scala-steward.conf` configuration file can be located in the root of your repository, in `.github` directory or in `.config` directory (searched in this order).
 If a configuration file exists in more than one location, only the first found file is taken into account.
 
-```properties
+```scala mdoc:passthrough
+import io.circe.refined._
+import io.circe.syntax._
+import org.scalasteward.core.repoconfig._
+
+print("```properties")
+print(s"""
 # pullRequests.frequency allows to control how often or when Scala Steward
 # is allowed to create pull requests.
 #
@@ -29,7 +35,7 @@ If a configuration file exists in more than one location, only the first found f
 #     while the time parts are only used to abide to the frequency of
 #     the given expression.
 #
-# Default: "@asap"
+# Default: ${PullRequestsConfig.defaultFrequency.asJson.noSpaces}
 #
 #pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
 pullRequests.frequency = "7 days"
@@ -62,14 +68,14 @@ pullRequests.frequency = "7 days"
 #
 # For grouping every update together a filter like {group = "*"} can be # provided.
 #
-# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+# To create a new PR for each unique combination of artifact-versions, include $${hash} in the name.
 #
 # Default: []
 pullRequests.grouping = [
   { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
   { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
   { name = "typelevel", "title" = "Typelevel updates", "filter" = [{"group" = "org.typelevel"}, {"group" = "org.http4s"}] },
-  { name = "my_libraries_${hash}", "filter" = [{"artifact" = "my-library"}, {"artifact" = "my-other-library", "group" = "my-org"}] },
+  { name = "my_libraries_$${hash}", "filter" = [{"artifact" = "my-library"}, {"artifact" = "my-other-library", "group" = "my-org"}] },
   { name = "all", "title" = "Dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
@@ -113,11 +119,11 @@ updates.allowPreReleases  = [ { groupId = "com.example", artifactId="foo" } ]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
-# Default: null
+# Default: ${UpdatesConfig.defaultLimit.asJson.noSpaces}
 updates.limit = 5
 
 # The extensions of files that should be updated.
-# Default: [".mill-version",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".yml","build.properties","mill-version","pom.xml"]
+# Default: ${UpdatesConfig.defaultFileExtensions.toList.sorted.asJson.noSpaces}
 updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md", ".markdown", ".txt"]
 
 # If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
@@ -125,23 +131,23 @@ updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md",
 # If "always", Scala Steward will always update the PR it created as long as
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
-# Default: "on-conflicts"
+# Default: ${PullRequestUpdateStrategy.default.asJson.noSpaces}
 updatePullRequests = "always" | "on-conflicts" | "never"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
-# Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
-# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
-commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+# Supported variables: $${artifactName}, $${currentVersion}, $${nextVersion} and $${default}
+# Default: "$${default}" which is equivalent to "Update $${artifactName} to $${nextVersion}"
+commits.message = "Update $${artifactName} from $${currentVersion} to $${nextVersion}"
 
 # If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt
 # and add a separate commit when format changed. So you don't need reformat manually and can merge PR.
 # If false, Scala Steward will not perform scalafmt, so your CI may abort when reformat needed.
-# Default: true
+# Default: ${ScalafmtConfig.defaultRunAfterUpgrading.asJson.noSpaces}
 scalafmt.runAfterUpgrading = false
 
 # It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
 # are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
-# Default: ["."]
+# Default: ${RepoConfig.defaultBuildRoots.asJson.noSpaces}
 buildRoots = [ ".", "subfolder/projectA" ]
 
 # Define commands that are executed after an update via a hook.
@@ -184,6 +190,8 @@ dependencyOverrides = [
 # to add assignees or request reviews. Consequently, it won't work for public @scala-steward instance on GitHub.
 assignees = [ "username1", "username2" ]
 reviewers = [ "username1", "username2" ]
+""")
+println("```")
 ```
 
 The version information given in the patterns above can be in two formats:

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -136,7 +136,7 @@ updatePullRequests = "always" | "on-conflicts" | "never"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: $${artifactName}, $${currentVersion}, $${nextVersion} and $${default}
-# Default: "$${default}" which is equivalent to "Update $${artifactName} to $${nextVersion}"
+# Default: ${CommitsConfig.defaultMessage.asJson.noSpaces} which is equivalent to "Update $${artifactName} to $${nextVersion}"
 commits.message = "Update $${artifactName} from $${currentVersion} to $${nextVersion}"
 
 # If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt


### PR DESCRIPTION
This generates `docs/repo-specific-configuration.md` from a mdoc source file such that the default values referenced in that documentation are always in sync with the actual default values in the source code.