### PR TITLE
Ensure PR bodies and titles are recreated when updating PRs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
@@ -27,6 +27,12 @@ trait ForgeApiAlg[F[_]] {
 
   def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut]
 
+  def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut]
+
   def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut]
 
   def getBranch(repo: Repo, branch: Branch): F[BranchOut]

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
@@ -27,11 +27,7 @@ trait ForgeApiAlg[F[_]] {
 
   def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut]
 
-  def updatePullRequest(
-      number: PullRequestNumber,
-      repo: Repo,
-      data: NewPullRequestData
-  ): F[PullRequestOut]
+  def updatePullRequest(number: PullRequestNumber, repo: Repo, data: NewPullRequestData): F[Unit]
 
   def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut]
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
@@ -54,6 +54,13 @@ final class AzureReposApiAlg[F[_]](
     } yield pullRequestOut
   }
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.1
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.patchWithBody[PullRequestOut, ClosePullRequestPayload](

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
@@ -59,7 +59,7 @@ final class AzureReposApiAlg[F[_]](
       repo: Repo,
       data: NewPullRequestData
   ): F[Unit] =
-    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+    logger.warn("Updating PRs is not yet supported for Azure Repos")
 
   // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.1
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
@@ -58,7 +58,7 @@ final class AzureReposApiAlg[F[_]](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] =
+  ): F[Unit] =
     F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
 
   // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.1

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
@@ -102,7 +102,7 @@ class BitbucketApiAlg[F[_]](
       repo: Repo,
       data: NewPullRequestData
   ): F[Unit] =
-    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+    logger.warn("Updating PRs is not yet supported for Bitbucket")
 
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branch(repo, branch), modify(repo))

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
@@ -101,7 +101,7 @@ class BitbucketApiAlg[F[_]](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] =
+  ): F[Unit] =
     F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
 
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
@@ -97,6 +97,13 @@ class BitbucketApiAlg[F[_]](
     } yield pullRequestOut
   }
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branch(repo, branch), modify(repo))
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -86,6 +86,13 @@ final class BitbucketServerApiAlg[F[_]](
     } yield pr.toPullRequestOut
   }
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   private def useDefaultReviewers(repo: Repo): F[List[Reviewer]] =
     if (config.useDefaultReviewers) getDefaultReviewers(repo) else F.pure(List.empty[Reviewer])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -90,7 +90,7 @@ final class BitbucketServerApiAlg[F[_]](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] =
+  ): F[Unit] =
     F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
 
   private def useDefaultReviewers(repo: Repo): F[List[Reviewer]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -91,7 +91,7 @@ final class BitbucketServerApiAlg[F[_]](
       repo: Repo,
       data: NewPullRequestData
   ): F[Unit] =
-    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+    logger.warn("Updating PRs is not yet supported for Bitbucket Server")
 
   private def useDefaultReviewers(repo: Repo): F[List[Reviewer]] =
     if (config.useDefaultReviewers) getDefaultReviewers(repo) else F.pure(List.empty[Reviewer])

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
@@ -186,6 +186,13 @@ final class GiteaApiAlg[F[_]: HttpJsonClient](
         )
     } yield pullRequestOut(resp)
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] = {
     val edit = EditPullRequestOption(state = "closed")
     client

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
@@ -191,7 +191,7 @@ final class GiteaApiAlg[F[_]: HttpJsonClient](
       repo: Repo,
       data: NewPullRequestData
   ): F[Unit] =
-    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+    logger.warn("Updating PRs is not yet supported for Gitea")
 
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] = {
     val edit = EditPullRequestOption(state = "closed")

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
@@ -190,7 +190,7 @@ final class GiteaApiAlg[F[_]: HttpJsonClient](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] =
+  ): F[Unit] =
     F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
 
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] = {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/CreatePullRequestPayload.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/CreatePullRequestPayload.scala
@@ -21,18 +21,18 @@ import io.circe.generic.semiauto.deriveEncoder
 import org.scalasteward.core.forge.data.NewPullRequestData
 import org.scalasteward.core.git.Branch
 
-final case class PullRequestPayload(
+final case class CreatePullRequestPayload(
     title: String,
     body: String,
     head: String,
     base: Branch,
     draft: Boolean
 )
-object PullRequestPayload {
-  implicit val encoder: Encoder[PullRequestPayload] = deriveEncoder
+object CreatePullRequestPayload {
+  implicit val encoder: Encoder[CreatePullRequestPayload] = deriveEncoder
 
-  def from(newPullRequestData: NewPullRequestData): PullRequestPayload =
-    PullRequestPayload(
+  def from(newPullRequestData: NewPullRequestData): CreatePullRequestPayload =
+    CreatePullRequestPayload(
       title = newPullRequestData.title,
       body = newPullRequestData.body,
       head = newPullRequestData.head,

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -70,7 +70,7 @@ final class GitHubApiAlg[F[_]](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] = {
+  ): F[Unit] = {
     val payload = UpdatePullRequestPayload.from(data)
 
     val update = client
@@ -82,11 +82,11 @@ final class GitHubApiAlg[F[_]](
       .adaptErr(SecondaryRateLimitExceeded.fromThrowable)
 
     for {
-      pullRequestOut <- update
+      _ <- update
       _ <- F.whenA(data.labels.nonEmpty)(labelPullRequest(repo, number, data.labels))
       _ <- F.whenA(data.assignees.nonEmpty)(addAssignees(repo, number, data.assignees))
       _ <- F.whenA(data.reviewers.nonEmpty)(addReviewers(repo, number, data.reviewers))
-    } yield pullRequestOut
+    } yield ()
   }
 
   /** https://docs.github.com/en/rest/repos/branches?apiVersion=2022-11-28#get-branch */

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -46,9 +46,13 @@ final class GitHubApiAlg[F[_]](
 
   /** https://developer.github.com/v3/pulls/#create-a-pull-request */
   override def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut] = {
-    val payload = PullRequestPayload.from(data)
+    val payload = CreatePullRequestPayload.from(data)
     val create = client
-      .postWithBody[PullRequestOut, PullRequestPayload](url.pulls(repo), payload, modify(repo))
+      .postWithBody[PullRequestOut, CreatePullRequestPayload](
+        uri = url.pulls(repo),
+        body = payload,
+        modify = modify(repo)
+      )
       .adaptErr(SecondaryRateLimitExceeded.fromThrowable)
 
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -61,6 +61,13 @@ final class GitHubApiAlg[F[_]](
     } yield pullRequestOut
   }
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   /** https://developer.github.com/v3/repos/branches/#get-branch */
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branches(repo, branch), modify(repo))

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -38,13 +38,13 @@ final class GitHubApiAlg[F[_]](
 ) extends ForgeApiAlg[F] {
   private val url = new Url(gitHubApiHost)
 
-  /** https://developer.github.com/v3/repos/forks/#create-a-fork */
+  /** https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28#create-a-fork */
   override def createFork(repo: Repo): F[RepoOut] =
     client.post[RepoOut](url.forks(repo), modify(repo)).flatTap { repoOut =>
       F.raiseWhen(repoOut.parent.exists(_.archived))(RepositoryArchived(repo))
     }
 
-  /** https://developer.github.com/v3/pulls/#create-a-pull-request */
+  /** https://docs.github.com/en/rest/pulls?apiVersion=2022-11-28#create-a-pull-request */
   override def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut] = {
     val payload = CreatePullRequestPayload.from(data)
     val create = client
@@ -65,6 +65,7 @@ final class GitHubApiAlg[F[_]](
     } yield pullRequestOut
   }
 
+  /** https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#update-a-pull-request */
   override def updatePullRequest(
       number: PullRequestNumber,
       repo: Repo,
@@ -88,21 +89,21 @@ final class GitHubApiAlg[F[_]](
     } yield pullRequestOut
   }
 
-  /** https://developer.github.com/v3/repos/branches/#get-branch */
+  /** https://docs.github.com/en/rest/repos/branches?apiVersion=2022-11-28#get-branch */
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branches(repo, branch), modify(repo))
 
-  /** https://developer.github.com/v3/repos/#get */
+  /** https://docs.github.com/en/rest/repos?apiVersion=2022-11-28#get */
   override def getRepo(repo: Repo): F[RepoOut] =
     client.get[RepoOut](url.repos(repo), modify(repo)).flatTap { repoOut =>
       F.raiseWhen(repoOut.archived)(RepositoryArchived(repo))
     }
 
-  /** https://developer.github.com/v3/pulls/#list-pull-requests */
+  /** https://docs.github.com/en/rest/pulls?apiVersion=2022-11-28#list-pull-requests */
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
     client.get(url.listPullRequests(repo, head, base), modify(repo))
 
-  /** https://developer.github.com/v3/pulls/#update-a-pull-request */
+  /** https://docs.github.com/en/rest/pulls?apiVersion=2022-11-28#update-a-pull-request */
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.patchWithBody[PullRequestOut, UpdateState](
       url.pull(repo, number),
@@ -110,7 +111,7 @@ final class GitHubApiAlg[F[_]](
       modify(repo)
     )
 
-  /** https://developer.github.com/v3/issues#create-an-issue-comment */
+  /** https://docs.github.com/en/rest/issues?apiVersion=2022-11-28#create-an-issue-comment */
   override def commentPullRequest(
       repo: Repo,
       number: PullRequestNumber,
@@ -119,7 +120,8 @@ final class GitHubApiAlg[F[_]](
     client
       .postWithBody(url.comments(repo, number), Comment(comment), modify(repo))
 
-  /** https://docs.github.com/en/rest/reference/issues#add-labels-to-an-issue */
+  /** https://docs.github.com/en/rest/reference/issues?apiVersion=2022-11-28#add-labels-to-an-issue
+    */
   private def labelPullRequest(
       repo: Repo,
       number: PullRequestNumber,

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/UpdatePullRequestPayload.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/UpdatePullRequestPayload.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.forge.github
+
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import org.scalasteward.core.forge.data.NewPullRequestData
+
+final case class UpdatePullRequestPayload(
+    title: String,
+    body: String
+)
+object UpdatePullRequestPayload {
+  implicit val encoder: Encoder[UpdatePullRequestPayload] = deriveEncoder
+
+  def from(newPullRequestData: NewPullRequestData): UpdatePullRequestPayload =
+    UpdatePullRequestPayload(
+      title = newPullRequestData.title,
+      body = newPullRequestData.body
+    )
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -252,7 +252,7 @@ final class GitLabApiAlg[F[_]: Parallel](
       number: PullRequestNumber,
       repo: Repo,
       data: NewPullRequestData
-  ): F[PullRequestOut] =
+  ): F[Unit] =
     F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
 
   private def mergePipelineUponSuccess(repo: Repo, mr: MergeRequestOut): F[MergeRequestOut] =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -248,6 +248,13 @@ final class GitLabApiAlg[F[_]: Parallel](
     updatedMergeRequest.map(_.pullRequestOut)
   }
 
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[PullRequestOut] =
+    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+
   private def mergePipelineUponSuccess(repo: Repo, mr: MergeRequestOut): F[MergeRequestOut] =
     mr match {
       case mr if mr.mergeStatus === GitLabMergeStatus.CanBeMerged =>

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -253,7 +253,7 @@ final class GitLabApiAlg[F[_]: Parallel](
       repo: Repo,
       data: NewPullRequestData
   ): F[Unit] =
-    F.raiseError(new NotImplementedError(s"updatePullRequest($number, $repo, $data)"))
+    logger.warn("Updating PRs is not yet supported for GitLab")
 
   private def mergePipelineUponSuccess(repo: Repo, mr: MergeRequestOut): F[MergeRequestOut] =
     mr match {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -1,7 +1,9 @@
 package org.scalasteward.core.forge.github
 
-import cats.syntax.semigroupk._
+import cats.effect.IO
+import cats.syntax.all._
 import io.circe.literal._
+import io.circe.Json
 import munit.CatsEffectSuite
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
@@ -66,7 +68,19 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
           }]"""
       )
 
-    case PATCH -> Root / "repos" / "fthomas" / "base.g8" / "pulls" / IntVar(_) =>
+    case req @ PATCH -> Root / "repos" / "fthomas" / "base.g8" / "pulls" / IntVar(42) =>
+      req.as[Json].flatMapF(_.hcursor.get[String]("title").liftTo[IO]).flatMap { title =>
+        Ok(
+          json"""{
+            "html_url": "https://github.com/octocat/Hello-World/pull/42",
+            "state": "open",
+            "number": 42,
+            "title": $title
+          }"""
+        )
+      }
+
+    case PATCH -> Root / "repos" / "fthomas" / "base.g8" / "pulls" / IntVar(1347) =>
       Ok(
         json"""{
             "html_url": "https://github.com/octocat/Hello-World/pull/1347",
@@ -115,11 +129,27 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
             "title": "new-feature"
             } """)
 
+    case PATCH -> Root / "repos" / "fthomas" / "cant-assign-reviewers" / "pulls" / "42" =>
+      Created(json"""  {
+            "html_url": "https://github.com/fthomas/cant-assign-reviewers/pull/42",
+            "state": "open",
+            "number": 42,
+            "title": "updated-title"
+            } """)
+
     case POST -> Root / "repos" / "fthomas" / "cant-add-labels" / "pulls" =>
       Created(json"""  {
             "html_url": "https://github.com/octocat/Hello-World/pull/13",
             "state": "open",
             "number": 13,
+            "title": "can't add labels to me"
+            } """)
+
+    case PATCH -> Root / "repos" / "fthomas" / "cant-add-labels" / "pulls" / "42" =>
+      Created(json"""  {
+            "html_url": "https://github.com/fthomas/cant-add-labels/pull/42",
+            "state": "open",
+            "number": 42,
             "title": "can't add labels to me"
             } """)
 
@@ -136,6 +166,9 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
             "default": true
           }]""")
 
+    case POST -> Root / "repos" / "fthomas" / "cant-add-labels" / "issues" / "42" / "labels" =>
+      BadRequest("can't add labels")
+
     case POST -> Root / "repos" / "fthomas" / "cant-add-labels" / "issues" / "13" / "labels" =>
       BadRequest("can't add labels")
 
@@ -151,6 +184,11 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       BadRequest()
 
     case POST ->
+        Root / "repos" / "fthomas" / "cant-assign-reviewers"
+        / "pulls" / IntVar(_) / "requested_reviewers" =>
+      BadRequest()
+
+    case PATCH ->
         Root / "repos" / "fthomas" / "cant-assign-reviewers"
         / "pulls" / IntVar(_) / "requested_reviewers" =>
       BadRequest()
@@ -284,6 +322,31 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     assertIO(pr, pullRequest)
   }
 
+  test("updatePullRequest") {
+    val data = NewPullRequestData(
+      title = "updated-title",
+      body = "body",
+      head = "aaa",
+      base = Branch("master"),
+      labels = Nil,
+      assignees = Nil,
+      reviewers = Nil
+    )
+
+    val number = PullRequestNumber(42)
+
+    val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
+
+    val expected = PullRequestOut(
+      uri"https://github.com/octocat/Hello-World/pull/42",
+      PullRequestState.Open,
+      number,
+      "updated-title"
+    )
+
+    assertIO(pr, expected)
+  }
+
   test("createPullRequest with assignees and reviewers") {
     val data = NewPullRequestData(
       title = "new-feature",
@@ -296,6 +359,31 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
     val pr = gitHubApiAlg.createPullRequest(repo, data).runA(state)
     assertIO(pr, pullRequest)
+  }
+
+  test("updatePullRequest with assignees and reviewers") {
+    val data = NewPullRequestData(
+      title = "updated-title",
+      body = "body",
+      head = "aaa",
+      base = Branch("master"),
+      labels = Nil,
+      assignees = List("foo"),
+      reviewers = List("bar")
+    )
+
+    val number = PullRequestNumber(42)
+
+    val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
+
+    val expected = PullRequestOut(
+      uri"https://github.com/octocat/Hello-World/pull/42",
+      PullRequestState.Open,
+      number,
+      "updated-title"
+    )
+
+    assertIO(pr, expected)
   }
 
   test("createPullRequest with assignees and reviewers should not fail if can't assign") {
@@ -321,6 +409,34 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     assertIO(pullRequestOut, expectedPullRequestOut)
   }
 
+  test("updatePullRequest with assignees and reviewers should not fail if can't assign") {
+    val data = NewPullRequestData(
+      title = "updated-title",
+      body = "body",
+      head = "aaa",
+      base = Branch("master"),
+      labels = Nil,
+      assignees = List("foo"),
+      reviewers = List("bar")
+    )
+
+    val number = PullRequestNumber(42)
+
+    val pr =
+      gitHubApiAlg
+        .updatePullRequest(number, repo.copy(repo = "cant-assign-reviewers"), data)
+        .runA(state)
+
+    val expected = PullRequestOut(
+      uri"https://github.com/fthomas/cant-assign-reviewers/pull/42",
+      PullRequestState.Open,
+      number,
+      "updated-title"
+    )
+
+    assertIO(pr, expected)
+  }
+
   test("createPullRequest with labels") {
     val data = NewPullRequestData(
       title = "new-feature",
@@ -333,6 +449,31 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
     val pr = gitHubApiAlg.createPullRequest(repo, data).runA(state)
     assertIO(pr, pullRequest)
+  }
+
+  test("updatePullRequest with labels") {
+    val data = NewPullRequestData(
+      title = "updated-title",
+      body = "body",
+      head = "aaa",
+      base = Branch("master"),
+      labels = List("foo", "bar"),
+      assignees = Nil,
+      reviewers = Nil
+    )
+
+    val number = PullRequestNumber(42)
+
+    val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
+
+    val expected = PullRequestOut(
+      uri"https://github.com/octocat/Hello-World/pull/42",
+      PullRequestState.Open,
+      number,
+      "updated-title"
+    )
+
+    assertIO(pr, expected)
   }
 
   test("createPullRequest should fail when can't add labels") {
@@ -359,6 +500,38 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
          |  Content-Type: text/plain; charset=UTF-8
          |  Content-Length: 16
          |body: can't add labels""".stripMargin
+    assertIO(error, Right(expectedError))
+  }
+
+  test("updatePullRequest should fail when can't add labels") {
+    val data = NewPullRequestData(
+      title = "updated-title",
+      body = "body",
+      head = "aaa",
+      base = Branch("master"),
+      labels = List("foo", "bar"),
+      assignees = Nil,
+      reviewers = Nil
+    )
+
+    val number = PullRequestNumber(42)
+
+    val error =
+      gitHubApiAlg
+        .updatePullRequest(number, repo.copy(repo = "cant-add-labels"), data)
+        .runA(state)
+        .attempt
+        .map(_.swap.map(_.getMessage))
+
+    val expectedError =
+      """|uri: http://example.com/repos/fthomas/cant-add-labels/issues/42/labels
+         |method: POST
+         |status: 400 Bad Request
+         |headers:
+         |  Content-Type: text/plain; charset=UTF-8
+         |  Content-Length: 16
+         |body: can't add labels""".stripMargin
+
     assertIO(error, Right(expectedError))
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -337,14 +337,7 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
     val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
 
-    val expected = PullRequestOut(
-      uri"https://github.com/octocat/Hello-World/pull/42",
-      PullRequestState.Open,
-      number,
-      "updated-title"
-    )
-
-    assertIO(pr, expected)
+    assertIO(pr, ())
   }
 
   test("createPullRequest with assignees and reviewers") {
@@ -376,14 +369,7 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
     val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
 
-    val expected = PullRequestOut(
-      uri"https://github.com/octocat/Hello-World/pull/42",
-      PullRequestState.Open,
-      number,
-      "updated-title"
-    )
-
-    assertIO(pr, expected)
+    assertIO(pr, ())
   }
 
   test("createPullRequest with assignees and reviewers should not fail if can't assign") {
@@ -427,14 +413,7 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
         .updatePullRequest(number, repo.copy(repo = "cant-assign-reviewers"), data)
         .runA(state)
 
-    val expected = PullRequestOut(
-      uri"https://github.com/fthomas/cant-assign-reviewers/pull/42",
-      PullRequestState.Open,
-      number,
-      "updated-title"
-    )
-
-    assertIO(pr, expected)
+    assertIO(pr, ())
   }
 
   test("createPullRequest with labels") {
@@ -466,14 +445,7 @@ class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
     val pr = gitHubApiAlg.updatePullRequest(number, repo, data).runA(state)
 
-    val expected = PullRequestOut(
-      uri"https://github.com/octocat/Hello-World/pull/42",
-      PullRequestState.Open,
-      number,
-      "updated-title"
-    )
-
-    assertIO(pr, expected)
+    assertIO(pr, ())
   }
 
   test("createPullRequest should fail when can't add labels") {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
@@ -38,8 +38,8 @@ class JsonCodecTest extends FunSuite {
     assertEquals(reviewers, expected)
   }
 
-  test("PullRequestPayload") {
-    val payload = PullRequestPayload(
+  test("CreatePullRequestPayload") {
+    val payload = CreatePullRequestPayload(
       title = "Update logback-classic to 1.2.3",
       body = "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3",
       head = "scala-steward:update/logback-classic-1.2.3",


### PR DESCRIPTION
## 💻 How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## 🚀 What's included in this PR?

This PR includes a new method in `ForgeApiAlg` for updating a PR details. This method will be used when updating a PR to ensure new updates (for example, when using grouping feature) are correctly detailed in the PR body/title.

Currently this is only supported for GitHub forge. Other forges will be added in subsequent PRs.

## References

This PR fixes #3110.