### PR TITLE
Support `scala-steward.conf` (makes sense in `.github` and `.config` folder)

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -1,7 +1,7 @@
 # Repository-specific configuration
 
-You can add a configuration file `.scala-steward.conf` to configure how Scala Steward updates your repository.
-The `.scala-steward.conf` configuration file can be located in the root of your repository, in `.github` directory or in `.config` directory (searched in this order).
+You can add a configuration file named either `.scala-steward.conf` or `scala-steward.conf` to configure how Scala Steward updates your repository.
+The `[.]scala-steward.conf` configuration file can be located in the root of your repository, in `.github` directory or in `.config` directory (searched in this order).
 If a configuration file exists in more than one location, only the first found file is taken into account.
 
 ```properties

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -43,7 +43,7 @@ final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(impli
       )(readRepoConfigFromFile(_))
       _ <- configParsingResult.fold(
         F.unit,
-        error => logger.info(s"Failed to parse $repoConfigBasename: ${error.getMessage}"),
+        error => logger.info(s"Failed to parse $activeConfigFile: ${error.getMessage}"),
         repoConfig => logger.info(s"Parsed repo config ${repoConfig.show}")
       )
     } yield configParsingResult
@@ -86,8 +86,10 @@ object RepoConfigAlg {
   private def activeConfigFile[F[_]](
       repoDir: File
   )(implicit fileAlg: FileAlg[F], logger: Logger[F], F: Monad[F]): F[Option[File]] = {
-    val configFileCandidates: F[List[File]] = repoConfigFileSearchPath
-      .map(_ :+ repoConfigBasename)
+    val configFileCandidates: F[List[File]] = (repoConfigFileSearchPath
+      .map(_ :+ repoConfigBasename) ++
+      repoConfigFileSearchPath
+        .map(_ :+ repoConfigBasename.substring(1)))
       .map(path => path.foldLeft(repoDir)(_ / _))
       .filterA(fileAlg.isRegularFile)
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -264,7 +264,7 @@ class RepoConfigAlgTest extends FunSuite {
     assert(clue(log).contains(startOfErrorMsg))
   }
 
-  test("config file in .github/") {
+  test("hidden config file in .github/") {
     val repo = Repo("test", "dot-github-config")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val rootConfigFile = repoDir / ".scala-steward.conf"
@@ -278,11 +278,39 @@ class RepoConfigAlgTest extends FunSuite {
     assert(config.maybeRepoConfig.isDefined)
   }
 
-  test("config file in .config/") {
+  test("not hidden config file in .github/") {
+    val repo = Repo("test", "dot-github-config")
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
+    val rootConfigFile = repoDir / "scala-steward.conf"
+    val dotGithubConfigFile = repoDir / ".github" / "scala-steward.conf"
+    val initialState = MockState.empty.addFiles(dotGithubConfigFile -> "").unsafeRunSync()
+    val config = repoConfigAlg.readRepoConfig(repo).runA(initialState).unsafeRunSync()
+
+    assert(!fileAlg.isRegularFile(rootConfigFile).unsafeRunSync())
+    assert(fileAlg.isRegularFile(dotGithubConfigFile).unsafeRunSync())
+
+    assert(config.maybeRepoConfig.isDefined)
+  }
+
+  test("hidden config file in .config/") {
     val repo = Repo("test", "dot-config-config")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val rootConfigFile = repoDir / ".scala-steward.conf"
     val dotConfigConfigFile = repoDir / ".config" / ".scala-steward.conf"
+    val initialState = MockState.empty.addFiles(dotConfigConfigFile -> "").unsafeRunSync()
+    val config = repoConfigAlg.readRepoConfig(repo).runA(initialState).unsafeRunSync()
+
+    assert(!fileAlg.isRegularFile(rootConfigFile).unsafeRunSync())
+    assert(fileAlg.isRegularFile(dotConfigConfigFile).unsafeRunSync())
+
+    assert(config.maybeRepoConfig.isDefined)
+  }
+
+  test("not hidden config file in .config/") {
+    val repo = Repo("test", "dot-config-config")
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
+    val rootConfigFile = repoDir / "scala-steward.conf"
+    val dotConfigConfigFile = repoDir / ".config" / "scala-steward.conf"
     val initialState = MockState.empty.addFiles(dotConfigConfigFile -> "").unsafeRunSync()
     val config = repoConfigAlg.readRepoConfig(repo).runA(initialState).unsafeRunSync()
 

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -1,7 +1,7 @@
 # Repository-specific configuration
 
-You can add a configuration file `.scala-steward.conf` to configure how Scala Steward updates your repository.
-The `.scala-steward.conf` configuration file can be located in the root of your repository, in `.github` directory or in `.config` directory (searched in this order).
+You can add a configuration file named either `.scala-steward.conf` or `scala-steward.conf` to configure how Scala Steward updates your repository.
+The `[.]scala-steward.conf` configuration file can be located in the root of your repository, in `.github` directory or in `.config` directory (searched in this order).
 If a configuration file exists in more than one location, only the first found file is taken into account.
 
 ```scala mdoc:passthrough


### PR DESCRIPTION
Without the leading dot (not hidden),

Now that the config can be located inside the already hidden `.github` and `.config` folder (#3033) there is not need for the config file to be hidden as well inside that folders.
To stay backward compatible a hidden config `.scala-steward.conf` will always be preferred, only when such a hidden file can't be found anywhere, only then we try to read the "unhidden" `scala-steward.conf` in the same search order (root, `.github`, `.config` folders)

See https://github.com/scala-steward-org/scala-steward/pull/3033#issuecomment-1629376018