### PR TITLE
Add fs2-data-json migrations

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -90,6 +90,12 @@ migrations = [
     authors: ["Frank Thomas <frank@timepit.eu>"]
   },
   {
+    groupId: "org.gnieh,
+    artifactIds: ["fs2-data-json.*"],
+    newVersion: "1.8.0",
+    rewriteRules: ["github:gnieh/fs2-data/json-parse?sha=v1.8.0"]
+  },
+  {
     groupId: "org.http4s",
     artifactIds: ["http4s-.*"],
     newVersion: "0.22.0",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -90,7 +90,7 @@ migrations = [
     authors: ["Frank Thomas <frank@timepit.eu>"]
   },
   {
-    groupId: "org.gnieh,
+    groupId: "org.gnieh",
     artifactIds: ["fs2-data-json.*"],
     newVersion: "1.8.0",
     rewriteRules: ["github:gnieh/fs2-data/json-parse?sha=v1.8.0"],

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -93,7 +93,8 @@ migrations = [
     groupId: "org.gnieh,
     artifactIds: ["fs2-data-json.*"],
     newVersion: "1.8.0",
-    rewriteRules: ["github:gnieh/fs2-data/json-parse?sha=v1.8.0"]
+    rewriteRules: ["github:gnieh/fs2-data/json-parse?sha=v1.8.0"],
+    doc: "https://github.com/scala-steward-org/scala-steward/pull/3123"
   },
   {
     groupId: "org.http4s",


### PR DESCRIPTION
These migrations attempt to rewrite some pattern that can be improved in the new release.

The rule rewrite following pattern:
```scala
input
  .through(fs2.data.json.tokens)
  .through(fs2.data.json.ast.values)
```

by

```scala
input
  .through(fs2.data.json.ast.parse)
```