### PR TITLE
Add a Scalafix migration for sbt-tpolecat v0.5.0

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -226,5 +226,13 @@ migrations = [
     doc: "https://github.com/scala/scala-collection-compat#collection213upgrade",
     rewriteRules: ["dependency:Collection213Upgrade@org.scala-lang.modules:scala-collection-migrations:2.8.1"], 
     scalacOptions: ["-P:semanticdb:synthetics:on"]
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["sbt-tpolecat"],
+    newVersion: "0.5.0",
+    doc: "https://github.com/typelevel/sbt-tpolecat/blob/main/CHANGELOG.md#050",
+    rewriteRules: ["github:typelevel/sbt-tpolecat/v0_5?sha=v0.5.0"],
+    target: "build"
   }
 ]

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -228,7 +228,7 @@ migrations = [
     scalacOptions: ["-P:semanticdb:synthetics:on"]
   },
   {
-    groupId: "org.typelevel",
+    groupId: "io.github.davidgregory084",
     artifactIds: ["sbt-tpolecat"],
     newVersion: "0.5.0",
     doc: "https://github.com/typelevel/sbt-tpolecat/blob/main/CHANGELOG.md#050",


### PR DESCRIPTION
This PR adds a Scalafix migration for sbt-tpolecat v0.5.0, which will [migrate many of the symbols in the project to a new package](https://github.com/typelevel/sbt-tpolecat/compare/v0.4.4...typelevel-migration-the-second).