### PR TITLE
Update the SHA for the sbt-tpolecat 0.5.0 Scalafix migration

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -232,7 +232,7 @@ migrations = [
     artifactIds: ["sbt-tpolecat"],
     newVersion: "0.5.0",
     doc: "https://github.com/typelevel/sbt-tpolecat/blob/main/CHANGELOG.md#050",
-    rewriteRules: ["github:typelevel/sbt-tpolecat/v0_5?sha=v0.5.0"],
+    rewriteRules: ["github:typelevel/sbt-tpolecat/v0_5?sha=4837a5bad7426c97be9bb3a5b792fd779f5c921a"],
     target: "build"
   }
 ]


### PR DESCRIPTION
This updates the SHA for the sbt-tpolecat Scalafix migration to address some of the issues found in the first batch of migrations.

See also #3133, #3126 