### PR TITLE
Refactor `UpdateInfoUrlFinder`, enhance `ForgeType`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -25,7 +25,7 @@ import eu.timepit.refined.auto._
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.headers.`User-Agent`
-import org.scalasteward.core.application.Config.StewardUsage
+import org.scalasteward.core.application.Config.{ForgeCfg, StewardUsage}
 import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.buildtool.maven.MavenAlg
 import org.scalasteward.core.buildtool.mill.MillAlg
@@ -211,8 +211,8 @@ object Context {
       implicit val forgeApiAlg: ForgeApiAlg[F] =
         ForgeSelection.forgeApiAlg[F](config.forgeCfg, config.forgeSpecificCfg, forgeUser)
       implicit val forgeRepoAlg: ForgeRepoAlg[F] = new ForgeRepoAlg[F](config)
-      implicit val updateInfoUrlFinder: UpdateInfoUrlFinder[F] =
-        new UpdateInfoUrlFinder[F](config.forgeCfg)
+      implicit val forgeCfg: ForgeCfg = config.forgeCfg
+      implicit val updateInfoUrlFinder: UpdateInfoUrlFinder[F] = new UpdateInfoUrlFinder[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](pullRequestsStore)
       implicit val scalafixCli: ScalafixCli[F] = new ScalafixCli[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
@@ -19,6 +19,8 @@ package org.scalasteward.core.coursier
 import cats.Monad
 import cats.syntax.all._
 import org.http4s.Uri
+import org.scalasteward.core.application.Config.ForgeCfg
+import org.scalasteward.core.forge.ForgeRepo
 import org.scalasteward.core.util.uri
 
 final case class DependencyMetadata(
@@ -46,6 +48,9 @@ final case class DependencyMetadata(
     val urls = scmUrl.toList ++ homePage.toList
     urls.find(_.scheme.exists(uri.httpSchemes)).orElse(urls.headOption)
   }
+
+  def forgeRepo(implicit config: ForgeCfg): Option[ForgeRepo] =
+    repoUrl.flatMap(ForgeRepo.fromRepoUrl)
 }
 
 object DependencyMetadata {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -124,6 +124,8 @@ final case class Version(value: String) {
 }
 
 object Version {
+  case class Update(currentVersion: Version, nextVersion: Version)
+
   val tagNames: List[Version => String] = List("v" + _, _.value, "release-" + _)
 
   implicit val versionCodec: Codec[Version] =

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -124,6 +124,8 @@ final case class Version(value: String) {
 }
 
 object Version {
+  val tagNames: List[Version => String] = List("v" + _, _.value, "release-" + _)
+
   implicit val versionCodec: Codec[Version] =
     deriveUnwrappedCodec
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeRepo.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.forge
+
+import org.http4s.Uri
+import org.scalasteward.core.application.Config.ForgeCfg
+
+/** ForgeRepo encapsulates two concepts that are commonly considered together - the URI of a repo,
+  * and the 'type' of forge that url represents. Given a URI, once we know it's a GitHub or GitLab
+  * forge, etc, then we can know how to construct many of the urls for common resources existing at
+  * that repo host- for instance, the url to view a particular file, or to diff two commits.
+  */
+case class ForgeRepo(forgeType: ForgeType, repoUrl: Uri) {
+  def diffUrlFor(from: String, to: String): Uri = forgeType.diffs.forDiff(from, to)(repoUrl)
+
+  def fileUrlFor(fileName: String): Uri = forgeType.files.forFile(fileName)(repoUrl)
+}
+
+object ForgeRepo {
+  def fromRepoUrl(repoUrl: Uri)(implicit config: ForgeCfg): Option[ForgeRepo] = for {
+    repoForgeType <- ForgeType.fromRepoUrl(repoUrl)
+  } yield ForgeRepo(repoForgeType, repoUrl)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -49,10 +49,7 @@ object ForgeType {
     override val publicWebHost: Some[String] = Some("dev.azure.com")
     override def supportsForking: Boolean = false
     val diffs: DiffUriPattern = (from, to) =>
-      _ / "branchCompare" withQueryParams Map(
-        "baseVersion" -> s"GT$from",
-        "targetVersion" -> s"GT$to"
-      )
+      _ / "branchCompare" +? ("baseVersion", s"GT$from") +? ("targetVersion", s"GT$to")
     val files: FileUriPattern =
       fileName =>
         _.withQueryParam(

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -18,12 +18,16 @@ package org.scalasteward.core.forge
 
 import cats.Eq
 import cats.syntax.all._
+import org.http4s.Uri
 import org.http4s.syntax.literals._
+import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.forge.ForgeType._
 import org.scalasteward.core.util.unexpectedString
 
 sealed trait ForgeType extends Product with Serializable {
   def publicWebHost: Option[String]
+  val diffs: DiffUriPattern
+  val files: FileUriPattern
   def supportsForking: Boolean = true
   def supportsLabels: Boolean = true
 
@@ -38,35 +42,64 @@ sealed trait ForgeType extends Product with Serializable {
 }
 
 object ForgeType {
+  trait DiffUriPattern { def forDiff(from: String, to: String): Uri => Uri }
+  trait FileUriPattern { def forFile(fileName: String): Uri => Uri }
+
   case object AzureRepos extends ForgeType {
     override val publicWebHost: Some[String] = Some("dev.azure.com")
     override def supportsForking: Boolean = false
+    val diffs: DiffUriPattern = (from, to) =>
+      _ / "branchCompare" withQueryParams Map(
+        "baseVersion" -> s"GT$from",
+        "targetVersion" -> s"GT$to"
+      )
+    val files: FileUriPattern =
+      fileName =>
+        _.withQueryParam(
+          "path",
+          fileName
+        ) // Azure's canonical value for the path is prefixed with a slash?
   }
 
   case object Bitbucket extends ForgeType {
     override val publicWebHost: Some[String] = Some("bitbucket.org")
     override def supportsLabels: Boolean = false
     val publicApiBaseUrl = uri"https://api.bitbucket.org/2.0"
+    val diffs: DiffUriPattern = (from, to) => _ / "compare" / s"$to..$from" withFragment "diff"
+    val files: FileUriPattern = fileName => _ / "src" / "master" / fileName
   }
 
+  /** Note Bitbucket Server will be End Of Service Life on 15th February 2024:
+    *
+    * https://www.atlassian.com/software/bitbucket/enterprise
+    * https://www.atlassian.com/migration/assess/journey-to-cloud
+    */
   case object BitbucketServer extends ForgeType {
     override val publicWebHost: None.type = None
     override def supportsForking: Boolean = false
     override def supportsLabels: Boolean = false
+    val diffs: DiffUriPattern = Bitbucket.diffs
+    val files: FileUriPattern = fileName => _ / "browse" / fileName
   }
 
   case object GitHub extends ForgeType {
     override val publicWebHost: Some[String] = Some("github.com")
     val publicApiBaseUrl = uri"https://api.github.com"
+    val diffs: DiffUriPattern = (from, to) => _ / "compare" / s"$from...$to"
+    val files: FileUriPattern = fileName => _ / "blob" / "master" / fileName
   }
 
   case object GitLab extends ForgeType {
     override val publicWebHost: Some[String] = Some("gitlab.com")
     val publicApiBaseUrl = uri"https://gitlab.com/api/v4"
+    val diffs: DiffUriPattern = GitHub.diffs
+    val files: FileUriPattern = GitHub.files
   }
 
   case object Gitea extends ForgeType {
     override val publicWebHost: Option[String] = None
+    val diffs: DiffUriPattern = GitHub.diffs
+    val files: FileUriPattern = fileName => _ / "src" / "branch" / "master" / fileName
   }
 
   val all: List[ForgeType] = List(AzureRepos, Bitbucket, BitbucketServer, GitHub, GitLab, Gitea)
@@ -82,6 +115,16 @@ object ForgeType {
 
   def fromPublicWebHost(host: String): Option[ForgeType] =
     all.find(_.publicWebHost.contains_(host))
+
+  /** Attempts to guess, based on the uri host and the config used to launch Scala Steward, what
+    * type of forge hosts the repo at the supplied uri.
+    */
+  def fromRepoUrl(repoUrl: Uri)(implicit config: ForgeCfg): Option[ForgeType] =
+    repoUrl.host.flatMap { repoHost =>
+      Option
+        .when(config.apiHost.host.contains(repoHost))(config.tpe)
+        .orElse(fromPublicWebHost(repoHost.value))
+    }
 
   implicit val forgeTypeEq: Eq[ForgeType] =
     Eq.fromUniversalEquals

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -26,7 +26,17 @@ import org.scalasteward.core.util.unexpectedString
 
 sealed trait ForgeType extends Product with Serializable {
   def publicWebHost: Option[String]
+
+  /** Defines how to construct 'diff' urls for this forge type - ie a url that will show the
+    * difference between two git tags. These can be very useful for understanding the difference
+    * between two releases of the same artifact.
+    */
   val diffs: DiffUriPattern
+
+  /** Defines how to construct 'file' urls for this forge type - ie a url that will display a
+    * specific file's contents. This is useful for linking to Release Notes, etc, in a Scala Steward
+    * PR description.
+    */
   val files: FileUriPattern
   def supportsForking: Boolean = true
   def supportsLabels: Boolean = true

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -217,7 +217,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
         case (currentVersion, dependency) =>
           dependencyToMetadata.get(dependency).toList.traverse { metadata =>
             updateInfoUrlFinder
-              .findUpdateInfoUrls(metadata, currentVersion, dependency.version)
+              .findUpdateInfoUrls(metadata, Version.Update(currentVersion, dependency.version))
               .tupleLeft(dependency.artifactId.name)
           }
       }

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
@@ -1,0 +1,81 @@
+package org.scalasteward.core.forge
+
+import munit.FunSuite
+import org.http4s.Uri
+import org.http4s.implicits._
+import org.scalasteward.core.forge.ForgeType._
+
+/** As much as possible, uris in this test suite should aim to be real, clickable, uris that
+  * actually go to real pages, allowing developers working against this test suite to verify that
+  * the url patterns constructed here actually _are_ valid, and match what forges are currently
+  * using in the real world.
+  */
+class ForgeRepoTest extends FunSuite {
+
+  def check(
+      repo: ForgeRepo,
+      expectedReadme: Uri,
+      diffTags: (String, String),
+      expectedDiff: Uri
+  ): Unit = {
+    assertEquals(repo.fileUrlFor("README.md"), expectedReadme)
+    assertEquals(repo.diffUrlFor(diffTags._1, diffTags._2), expectedDiff)
+  }
+
+  test("GitHub url patterns") {
+    check(
+      ForgeRepo(GitHub, uri"https://github.com/scala-steward-org/scala-steward-action"),
+      uri"https://github.com/scala-steward-org/scala-steward-action/blob/master/README.md",
+      "v2.55.0" -> "v2.56.0",
+      uri"https://github.com/scala-steward-org/scala-steward-action/compare/v2.55.0...v2.56.0"
+    )
+  }
+
+  test("GitLab url patterns") {
+    check(
+      ForgeRepo(GitLab, uri"https://gitlab.com/gitlab-org/gitlab"),
+      uri"https://gitlab.com/gitlab-org/gitlab/blob/master/README.md",
+      "v15.11.8-ee" -> "v15.11.9-ee",
+      uri"https://gitlab.com/gitlab-org/gitlab/compare/v15.11.8-ee...v15.11.9-ee"
+    )
+  }
+
+  test("Gitea url patterns") {
+    check(
+      ForgeRepo(Gitea, uri"https://gitea.com/lunny/levelqueue"),
+      uri"https://gitea.com/lunny/levelqueue/src/branch/master/README.md",
+      "v0.1.0" -> "v0.2.0",
+      uri"https://gitea.com/lunny/levelqueue/compare/v0.1.0...v0.2.0"
+    )
+  }
+
+  test("Azure url patterns") {
+    check(
+      ForgeRepo(
+        AzureRepos,
+        uri"https://dev.azure.com/rtyley/scala-steward-testing/_git/scala-steward-testing"
+      ),
+      uri"https://dev.azure.com/rtyley/scala-steward-testing/_git/scala-steward-testing?path=README.md",
+      "v1.0.0" -> "v1.0.1",
+      uri"https://dev.azure.com/rtyley/scala-steward-testing/_git/scala-steward-testing/branchCompare?baseVersion=GTv1.0.0&targetVersion=GTv1.0.1"
+    )
+  }
+
+  test("BitBucket url patterns") {
+    check(
+      ForgeRepo(Bitbucket, uri"https://bitbucket.org/rtyley/scala-steward-test-repo"),
+      uri"https://bitbucket.org/rtyley/scala-steward-test-repo/src/master/README.md",
+      "v1.0.0" -> "v1.0.1",
+      uri"https://bitbucket.org/rtyley/scala-steward-test-repo/compare/v1.0.1..v1.0.0#diff"
+    )
+  }
+
+  test("BitBucket Server url patterns") {
+    check(
+      ForgeRepo(BitbucketServer, uri"https://bitbucket-server.on-prem.com/foo/bar"),
+      uri"https://bitbucket-server.on-prem.com/foo/bar/browse/README.md",
+      "v1.0.0" -> "v1.0.1",
+      uri"https://bitbucket-server.on-prem.com/foo/bar/compare/v1.0.1..v1.0.0#diff"
+    )
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -27,16 +27,17 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
   private val v1 = Version("0.1.0")
   private val v2 = Version("0.2.0")
+  private val versionUpdate = Version.Update(v1, v2)
 
   test("findUpdateInfoUrls: repoUrl not found") {
     val metadata = DependencyMetadata.empty.copy(scmUrl = uri"https://github.com/foo/foo".some)
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     assertIO(obtained, List.empty)
   }
 
   test("findUpdateInfoUrls: repoUrl ok") {
     val metadata = DependencyMetadata.empty.copy(scmUrl = uri"https://github.com/foo/bar".some)
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     val expected = List(VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0"))
     assertIO(obtained, expected)
   }
@@ -46,7 +47,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       scmUrl = uri"https://github.com/foo/bar".some,
       releaseNotesUrl = uri"https://github.com/foo/bar/README.md#changelog".some
     )
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     val expected = List(
       CustomReleaseNotes(metadata.releaseNotesUrl.get),
       VersionDiff(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
@@ -59,7 +60,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       scmUrl = uri"https://github.com/foo/bar2".some,
       releaseNotesUrl = uri"https://github.com/foo/bar2/releases/tag/v0.2.0".some
     )
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     val expected = List(GitHubReleaseNotes(metadata.releaseNotesUrl.get))
     assertIO(obtained, expected)
   }
@@ -69,14 +70,14 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       scmUrl = uri"https://github.com/foo/bar1".some,
       releaseNotesUrl = uri"https://github.com/foo/bar1/blob/master/RELEASES.md".some
     )
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     val expected = List(CustomReleaseNotes(metadata.releaseNotesUrl.get))
     assertIO(obtained, expected)
   }
 
   test("findUpdateInfoUrls: repoUrl permanent redirect") {
     val metadata = DependencyMetadata.empty.copy(scmUrl = uri"https://github.com/foo/buz".some)
-    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = updateInfoUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     assertIO(obtained, List.empty)
   }
 
@@ -95,14 +96,14 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("findUpdateInfoUrls: on-prem, repoUrl not found") {
     val metadata =
       DependencyMetadata.empty.copy(scmUrl = uri"https://github.on-prem.com/foo/foo".some)
-    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     assertIO(obtained, List.empty)
   }
 
   test("findUpdateInfoUrls: on-prem, repoUrl ok") {
     val metadata =
       DependencyMetadata.empty.copy(scmUrl = uri"https://github.on-prem.com/foo/bar".some)
-    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     val expected =
       List(VersionDiff(uri"https://github.on-prem.com/foo/bar/compare/v0.1.0...v0.2.0"))
     assertIO(obtained, expected)
@@ -111,7 +112,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("findUpdateInfoUrls: on-prem, repoUrl permanent redirect") {
     val metadata =
       DependencyMetadata.empty.copy(scmUrl = uri"https://github.on-prem.com/foo/buz".some)
-    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, v1, v2).runA(state)
+    val obtained = onPremUpdateUrlFinder.findUpdateInfoUrls(metadata, versionUpdate).runA(state)
     assertIO(obtained, List.empty)
   }
 
@@ -119,7 +120,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val onPremForgeUrl = uri"https://github.onprem.io/"
 
     assertEquals(
-      possibleVersionDiffs(gitHubFooBarRepo, v1, v2)
+      possibleVersionDiffs(gitHubFooBarRepo, versionUpdate)
         .map(_.url.renderString),
       List(
         s"https://github.com/foo/bar/compare/v$v1...v$v2",
@@ -130,7 +131,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
 
     // should canonicalize (drop last slash)
     assertEquals(
-      possibleVersionDiffs(gitHubFooBarRepo, v1, v2)
+      possibleVersionDiffs(gitHubFooBarRepo, versionUpdate)
         .map(_.url.renderString),
       List(
         s"https://github.com/foo/bar/compare/v$v1...v$v2",
@@ -140,7 +141,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
 
     assertEquals(
-      possibleVersionDiffs(gitLabFooBarRepo, v1, v2)
+      possibleVersionDiffs(gitLabFooBarRepo, versionUpdate)
         .map(_.url.renderString),
       List(
         s"https://gitlab.com/foo/bar/compare/v$v1...v$v2",
@@ -150,7 +151,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
 
     assertEquals(
-      possibleVersionDiffs(bitbucketFooBarRepo, v1, v2)
+      possibleVersionDiffs(bitbucketFooBarRepo, versionUpdate)
         .map(_.url.renderString),
       List(
         s"https://bitbucket.org/foo/bar/compare/v$v2..v$v1#diff",
@@ -160,7 +161,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
 
     assertEquals(
-      possibleVersionDiffs(ForgeRepo(GitHub, onPremForgeUrl.addPath("foo/bar")), v1, v2)
+      possibleVersionDiffs(ForgeRepo(GitHub, onPremForgeUrl.addPath("foo/bar")), versionUpdate)
         .map(_.url.renderString),
       List(
         s"${onPremForgeUrl}foo/bar/compare/v$v1...v$v2",
@@ -170,7 +171,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
 
     assertEquals(
-      possibleVersionDiffs(ForgeRepo(AzureRepos, onPremForgeUrl.addPath("foo/bar")), v1, v2)
+      possibleVersionDiffs(ForgeRepo(AzureRepos, onPremForgeUrl.addPath("foo/bar")), versionUpdate)
         .map(_.url.renderString),
       List(
         s"${onPremForgeUrl}foo/bar/branchCompare?baseVersion=GTv$v1&targetVersion=GTv$v2",
@@ -183,8 +184,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("possibleUpdateInfoUrls: github.com") {
     val obtained = possibleUpdateInfoUrls(
       gitHubFooBarRepo,
-      v1,
-      v2
+      versionUpdate
     ).map(_.url.renderString)
     val expected = List(
       s"https://github.com/foo/bar/releases/tag/v$v2",
@@ -224,8 +224,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("possibleUpdateInfoUrls: gitlab.com") {
     val obtained = possibleUpdateInfoUrls(
       gitLabFooBarRepo,
-      v1,
-      v2
+      versionUpdate
     ).map(_.url.renderString)
     val expected =
       possibleReleaseNotesFilenames.map(name => s"https://gitlab.com/foo/bar/blob/master/$name") ++
@@ -241,8 +240,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("possibleUpdateInfoUrls: on-prem gitlab") {
     val obtained = possibleUpdateInfoUrls(
       ForgeRepo(GitLab, uri"https://gitlab.on-prem.net/foo/bar"),
-      v1,
-      v2
+      versionUpdate
     ).map(_.url.renderString)
     val expected = possibleReleaseNotesFilenames.map(name =>
       s"https://gitlab.on-prem.net/foo/bar/blob/master/$name"
@@ -259,8 +257,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("possibleUpdateInfoUrls: bitbucket.org") {
     val obtained = possibleUpdateInfoUrls(
       bitbucketFooBarRepo,
-      v1,
-      v2
+      versionUpdate
     ).map(_.url.renderString)
     val expected =
       possibleReleaseNotesFilenames.map(name =>
@@ -278,7 +275,7 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("possibleUpdateInfoUrls: on-prem Bitbucket Server") {
     val repoUrl = uri"https://bitbucket-server.on-prem.com" / "foo" / "bar"
     val obtained =
-      possibleUpdateInfoUrls(ForgeRepo(BitbucketServer, repoUrl), v1, v2).map(_.url)
+      possibleUpdateInfoUrls(ForgeRepo(BitbucketServer, repoUrl), versionUpdate).map(_.url)
     val expected = repoUrl / "browse" / "ReleaseNotes.md"
     assert(clue(obtained).contains(expected))
   }


### PR DESCRIPTION
This PR has 3 commits, which each can be reviewed separately and contain a single refactor:

* ➡️ replace conditionals in `UpdateInfoUrlFinder` with polymorphism on `ForgeType` - responsibility for generating urls displaying diffs & files moves to `ForgeType`
* 📦 introduce `ForgeRepo` as a parameter object
* 📦 introduce `Version.Update` as a parameter object

_(as it happens, each subsequent refactor here is smaller than the last)_

Cumulatively, the benefits of these changes are:

* **clearer responsibility**: when supporting a new type of forge, the responsibility is now solely implementing a new instance of `ForgeType`, without also having to search out additional switch statements elsewhere in the codebase
* **reduced parameter count** for several methods - for instance, `possibleUpdateInfoUrls()` & `possibleVersionDiffs()` both go **from 5 to 2** parameters.
* **more focused testing of generated urls**: a new test suite, `ForgeRepoTest`, has been introduced which gives clear examples of what diff and file urls look like for different forge types. The urls included in the tests correspond to real live repos as much as possible, so it's possible to click through on them and see that they do indeed correspond to real urls genuinely served by those different forge hosts (note that Azure diff urls have been fixed). The tests here have some overlap with `UpdateInfoUrlFinderTest`, but are more focussed on making sure that generated url structure is correct, rather than ensuring the correct info sources (release notes, diffs) have been identified for a given dependency update.