### PR TITLE
Allow groupId `com.typesafe.play`, exact version `2.9.0-RC1`

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -31,7 +31,6 @@ updates.ignore = [
   // Wait with sbt 1.9.5 until we know more about https://github.com/scala/bug/issues/12868
   { groupId = "org.scala-sbt", artifactId = "sbt", version = { exact = "1.9.5" } },
   // The following libraries were published with sbt 1.9.5 and should therefore not be released into the wild:
-  { groupId = "com.typesafe.play", version = { exact = "2.9.0-RC1" } },
   { groupId = "com.typesafe.play", artifactId = "sbt-play-ebean", version = { exact = "7.0.0-RC1" } },
   { groupId = "com.typesafe.play", artifactId = "play-ebean", version = { exact = "7.0.0-RC1" } },
   { groupId = "com.typesafe.play", artifactId = "play-file-watch", version = { exact = "1.2.0" } },


### PR DESCRIPTION
We have published RC2 now, so this line from #3169 can be reverted, so other Play libs are allowed to release a version `2.9.0-RC1` (since the `artifactId` is missing). Everything else can stay as it matches the exact version with the artifactId.