### PR TITLE
OpenTelemetry Semantic Conventions groupId migrated

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -994,4 +994,9 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-osgi
   },
+  {
+    groupIdBefore = io.opentelemetry.semconv
+    groupIdAfter = io.opentelemetry
+    artifactIdAfter = opentelemetry-semconv
+  },
 ]


### PR DESCRIPTION
I noticed that we didn't automatically get prompted to version bump opentelemetry-semconv.

This should be the needed additions for the groupId migration