### PR TITLE
Add label for artifact migrations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -314,12 +314,18 @@ object NewPullRequestData {
     val semverLabels =
       update.on(u => semverForUpdate(u), _.updates.flatMap(semverForUpdate(_)).distinct)
 
+    val artifactMigrationsLabel = Option.when {
+      update.asSingleUpdates
+        .flatMap(_.forArtifactIds.toList)
+        .exists(u => u.newerGroupId.nonEmpty || u.newerArtifactId.nonEmpty)
+    }("artifact-migrations")
     val scalafixLabel = edits.collectFirst { case _: ScalafixEdit => "scalafix-migrations" }
     val oldVersionLabel = Option.when(filesWithOldVersion.nonEmpty)("old-version-remains")
 
     List.concat(
       updateTypeLabels(update),
       semverLabels,
+      artifactMigrationsLabel,
       scalafixLabel,
       oldVersionLabel,
       List(commitCountLabel)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -131,7 +131,7 @@ class NewPullRequestDataTest extends FunSuite {
     assertEquals(body, expected)
   }
 
-  test("bodyFor() groupped update") {
+  test("bodyFor() grouped update") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
     val update = Update.Grouped("my-group", Some("The PR title"), List(update1, update2))
@@ -515,6 +515,13 @@ class NewPullRequestDataTest extends FunSuite {
     assertEquals(labels, expected)
   }
 
+  test("artifact-migrations label") {
+    val update = ("a".g % "b".a % "1" -> "2").single.copy(newerGroupId = Some("aa".g))
+    val obtained = labelsFor(update)
+    val expected = List("library-update", "artifact-migrations", "commit-count:0")
+    assertEquals(obtained, expected)
+  }
+
   test("oldVersionNote doesn't show version for grouped updates") {
     val files = List("Readme.md", "travis.yml")
     val update1 = ("a".g % "b".a % "1" -> "2").single
@@ -539,7 +546,7 @@ class NewPullRequestDataTest extends FunSuite {
     )
   }
 
-  test("adjustFutureUpdates for grouped udpates shows settings for each update") {
+  test("adjustFutureUpdates for grouped updates shows settings for each update") {
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
     val update = Update.Grouped("my-group", None, List(update1, update2))


### PR DESCRIPTION
This adds a `artifact-migrations` label for updates where the groupId and/or artifactId is changed. My main motivation for this label is to search for PRs that rewrite the groupId/artifactId on GitHub and to add this search to our [Artifact Migrations documentation](https://github.com/scala-steward-org/scala-steward/blob/main/docs/artifact-migrations.md).