### PR TITLE
Migration for play-swagger

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -994,4 +994,9 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-osgi
   },
+  {
+    groupIdBefore = com.iheart
+    groupIdAfter = io.github.play-swagger
+    artifactIdAfter = sbt-play-swagger
+  },
 ]


### PR DESCRIPTION
I am taking over the maintenance of [play-swagger](https://github.com/iheartradio/play-swagger/), which has been discontinued by `com.iheart`.

With the change in maintainer, the groupId has been changed. Therefore, please allow me to add instructions for migration settings.

[docs: Add guide for repository migration](https://github.com/iheartradio/play-swagger/pull/606)