### PR TITLE
Use sbt-tpolecat's DevMode if CI env var is not set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,11 @@ ThisBuild / dynverSeparator := "-"
 
 ThisBuild / evictionErrorLevel := Level.Info
 
+ThisBuild / tpolecatDefaultOptionsMode := {
+  val isCiBuild = sys.env.get("CI").fold(false)(_ == "true")
+  if (isCiBuild) org.typelevel.sbt.tpolecat.CiMode else org.typelevel.sbt.tpolecat.DevMode
+}
+
 /// projects
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -85,8 +85,7 @@ ThisBuild / dynverSeparator := "-"
 ThisBuild / evictionErrorLevel := Level.Info
 
 ThisBuild / tpolecatDefaultOptionsMode := {
-  val isCiBuild = sys.env.get("CI").fold(false)(_ == "true")
-  if (isCiBuild) org.typelevel.sbt.tpolecat.CiMode else org.typelevel.sbt.tpolecat.DevMode
+  if (insideCI.value) org.typelevel.sbt.tpolecat.CiMode else org.typelevel.sbt.tpolecat.DevMode
 }
 
 /// projects


### PR DESCRIPTION
`DevMode` is nicer for development because it does not set `-Xfatal-warnings`. More about sbt-tpolecat's modes can be found here: https://github.com/typelevel/sbt-tpolecat#modes