### PR TITLE
Use default resolver in `MillAlg`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -216,7 +216,7 @@ object Context {
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](pullRequestsStore)
       implicit val scalafixCli: ScalafixCli[F] = new ScalafixCli[F]
-      implicit val scalafmtAlg: ScalafmtAlg[F] = new ScalafmtAlg[F](config)
+      implicit val scalafmtAlg: ScalafmtAlg[F] = new ScalafmtAlg[F](config.defaultResolver)
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F](config)
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create[F]
       implicit val versionsCache: VersionsCache[F] =
@@ -225,7 +225,7 @@ object Context {
       implicit val mavenAlg: MavenAlg[F] = new MavenAlg[F](config)
       implicit val sbtAlg: SbtAlg[F] = new SbtAlg[F](config)
       implicit val scalaCliAlg: ScalaCliAlg[F] = new ScalaCliAlg[F]
-      implicit val millAlg: MillAlg[F] = new MillAlg[F]
+      implicit val millAlg: MillAlg[F] = new MillAlg[F](config.defaultResolver)
       implicit val buildToolDispatcher: BuildToolDispatcher[F] = new BuildToolDispatcher[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
         new RefreshErrorAlg[F](refreshErrorStore, config.refreshBackoffPeriod)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -95,8 +95,8 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       buildRootDir: File
   ): F[Seq[Scope[List[Dependency]]]] =
     for {
-      buildConent <- fileAlg.readFile(buildRootDir / "build.sc")
-      deps = buildConent.toList.map(content =>
+      buildContent <- fileAlg.readFile(buildRootDir / "build.sc")
+      deps = buildContent.toList.map(content =>
         Scope(parser.parseMillPluginDeps(content, millVersion), List(defaultResolver))
       )
     } yield deps

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -27,7 +27,7 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class MillAlg[F[_]](implicit
+final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
     processAlg: ProcessAlg[F],
@@ -66,7 +66,7 @@ final class MillAlg[F[_]](implicit
       )
       dependencies = parsed.map(module => Scope(module.dependencies, module.repositories))
       millBuildDeps = millBuildVersion.toSeq.map(version =>
-        Scope(List(millMainArtifact(version)), List(millMainResolver))
+        Scope(List(millMainArtifact(version)), List(defaultResolver))
       )
       millPluginDeps <- millBuildVersion match {
         case None        => F.pure(Seq.empty[Scope[List[Dependency]]])
@@ -97,7 +97,7 @@ final class MillAlg[F[_]](implicit
     for {
       buildConent <- fileAlg.readFile(buildRootDir / "build.sc")
       deps = buildConent.toList.map(content =>
-        Scope(parser.parseMillPluginDeps(content, millVersion), List(millMainResolver))
+        Scope(parser.parseMillPluginDeps(content, millVersion), List(defaultResolver))
       )
     } yield deps
 }
@@ -129,7 +129,6 @@ object MillAlg {
 
   val extractDeps: String = "org.scalasteward.mill.plugin.StewardPlugin/extractDeps"
 
-  private val millMainResolver: Resolver = Resolver.mavenCentral
   private val millMainGroupId = GroupId("com.lihaoyi")
   private val millMainArtifactId = ArtifactId("mill-main", "mill-main_2.13")
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -20,16 +20,15 @@ import cats.Monad
 import cats.data.OptionT
 import cats.syntax.all._
 import io.circe.ParsingFailure
-import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.data.{Scope, Version}
+import org.scalasteward.core.data.{Resolver, Scope, Version}
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.{opts, parseScalafmtConf}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class ScalafmtAlg[F[_]](config: Config)(implicit
+final class ScalafmtAlg[F[_]](defaultResolver: Resolver)(implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
     processAlg: ProcessAlg[F],
@@ -49,7 +48,7 @@ final class ScalafmtAlg[F[_]](config: Config)(implicit
 
   def getScopedScalafmtDependency(buildRoot: BuildRoot): F[Option[Scope.Dependencies]] =
     OptionT(getScalafmtVersion(buildRoot))
-      .map(version => Scope(List(scalafmtDependency(version)), List(config.defaultResolver)))
+      .map(version => Scope(List(scalafmtDependency(version)), List(defaultResolver)))
       .value
 
   def reformatChanged(buildRoot: BuildRoot): F[Unit] =


### PR DESCRIPTION
... instead of hardcoding Maven Central. If the default resolver is not overridden it, it will be Maven Central, so nothing will change in this case.

I'm doing this for the same reason as given in https://github.com/scala-steward-org/scala-steward/pull/1899 where the hardcoded Maven Central was replaced in `SbtAlg` with the default resolver.