### PR TITLE
Remove `-Xfatal-warnings` comment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -297,8 +297,6 @@ lazy val commonSettings = Def.settings(
 
 lazy val compileSettings = Def.settings(
   scalaVersion := Scala213,
-  // Uncomment for local development:
-  // scalacOptions -= "-Xfatal-warnings",
   doctestTestFramework := DoctestTestFramework.Munit
 )
 


### PR DESCRIPTION
This is not necessary anymore since https://github.com/scala-steward-org/scala-steward/pull/3233.