### PR TITLE
We migrate play-silhouette to the Play Framework organization

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -999,4 +999,79 @@ changes = [
     groupIdAfter = io.github.play-swagger
     artifactIdAfter = sbt-play-swagger
   },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-cas
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter =play-silhouette-crypto-jca
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-password-bcrypt
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-persistence
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-testkit
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-totp
+  },
+  {
+    groupIdBefore = com.mohiva
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-cas
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter =play-silhouette-crypto-jca
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-password-argon2
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-password-bcrypt
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-persistence
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-testkit
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette-totp
+  },
+  {
+    groupIdBefore = io.github.honeycomb-cheesecake
+    groupIdAfter = org.playframework.silhouette
+    artifactIdAfter = play-silhouette
+  },
 ]


### PR DESCRIPTION
Old groupId(s)
- https://repo1.maven.org/maven2/com/mohiva/
- https://repo1.maven.org/maven2/io/github/honeycomb-cheesecake/

The new groupId:
- https://repo1.maven.org/maven2/org/playframework/silhouette/

The project itself:
- https://github.com/playframework/play-silhouette

Thanks!