### PR TITLE
Add default implementation for `BuildToolAlg#runMigration`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
@@ -18,6 +18,8 @@ package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
+import org.typelevel.log4cats.Logger
+import scala.annotation.nowarn
 
 trait BuildToolAlg[F[_]] {
   def name: String
@@ -26,5 +28,13 @@ trait BuildToolAlg[F[_]] {
 
   def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]]
 
-  def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit]
+  def runMigration(@nowarn buildRoot: BuildRoot, @nowarn migration: ScalafixMigration): F[Unit] =
+    logger.warn(
+      s"Scalafix migrations are currently not supported in $name projects" +
+        scalafixIssue.fold("")(issue => s", see $issue for details")
+    )
+
+  protected def logger: Logger[F]
+
+  protected def scalafixIssue: Option[String] = None
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -22,14 +22,13 @@ import cats.syntax.all._
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data._
-import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
 final class MavenAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],
-    logger: Logger[F],
+    override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
     workspaceAlg: WorkspaceAlg[F],
     F: MonadCancelThrow[F]
@@ -56,10 +55,8 @@ final class MavenAlg[F[_]](config: Config)(implicit
       resolvers = parser.parseResolvers(repositoriesRaw).distinct
     } yield List(Scope(dependencies, resolvers))
 
-  override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-    logger.warn(
-      s"Scalafix migrations are currently not supported in $name projects, see https://github.com/scala-steward-org/scala-steward/issues/2839 for details"
-    )
+  override protected val scalafixIssue: Option[String] =
+    Some("https://github.com/scala-steward-org/scala-steward/issues/2839")
 
   private def exec(command: Nel[String], repoDir: File): F[List[String]] =
     maybeIgnoreOptsFiles(repoDir).surround(processAlg.execSandboxed(command, repoDir))

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -22,14 +22,13 @@ import cats.syntax.all._
 import org.scalasteward.core.buildtool.mill.MillAlg._
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data._
-import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
 final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
     fileAlg: FileAlg[F],
-    logger: Logger[F],
+    override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
     workspaceAlg: WorkspaceAlg[F],
     F: MonadCancelThrow[F]
@@ -82,10 +81,8 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       dependencies = parsed.map(module => Scope(module.dependencies, module.repositories))
     } yield dependencies
 
-  override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-    logger.warn(
-      s"Scalafix migrations are currently not supported in $name projects, see https://github.com/scala-steward-org/scala-steward/issues/2838 for details"
-    )
+  override protected val scalafixIssue: Option[String] =
+    Some("https://github.com/scala-steward-org/scala-steward/issues/2838")
 
   private def getMillVersion(buildRootDir: File): F[Option[Version]] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -29,9 +29,11 @@ import org.scalasteward.core.edit.scalafix.{ScalafixCli, ScalafixMigration}
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
+import org.typelevel.log4cats.Logger
 
 final class SbtAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],
+    override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
     scalafixCli: ScalafixCli[F],
     workspaceAlg: WorkspaceAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
@@ -21,7 +21,6 @@ import cats.syntax.all._
 import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data.Scope
-import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -53,7 +52,7 @@ object ScalaCliAlg {
 final class ScalaCliAlg[F[_]](implicit
     fileAlg: FileAlg[F],
     gitAlg: GitAlg[F],
-    logger: Logger[F],
+    override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
     sbtAlg: SbtAlg[F],
     workspaceAlg: WorkspaceAlg[F],
@@ -92,8 +91,6 @@ final class ScalaCliAlg[F[_]](implicit
       _ <- fileAlg.deleteForce(buildRootDir / exportDir)
     } yield dependencies
 
-  override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
-    logger.warn(
-      s"Scalafix migrations are currently not supported in $name projects, see https://github.com/VirtusLab/scala-cli/issues/647 for details"
-    )
+  override protected val scalafixIssue: Option[String] =
+    Some("https://github.com/VirtusLab/scala-cli/issues/647")
 }


### PR DESCRIPTION
This adds a default implementation for `BuildToolAlg#runMigration` that logs a warning that Scalafix migrations are not supported by the build tool. It saves some repeated text that is used for every build tool except sbt.