### PR TITLE
Remove `StewardContext` hierarchy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -446,6 +446,15 @@ runSteward := Def.taskDyn {
   (core.jvm / Compile / run).toTask(args)
 }.value
 
+lazy val runValidateRepoConfig = taskKey[Unit]("")
+runValidateRepoConfig := Def.taskDyn {
+  val projectDir = (LocalRootProject / baseDirectory).value
+  val args = Seq(
+    Seq("validate-repo-config", s"$projectDir/.scala-steward.conf")
+  ).flatten.mkString(" ", " ", "")
+  (core.jvm / Compile / run).toTask(args)
+}.value
+
 /// commands
 
 def addCommandsAlias(name: String, cmds: Seq[String]) =

--- a/docs/help.md
+++ b/docs/help.md
@@ -4,8 +4,8 @@ All command line arguments for the `scala-steward` application.
 
 ```
 Usage:
-    scala-steward validate-repo-config
     scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
+    scala-steward validate-repo-config
 
 
 

--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -18,13 +18,16 @@ package org.scalasteward.core
 
 import cats.effect.std.Console
 import cats.effect.{ExitCode, IO, IOApp}
-import org.scalasteward.core.application.{Cli, Context}
+import org.scalasteward.core.application.{Cli, Context, ValidateRepoConfigContext}
 
 object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     Cli.parseArgs(args) match {
-      case Cli.ParseResult.Success(config) => Context.step0[IO](config).use(_.runF)
-      case Cli.ParseResult.Help(help)      => Console[IO].println(help).as(ExitCode.Success)
-      case Cli.ParseResult.Error(error)    => Console[IO].errorln(error).as(ExitCode.Error)
+      case Cli.ParseResult.Success(Cli.Usage.Regular(config)) =>
+        Context.step0[IO](config).use(_.stewardAlg.runF)
+      case Cli.ParseResult.Success(Cli.Usage.ValidateRepoConfig(file)) =>
+        ValidateRepoConfigContext.run[IO](file)
+      case Cli.ParseResult.Help(help)   => Console[IO].println(help).as(ExitCode.Success)
+      case Cli.ParseResult.Error(error) => Console[IO].errorln(error).as(ExitCode.Error)
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/Main.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/Main.scala
@@ -26,7 +26,7 @@ object Main extends IOApp {
       case Cli.ParseResult.Success(Cli.Usage.Regular(config)) =>
         Context.step0[IO](config).use(_.stewardAlg.runF)
       case Cli.ParseResult.Success(Cli.Usage.ValidateRepoConfig(file)) =>
-        ValidateRepoConfigContext.run[IO](file)
+        ValidateRepoConfigContext.step0[IO].flatMap(_.validateRepoConfigAlg.validateAndReport(file))
       case Cli.ParseResult.Help(help)   => Console[IO].println(help).as(ExitCode.Success)
       case Cli.ParseResult.Error(error) => Console[IO].errorln(error).as(ExitCode.Error)
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -164,10 +164,4 @@ object Config {
 
   final case class GiteaCfg(
   ) extends ForgeSpecificCfg
-
-  sealed trait StewardUsage
-  object StewardUsage {
-    final case class Regular(config: Config) extends StewardUsage
-    final case class ValidateRepoConfig(file: File) extends StewardUsage
-  }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -16,8 +16,6 @@
 
 package org.scalasteward.core.application
 
-import better.files.File
-import cats.MonadThrow
 import cats.effect._
 import cats.effect.implicits._
 import cats.syntax.all._
@@ -25,7 +23,7 @@ import eu.timepit.refined.auto._
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.headers.`User-Agent`
-import org.scalasteward.core.application.Config.{ForgeCfg, StewardUsage}
+import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.buildtool.maven.MavenAlg
 import org.scalasteward.core.buildtool.mill.MillAlg
@@ -45,7 +43,7 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository, UpdateInfoUrlFinder}
 import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
 import org.scalasteward.core.repocache._
-import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader, ValidateRepoConfigAlg}
+import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader}
 import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.update.artifact.{ArtifactMigrationsFinder, ArtifactMigrationsLoader}
 import org.scalasteward.core.update.{FilterAlg, PruningAlg, UpdateAlg}
@@ -89,29 +87,10 @@ final class Context[F[_]](implicit
 )
 
 object Context {
-
-  sealed trait StewardContext[F[_]] {
-    def runF: F[ExitCode]
-  }
-  object StewardContext {
-    final case class Regular[F[_]](context: Context[F]) extends StewardContext[F] {
-      override def runF: F[ExitCode] = context.stewardAlg.runF
-    }
-
-    final case class ValidateRepoConfig[F[_]](file: File)(implicit
-        val validateRepoConfigAlg: ValidateRepoConfigAlg[F],
-        val logger: Logger[F]
-    ) extends StewardContext[F] {
-      override def runF: F[ExitCode] = validateRepoConfigAlg.validateAndReport(file)
-    }
-  }
-
-  def step0[F[_]](
-      usage: Config.StewardUsage
-  )(implicit F: Async[F]): Resource[F, StewardContext[F]] =
+  def step0[F[_]](config: Config)(implicit F: Async[F]): Resource[F, Context[F]] =
     for {
-      logger0 <- Resource.eval(Slf4jLogger.fromName[F]("org.scalasteward.core"))
-      _ <- Resource.eval(logger0.info(banner))
+      logger <- Resource.eval(Slf4jLogger.fromName[F]("org.scalasteward.core"))
+      _ <- Resource.eval(logger.info(banner))
       _ <- Resource.eval(F.delay(System.setProperty("http.agent", userAgentString)))
       userAgent <- Resource.eval(F.fromEither(`User-Agent`.parse(1)(userAgentString)))
       middleware = ClientConfiguration
@@ -125,45 +104,21 @@ object Context {
         ClientConfiguration.disableFollowRedirect,
         middleware
       )
-      fileAlg0 = FileAlg.create(logger0, F)
-      context <- usage match {
-        case StewardUsage.Regular(config) =>
-          initRegular(config)(
-            defaultClient,
-            UrlCheckerClient(urlCheckerClient),
-            fileAlg0,
-            logger0,
-            F
-          ).map(StewardContext.Regular(_))
-
-        case StewardUsage.ValidateRepoConfig(file) =>
-          implicit val fileAlg: FileAlg[F] = fileAlg0
-          implicit val logger: Logger[F] = logger0
-          Resource.pure[F, StewardContext[F]](initValidateRepoConfig(file))
+      fileAlg = FileAlg.create(logger, F)
+      processAlg = ProcessAlg.create(config.processCfg)(logger, F)
+      workspaceAlg = WorkspaceAlg.create(config)(fileAlg, logger, F)
+      context <- Resource.eval {
+        step1(config)(
+          defaultClient,
+          UrlCheckerClient(urlCheckerClient),
+          fileAlg,
+          logger,
+          processAlg,
+          workspaceAlg,
+          F
+        )
       }
-
     } yield context
-
-  def initRegular[F[_]](config: Config)(implicit
-      client: Client[F],
-      urlCheckerClient: UrlCheckerClient[F],
-      fileAlg: FileAlg[F],
-      logger: Logger[F],
-      F: Async[F]
-  ): Resource[F, Context[F]] = {
-    implicit val processAlg = ProcessAlg.create(config.processCfg)
-    implicit val workspaceAlg = WorkspaceAlg.create(config)
-    Resource.eval(step1(config))
-  }
-
-  def initValidateRepoConfig[F[_]](file: File)(implicit
-      fileAlg: FileAlg[F],
-      logger: Logger[F],
-      F: MonadThrow[F]
-  ): StewardContext.ValidateRepoConfig[F] = {
-    implicit val validateRepoConfigAlg = new ValidateRepoConfigAlg[F]()
-    StewardContext.ValidateRepoConfig[F](file)
-  }
 
   def step1[F[_]](config: Config)(implicit
       client: Client[F],
@@ -235,7 +190,7 @@ object Context {
       implicit val editAlg: EditAlg[F] = new EditAlg[F]
       implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F](config.forgeCfg)
       implicit val pruningAlg: PruningAlg[F] = new PruningAlg[F]
-      implicit val reposFilesLoader: ReposFilesLoader[F] = new ReposFilesLoader[F]()
+      implicit val reposFilesLoader: ReposFilesLoader[F] = new ReposFilesLoader[F]
       implicit val gitHubAppApiAlg: GitHubAppApiAlg[F] =
         new GitHubAppApiAlg[F](config.forgeCfg.apiHost)
       implicit val stewardAlg: StewardAlg[F] = new StewardAlg[F](config)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.application
+
+import better.files.File
+import cats.effect.{ExitCode, Sync}
+import cats.syntax.all._
+import org.scalasteward.core.io.FileAlg
+import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object ValidateRepoConfigContext {
+  def run[F[_]](repoConfigFile: File)(implicit F: Sync[F]): F[ExitCode] =
+    for {
+      logger <- Slf4jLogger.fromName[F]("org.scalasteward.core")
+      fileAlg = FileAlg.create(logger, F)
+      validateRepoConfigAlg = new ValidateRepoConfigAlg()(fileAlg, logger, F)
+      exitCode <- validateRepoConfigAlg.validateAndReport(repoConfigFile)
+    } yield exitCode
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
@@ -40,8 +40,7 @@ object ValidateRepoConfigContext {
       logger: Logger[F],
       F: Sync[F]
   ): ValidateRepoConfigContext[F] = {
-    implicit val validateRepoConfigAlg: ValidateRepoConfigAlg[F] =
-      new ValidateRepoConfigAlg()(fileAlg, logger, F)
+    implicit val validateRepoConfigAlg: ValidateRepoConfigAlg[F] = new ValidateRepoConfigAlg
     new ValidateRepoConfigContext[F]
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -4,9 +4,8 @@ import better.files.File
 import cats.data.Validated.Valid
 import munit.FunSuite
 import org.http4s.syntax.literals._
-import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.Cli.ParseResult._
-import org.scalasteward.core.application.Config.StewardUsage
+import org.scalasteward.core.application.Cli.{EnvVar, Usage}
 import org.scalasteward.core.forge.ForgeType
 import org.scalasteward.core.forge.github.GitHubApp
 import org.scalasteward.core.util.Nel
@@ -14,7 +13,7 @@ import scala.concurrent.duration._
 
 class CliTest extends FunSuite {
   test("parseArgs: example") {
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -79,7 +78,7 @@ class CliTest extends FunSuite {
   )
 
   test("parseArgs: minimal example") {
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       minimumRequiredParams.flatten
     )
 
@@ -92,7 +91,7 @@ class CliTest extends FunSuite {
   }
 
   test("parseArgs: enable sandbox") {
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -123,7 +122,7 @@ class CliTest extends FunSuite {
   }
 
   test("parseArgs: disable sandbox") {
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
@@ -157,7 +156,7 @@ class CliTest extends FunSuite {
       List("--gitlab-merge-when-pipeline-succeeds"),
       List("--gitlab-required-reviewers", "5")
     )
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
 
     assert(obtained.gitLabCfg.mergeWhenPipelineSucceeds)
     assertEquals(obtained.gitLabCfg.requiredReviewers, Some(5))
@@ -174,7 +173,7 @@ class CliTest extends FunSuite {
   }
 
   test("parseArgs: validate-repo-config") {
-    val Success(StewardUsage.ValidateRepoConfig(file)) = Cli.parseArgs(
+    val Success(Usage.ValidateRepoConfig(file)) = Cli.parseArgs(
       List(
         List("validate-repo-config", "file.conf")
       ).flatten
@@ -188,7 +187,7 @@ class CliTest extends FunSuite {
       List("--forge-type", "azure-repos"),
       List("--do-not-fork")
     )
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
     assert(obtained.forgeCfg.doNotFork)
   }
 
@@ -204,7 +203,7 @@ class CliTest extends FunSuite {
     val params = minimumRequiredParams ++ List(
       List("--forge-type", "bitbucket")
     )
-    val Success(StewardUsage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
     assert(!obtained.forgeCfg.addLabels)
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -68,7 +68,7 @@ class CliTest extends FunSuite {
     assert(!obtained.bitbucketServerCfg.useDefaultReviewers)
   }
 
-  val minimumRequiredParams = List(
+  private val minimumRequiredParams = List(
     List("--workspace", "a"),
     List("--repos-file", "b"),
     List("--git-author-email", "d"),

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -2,8 +2,8 @@ package org.scalasteward.core.mock
 
 import better.files.File
 import org.http4s.Uri
+import org.scalasteward.core.application.Cli
 import org.scalasteward.core.application.Cli.ParseResult.Success
-import org.scalasteward.core.application.{Cli, Config}
 
 object MockConfig {
   val mockRoot: File = File.temp / "scala-steward"
@@ -24,5 +24,5 @@ object MockConfig {
     "--add-labels",
     "--refresh-backoff-period=1hour"
   )
-  val Success(Config.StewardUsage.Regular(config)) = Cli.parseArgs(args)
+  val Success(Cli.Usage.Regular(config)) = Cli.parseArgs(args)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -4,7 +4,7 @@ import cats.data.Kleisli
 import cats.effect.kernel.Resource
 import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
-import org.scalasteward.core.application.{Config, Context}
+import org.scalasteward.core.application.{Config, Context, ValidateRepoConfigContext}
 import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.io._
@@ -44,4 +44,7 @@ object MockContext {
   val context: Context[MockEff] = context(config)
   def context(stewardConfig: Config): Context[MockEff] =
     mockState.toRef.flatMap(Context.step1(stewardConfig).run).unsafeRunSync()
+
+  val validateRepoConfigContext: ValidateRepoConfigContext[MockEff] =
+    ValidateRepoConfigContext.step1
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,12 +1,10 @@
 package org.scalasteward.core.mock
 
-import better.files.File
 import cats.data.Kleisli
 import cats.effect.kernel.Resource
 import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
-import org.scalasteward.core.application.Context
-import org.scalasteward.core.application.Context.StewardContext
+import org.scalasteward.core.application.{Config, Context}
 import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.io._
@@ -15,7 +13,6 @@ import org.scalasteward.core.repoconfig.RepoConfigLoader
 import org.scalasteward.core.update.artifact.ArtifactMigrationsLoader
 import org.scalasteward.core.util.UrlCheckerClient
 import org.typelevel.log4cats.Logger
-import org.scalasteward.core.application.Config
 
 object MockContext {
   implicit private val client: Client[MockEff] =
@@ -47,6 +44,4 @@ object MockContext {
   val context: Context[MockEff] = context(config)
   def context(stewardConfig: Config): Context[MockEff] =
     mockState.toRef.flatMap(Context.step1(stewardConfig).run).unsafeRunSync()
-  def validateRepoConfigContext(file: File): StewardContext.ValidateRepoConfig[MockEff] =
-    Context.initValidateRepoConfig(file)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -1,15 +1,15 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import cats.effect.ExitCode
 import cats.effect.unsafe.implicits.global
+import cats.effect.{ExitCode, IO}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import org.scalasteward.core.mock.{MockContext, MockState}
+import org.scalasteward.core.application.ValidateRepoConfigContext
 
 class ValidateRepoConfigAlgTest extends munit.FunSuite {
 
-  def configFile(content: String) = FunFixture[(File, ExitCode)](
+  private def configFile(content: String) = FunFixture[(File, ExitCode)](
     setup = { _ =>
       val tmpFile =
         File(
@@ -19,12 +19,7 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
           )
         )
 
-      val obtained = MockContext
-        .validateRepoConfigContext(tmpFile)
-        .runF
-        .runA(MockState.empty)
-        .unsafeRunSync()
-
+      val obtained = ValidateRepoConfigContext.run[IO](tmpFile).unsafeRunSync()
       (tmpFile, obtained)
     },
     teardown = { case (file, _) =>
@@ -65,11 +60,7 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
 
   test("rejects non-existent config file") {
     val nonExistentFile = File("/", "scripts", "script")
-    val obtained = MockContext
-      .validateRepoConfigContext(nonExistentFile)
-      .runF
-      .runA(MockState.empty)
-      .unsafeRunSync()
+    val obtained = ValidateRepoConfigContext.run[IO](nonExistentFile).unsafeRunSync()
 
     assertEquals(obtained, ExitCode.Error)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -1,66 +1,47 @@
 package org.scalasteward.core.repoconfig
 
-import better.files.File
 import cats.effect.ExitCode
-import cats.effect.unsafe.implicits.global
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import org.scalasteward.core.Main
+import munit.CatsEffectSuite
+import org.scalasteward.core.mock.MockConfig.mockRoot
+import org.scalasteward.core.mock.MockContext.validateRepoConfigContext.validateRepoConfigAlg
+import org.scalasteward.core.mock.MockState
 
-class ValidateRepoConfigAlgTest extends munit.FunSuite {
+class ValidateRepoConfigAlgTest extends CatsEffectSuite {
+  test("accepts valid config") {
+    val file = mockRoot / ".scala-steward.conf"
+    val content =
+      """|updates.pin = [
+         |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+         |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
+         |]""".stripMargin
+    val state = MockState.empty.addFiles(file -> content)
+    val obtained = state.flatMap(validateRepoConfigAlg.validateAndReport(file).runA)
+    assertIO(obtained, ExitCode.Success)
+  }
 
-  private def configFile(content: String) = FunFixture[(File, ExitCode)](
-    setup = { _ =>
-      val tmpFile =
-        File(
-          Files.write(
-            Files.createTempFile(".scala-steward", ".conf"),
-            content.getBytes(StandardCharsets.UTF_8)
-          )
-        )
+  test("rejects config with a parsing failure") {
+    val file = mockRoot / ".scala-steward.conf"
+    val content =
+      """|updates.pin  =? [
+         |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+         |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." },
+         |]""".stripMargin
+    val state = MockState.empty.addFiles(file -> content)
+    val obtained = state.flatMap(validateRepoConfigAlg.validateAndReport(file).runA)
+    assertIO(obtained, ExitCode.Error)
+  }
 
-      val obtained = Main.run(List("validate-repo-config", tmpFile.pathAsString)).unsafeRunSync()
-      (tmpFile, obtained)
-    },
-    teardown = { case (file, _) =>
-      file.delete()
-    }
-  )
-
-  configFile(
-    """|updates.pin = [
-       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
-       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
-       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
-       |]""".stripMargin
-  )
-    .test("accepts valid config") { case (_, obtained) =>
-      assertEquals(obtained, ExitCode.Success)
-    }
-
-  configFile(
-    """|updates.pin  =? [
-       |  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
-       |  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
-       |  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." },
-       |]""".stripMargin
-  )
-    .test("rejects config with a parsing failure") { case (_, obtained) =>
-      assertEquals(obtained, ExitCode.Error)
-    }
-
-  configFile(
-    """|updatePullRequests = 123
-       |
-       |""".stripMargin
-  )
-    .test("rejects config with a decoding failure") { case (_, obtained) =>
-      assertEquals(obtained, ExitCode.Error)
-    }
+  test("rejects config with a decoding failure") {
+    val file = mockRoot / ".scala-steward.conf"
+    val content = """updatePullRequests = 123""".stripMargin
+    val state = MockState.empty.addFiles(file -> content)
+    val obtained = state.flatMap(validateRepoConfigAlg.validateAndReport(file).runA)
+    assertIO(obtained, ExitCode.Error)
+  }
 
   test("rejects non-existent config file") {
-    val obtained = Main.run(List("validate-repo-config", "/scripts.script")).unsafeRunSync()
-
-    assertEquals(obtained, ExitCode.Error)
+    val file = mockRoot / ".scala-steward.conf"
+    val obtained = validateRepoConfigAlg.validateAndReport(file).runA(MockState.empty)
+    assertIO(obtained, ExitCode.Error)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -1,11 +1,11 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
+import cats.effect.ExitCode
 import cats.effect.unsafe.implicits.global
-import cats.effect.{ExitCode, IO}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import org.scalasteward.core.application.ValidateRepoConfigContext
+import org.scalasteward.core.Main
 
 class ValidateRepoConfigAlgTest extends munit.FunSuite {
 
@@ -19,7 +19,7 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
           )
         )
 
-      val obtained = ValidateRepoConfigContext.run[IO](tmpFile).unsafeRunSync()
+      val obtained = Main.run(List("validate-repo-config", tmpFile.pathAsString)).unsafeRunSync()
       (tmpFile, obtained)
     },
     teardown = { case (file, _) =>
@@ -59,8 +59,7 @@ class ValidateRepoConfigAlgTest extends munit.FunSuite {
     }
 
   test("rejects non-existent config file") {
-    val nonExistentFile = File("/", "scripts", "script")
-    val obtained = ValidateRepoConfigContext.run[IO](nonExistentFile).unsafeRunSync()
+    val obtained = Main.run(List("validate-repo-config", "/scripts.script")).unsafeRunSync()
 
     assertEquals(obtained, ExitCode.Error)
   }


### PR DESCRIPTION
This removes the `Context.StewardContext` hierarchy. IMO `StewardContext` makes `Context.scala` unnecessarily more complicated only for saving one `case` in `Main.run` and a little duplication.