### PR TITLE
Remove repo from function for modifying requests

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
@@ -45,7 +45,7 @@ object ForgeSelection {
       logger: Logger[F],
       F: Temporal[F]
   ): ForgeApiAlg[F] = {
-    val auth = (_: Any) => authenticate(forgeCfg.tpe, user)
+    val auth = authenticate(forgeCfg.tpe, user)
     forgeSpecificCfg match {
       case specificCfg: Config.AzureReposCfg =>
         new AzureReposApiAlg(forgeCfg.apiHost, specificCfg, auth)

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -33,7 +33,7 @@ import org.typelevel.log4cats.Logger
 final class BitbucketServerApiAlg[F[_]](
     bitbucketApiHost: Uri,
     config: BitbucketServerCfg,
-    modify: Repo => Request[F] => F[Request[F]]
+    modify: Request[F] => F[Request[F]]
 )(implicit client: HttpJsonClient[F], logger: Logger[F], F: MonadThrow[F])
     extends ForgeApiAlg[F] {
   private val url = new Url(bitbucketApiHost)
@@ -53,7 +53,7 @@ final class BitbucketServerApiAlg[F[_]](
       .postWithBody[Json.Comment, Json.Comment](
         url.comments(repo, number),
         Json.Comment(comment),
-        modify(repo)
+        modify
       )
       .map(comment => Comment(comment.text))
 
@@ -82,7 +82,7 @@ final class BitbucketServerApiAlg[F[_]](
         locked = false,
         reviewers = reviewers
       )
-      pr <- client.postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify(repo))
+      pr <- client.postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify)
     } yield pr.toPullRequestOut
   }
 
@@ -97,10 +97,10 @@ final class BitbucketServerApiAlg[F[_]](
     if (config.useDefaultReviewers) getDefaultReviewers(repo) else F.pure(List.empty[Reviewer])
 
   private def declinePullRequest(repo: Repo, number: PullRequestNumber, version: Int): F[Unit] =
-    client.post_(url.declinePullRequest(repo, number, version), modify(repo))
+    client.post_(url.declinePullRequest(repo, number, version), modify)
 
   private def getDefaultReviewers(repo: Repo): F[List[Reviewer]] =
-    client.get[List[Json.Condition]](url.reviewers(repo), modify(repo)).map { conditions =>
+    client.get[List[Json.Condition]](url.reviewers(repo), modify).map { conditions =>
       conditions.flatMap { condition =>
         condition.reviewers.map(reviewer => Reviewer(User(reviewer.name)))
       }
@@ -108,25 +108,25 @@ final class BitbucketServerApiAlg[F[_]](
 
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client
-      .get[Json.Branches](url.listBranch(repo, branch), modify(repo))
+      .get[Json.Branches](url.listBranch(repo, branch), modify)
       .map(_.values.head.toBranchOut)
 
   private def getDefaultBranch(repo: Repo): F[Json.Branch] =
-    client.get[Json.Branch](url.defaultBranch(repo), modify(repo))
+    client.get[Json.Branch](url.defaultBranch(repo), modify)
 
   private def getPullRequest(repo: Repo, number: PullRequestNumber): F[PR] =
-    client.get[Json.PR](url.pullRequest(repo, number), modify(repo))
+    client.get[Json.PR](url.pullRequest(repo, number), modify)
 
   override def getRepo(repo: Repo): F[RepoOut] =
     for {
-      jRepo <- client.get[Json.Repo](url.repos(repo), modify(repo))
+      jRepo <- client.get[Json.Repo](url.repos(repo), modify)
       cloneUrl <- jRepo.cloneUrlOrRaise[F]
       defaultBranch <- getDefaultBranch(repo)
     } yield RepoOut(jRepo.slug, UserOut(repo.owner), None, cloneUrl, defaultBranch.displayId)
 
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
     client
-      .get[Json.Page[Json.PR]](url.listPullRequests(repo, s"refs/heads/$head"), modify(repo))
+      .get[Json.Page[Json.PR]](url.listPullRequests(repo, s"refs/heads/$head"), modify)
       .map(_.values.map(_.toPullRequestOut))
 
   private def warnIfLabelsAreUsed =


### PR DESCRIPTION
This removes the unnecessary `Repo` parameter from the function for modifying requests to add authentication headers. This parameter was added in #373 but wasn't ever used as can be observed in the diff of `ForgeSelection`. My motivation for adding `Repo` back then was to eventually use different credentials for different repositories for proper GitHub App support. But #3250 demonstrates that we can achieve this without this extra parameter.