### PR TITLE
Recognize hashes if they are preceded by `.` or `_`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -190,7 +190,7 @@ object Version {
       val numeric = Numbers.digits.map(s => List(Numeric(s)))
       val alpha = Parser.charsWhile(c => !digits(c) && !separators(c)).map(s => List(Alpha(s)))
       val separator = Parser.charIn(separators).map(c => List(Separator(c)))
-      val hash = (Parser.charIn('-', '+') ~
+      val hash = (Parser.charIn(separators) ~
         Parser.char('g').string.? ~
         Rfc5234.hexdig.rep(6).string.filterNot(startsWithDate)).backtrack
         .map { case ((s, g), h) => List(Separator(s), Hash(g.getOrElse("") + h)) }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -222,6 +222,7 @@ class VersionTest extends DisciplineSuite {
       ("10000000", List("20000000"), Some("20000000")),
       ("1032048a", List("2032048a4c2"), Some("2032048a4c2")),
       ("0.1.1-3dfde9d7", List("0.2.1-485fdf3b"), None),
+      ("1.0.0+1319.ae77058", List("1.0.0+1320.38b57aa"), Some("1.0.0+1320.38b57aa")),
       ("0.1.1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-ALPHA", List("0.2.1-485fdf3b"), None),
       ("0.1.1-ALPHA", List("0.2.1-BETA"), None),


### PR DESCRIPTION
This allows hashes to also be separated with a `.` and `_` from the preceding component.

Here is for example what `Version.Component.parse("1.0.0+1320.38b57aa")` returned before this change and what it returns now:
```
before:
Numeric(1), Separator(.), Numeric(0), Separator(.), Numeric(0), Separator(+),
Numeric(1320), Separator(.), Numeric(38), Alpha(b), Numeric(57), Alpha(aa)

now:
Numeric(1), Separator(.), Numeric(0), Separator(.), Numeric(0), Separator(+),
Numeric(1320), Separator(.), Hash(38b57aa))
```

Recognizing hashes was added in #1549 but that PR gives no explanation why they only could preceded by `-` and `+`.

Closes #3124