### PR TITLE
Remove `--vcs-*` options

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -28,16 +28,10 @@ Options and flags:
         Whether to sign commits; default: false
     --forge-type <forge-type>
         One of azure-repos, bitbucket, bitbucket-server, github, gitlab, gitea; default: github
-    --vcs-type <forge-type>
-        deprecated in favor of --forge-type
     --forge-api-host <uri>
         API URL of the forge; default: https://api.github.com
-    --vcs-api-host <uri>
-        deprecated in favor of --forge-api-host
     --forge-login <string>
         The user name for the forge
-    --vcs-login <string>
-        deprecated in favor of --forge-login
     --do-not-fork
         Whether to not push the update branches to a fork; default: false
     --add-labels

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -102,40 +102,18 @@ object Cli {
   private val gitCfg: Opts[GitCfg] =
     (gitAuthor, gitAskPass, signCommits).mapN(GitCfg.apply)
 
-  private val vcsType =
-    option[ForgeType](
-      "vcs-type",
-      s"deprecated in favor of --${name.forgeType}",
-      visibility = Visibility.Partial
-    ).validate(s"--vcs-type is deprecated; use --${name.forgeType} instead")(_ => false)
-
   private val forgeType = {
     val help = ForgeType.all.map(_.asString).mkString("One of ", ", ", "") +
       s"; default: ${GitHub.asString}"
-    option[ForgeType](name.forgeType, help).orElse(vcsType).withDefault(GitHub)
+    option[ForgeType](name.forgeType, help).withDefault(GitHub)
   }
-
-  private val vcsApiHost =
-    option[Uri](
-      "vcs-api-host",
-      s"deprecated in favor of --${name.forgeApiHost}",
-      visibility = Visibility.Partial
-    ).validate(s"--vcs-api-host is deprecated; use --${name.forgeApiHost} instead")(_ => false)
 
   private val forgeApiHost: Opts[Uri] =
     option[Uri](name.forgeApiHost, s"API URL of the forge; default: ${GitHub.publicApiBaseUrl}")
-      .orElse(vcsApiHost)
       .withDefault(GitHub.publicApiBaseUrl)
 
-  private val vcsLogin =
-    option[String](
-      "vcs-login",
-      s"deprecated in favor of --${name.forgeLogin}",
-      visibility = Visibility.Partial
-    ).validate(s"--vcs-login is deprecated; use --${name.forgeLogin} instead")(_ => false)
-
   private val forgeLogin: Opts[String] =
-    option[String](name.forgeLogin, "The user name for the forge").orElse(vcsLogin)
+    option[String](name.forgeLogin, "The user name for the forge")
 
   private val doNotFork: Opts[Boolean] =
     flag("do-not-fork", "Whether to not push the update branches to a fork; default: false").orFalse


### PR DESCRIPTION
Successor to #3241. This should not be merged before Q3 2024 so that people have enough time to see the current deprecation messages and migrate to the `--forge-*` options.