### PR TITLE
Migrate `sbt-pull-request-validator`

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1134,4 +1134,9 @@ changes = [
     groupIdAfter = com.markatta
     artifactIdAfter = sbt-akka-version-check
   },
+  {
+    groupIdBefore = com.hpe.sbt
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-pull-request-validator
+  },
 ]


### PR DESCRIPTION
We are currently also migrating this plugin to the `com.github.sbt` groupId, the repo itself already lives under the sbt github repo organisation, also see
- https://github.com/sbt/sbt-pull-request-validator/pull/12