### PR TITLE
Migrate `sbt-paradox-material-theme` to `com.github.sbt`

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1189,4 +1189,14 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = sbt-mocha
   },
+  {
+    groupIdBefore = io.github.jonas
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-paradox-material-theme
+  },
+  {
+    groupIdBefore = io.github.jonas
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = paradox-material-theme
+  },
 ]


### PR DESCRIPTION
We just transferred the repo to the sbt GitHub organization and will publish new releases under its groupId:
- https://github.com/sbt/sbt-paradox-material-theme/pull/34#issuecomment-1919400459