### PR TITLE
Improve documentation for workspace ownership mismatches

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -203,7 +203,6 @@ pipelines:
 There is multiple articles on how to run Scala Steward on-premise:
 
 * [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)
-* [Running scala-steward periodically on AWS Fargate](https://medium.com/@tanishiking/running-scala-steward-periodically-on-aws-fargate-3d3d202f0f7)
 * [Scala StewardとGitHub Actionsで依存ライブラリの更新を自動化する](https://scalapedia.com/articles/145/Scala+Steward%E3%81%A8GitHub+Actions%E3%81%A7%E4%BE%9D%E5%AD%98%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AE%E6%9B%B4%E6%96%B0%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B)
 * [Centralized Scala Steward with GitHub Actions](https://hector.dev/2020/11/18/centralized-scala-steward-with-github-actions)
 * [Big Timesavers for Busy Scala Developers](https://speakerdeck.com/exoego/big-timesavers-for-busy-scala-developers)

--- a/docs/running.md
+++ b/docs/running.md
@@ -51,7 +51,16 @@ More information about using the `--scalafix-migrations` and `--artifact-migrati
 The workspace directory (specified with `--workspace`) provides a location for cache and temporary files.  
 
 It is important to persist this workspace between runs.  Without this, Scala Steward will be unable to observe 
-repo-specific preferences (such as [pullRequests.frequency](repo-specific-configuration.md)) correctly.   
+repo-specific preferences (such as [pullRequests.frequency](repo-specific-configuration.md)) correctly.
+
+Furthermore, `git` requires the workspace directory to be owned by the same user that will run Scala Steward.
+If there is an ownership mismatch, `git` may print error messages like
+
+> fatal: detected dubious ownership in repository …
+
+or
+
+> fatal: not in a git directory
 
 ### Private repositories
 

--- a/modules/docs/mdoc/running.md
+++ b/modules/docs/mdoc/running.md
@@ -203,7 +203,6 @@ pipelines:
 There is multiple articles on how to run Scala Steward on-premise:
 
 * [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)
-* [Running scala-steward periodically on AWS Fargate](https://medium.com/@tanishiking/running-scala-steward-periodically-on-aws-fargate-3d3d202f0f7)
 * [Scala StewardとGitHub Actionsで依存ライブラリの更新を自動化する](https://scalapedia.com/articles/145/Scala+Steward%E3%81%A8GitHub+Actions%E3%81%A7%E4%BE%9D%E5%AD%98%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AE%E6%9B%B4%E6%96%B0%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B)
 * [Centralized Scala Steward with GitHub Actions](https://hector.dev/2020/11/18/centralized-scala-steward-with-github-actions)
 * [Big Timesavers for Busy Scala Developers](https://speakerdeck.com/exoego/big-timesavers-for-busy-scala-developers)

--- a/modules/docs/mdoc/running.md
+++ b/modules/docs/mdoc/running.md
@@ -51,7 +51,16 @@ More information about using the `--scalafix-migrations` and `--artifact-migrati
 The workspace directory (specified with `--workspace`) provides a location for cache and temporary files.  
 
 It is important to persist this workspace between runs.  Without this, Scala Steward will be unable to observe 
-repo-specific preferences (such as [pullRequests.frequency](repo-specific-configuration.md)) correctly.   
+repo-specific preferences (such as [pullRequests.frequency](repo-specific-configuration.md)) correctly.
+
+Furthermore, `git` requires the workspace directory to be owned by the same user that will run Scala Steward.
+If there is an ownership mismatch, `git` may print error messages like
+
+> fatal: detected dubious ownership in repository …
+
+or
+
+> fatal: not in a git directory
 
 ### Private repositories
 


### PR DESCRIPTION
[Git requires](https://github.com/git/git/commit/3b0bf2704980b1ed6018622bdf5377ec22289688) that a repository directory be owned by the user executing `git`. In the normal case, it will print a message

> fatal: detected dubious ownership in repository …

which is easily searchable online, but unfortunately `git config` does not print such a nice message, and simply prints

> fatal: not in a git directory

which is misleading and hard to diagnose.

This came up for us when running Scala Steward as a AWS Fargate task using AWS EFS as its persistent storage. We configured the task to mount the EFS volume using UID 1001, which is the default UID for sbt-native-packager Docker containers, but in fact, Scala Steward current runs as root (#3283). While looking into the issue, we noticed that the article titled [_Running scala-steward periodically on AWS Fargate_](https://medium.com/@tanishiking/running-scala-steward-periodically-on-aws-fargate-3d3d202f0f7) no longer exists, so this PR also removes that link from the documentation. (Hopefully we'll be able to publish some details about how we're running Scala Steward using Fargate as a replacement!)