### PR TITLE
Ignore Scala 3.4.0 until it's announced

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -31,6 +31,9 @@ updates.ignore = [
   // Artifacts below are ignored because they are not yet announced.
 
   // Ignore the next Scala 3 version until it is announced.
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.4.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.4.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.4.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.2" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.2" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.2" } },


### PR DESCRIPTION
We're already seeing [Scala Steward raise PRs for Scala 3.4.0](https://github.com/guardian/play-secret-rotation/pull/432), this might be unintentional, as there are no [GitHub release notes for 3.4.0](https://github.com/lampepfl/dotty/releases/tag/3.4.0)?

See also https://github.com/scala-steward-org/scala-steward/pull/2337 & https://github.com/scala-steward-org/scala-steward/issues/1104.

cc @Kordyjan
