### PR TITLE
run as the configured sbt-native-packager user instead of root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,8 @@ lazy val dockerSettings = Def.settings(
       Cmd("RUN", "npm install --global yarn"),
       // Ensure binaries are in PATH
       Cmd("RUN", "echo $PATH"),
-      Cmd("RUN", "which cs mill mvn node npm sbt scala-cli scalafix scalafmt yarn")
+      Cmd("RUN", "which cs mill mvn node npm sbt scala-cli scalafix scalafmt yarn"),
+      Cmd("USER", (Docker / daemonUser).value)
     )
   },
   Docker / packageName := s"fthomas/${name.value}",


### PR DESCRIPTION
Fixes #3283.

This works for us—the container runs and is able to clone, make PRs, etc., when running as the default user (`demiourgos728` / UID `1001`).

For fresh installs, I don't think any changes are needed to how one would run the container. However, for existing installs where the containers has been writing to some persistent storage as `root`, there may be some permissions issues. I'm not sure how to handle that.