### PR TITLE
Add migrations for `otel4s` 0.5.0

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -240,5 +240,11 @@ migrations = [
     doc: "https://github.com/typelevel/sbt-tpolecat/blob/main/CHANGELOG.md#050",
     rewriteRules: ["github:typelevel/sbt-tpolecat/v0_5?sha=4837a5bad7426c97be9bb3a5b792fd779f5c921a"],
     target: "build"
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["otel4s-.*"],
+    newVersion: "0.5.0",
+    rewriteRules: ["dependency:V0_5_0Rewrites@org.typelevel:otel4s-scalafix:0.5.0"]
   }
 ]


### PR DESCRIPTION
Context: https://github.com/typelevel/otel4s/pull/426.