### PR TITLE
Abandon Scala 3.3.2. Prepare for the 3.3.3 hotfix release

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -34,6 +34,12 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.4.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.4.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.4.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.3" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.3" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.3" } },
+
+
+  // Ignore the 3.3.2 version as it is abandonned due to broken compatibility
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.2" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.2" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.2" } },


### PR DESCRIPTION
Scala hotfix 3.3.3 will be released in a couple of hours. For the safety's sake we should postpone the updates until the release is announced.