### PR TITLE
Unlock Scala 3.3.3

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -34,9 +34,9 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.4.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.4.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.4.0" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.3" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.3" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.3" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.4" } },
 
 
   // Ignore the 3.3.2 version as it is abandonned due to broken compatibility


### PR DESCRIPTION
Scala 3.3.3 is officially released.
https://www.scala-lang.org/blog/2024/02/29/scala-3.4.0-and-3.3.3-released.html
