### PR TITLE
Migrate `sbt-jupiter-interface` to `com.github.sbt`

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1199,4 +1199,9 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdAfter = paradox-material-theme
   },
+  {
+    groupIdBefore = net.aichler
+    groupIdAfter = com.github.sbt
+    artifactIdAfter = sbt-jupiter-interface
+  },
 ]


### PR DESCRIPTION
- https://github.com/sbt/sbt-jupiter-interface/issues/64

Related:
- https://github.com/VirtusLab/scala-steward-repos/pull/356