### PR TITLE
Combine `RepoConfig` with the one taken the higher importance on the right side

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -32,7 +32,7 @@ final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(impli
     F: MonadThrow[F]
 ) {
   def mergeWithGlobal(maybeRepoConfig: Option[RepoConfig]): RepoConfig =
-    (maybeRepoConfig |+| maybeGlobalRepoConfig).getOrElse(RepoConfig.empty)
+    (maybeGlobalRepoConfig |+| maybeRepoConfig).getOrElse(RepoConfig.empty)
 
   def readRepoConfig(repo: Repo): F[ConfigParsingResult] =
     for {


### PR DESCRIPTION
This is done in the [`RepoConfigLoader`](https://github.com/scala-steward-org/scala-steward/blob/main/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigLoader.scala#L35) with the default config and the supplied additional configs. And now here in the same way.

The `RepoConfig.combine`  function treats the 2nd argument as the one overwriting the 1st one in cas emerging doesn't make sense. This applies at the moment only for "pin".

This fixes the problem reported in https://github.com/typelevel/sbt-typelevel/pull/703#issuecomment-2079703210 
Without the fix the https://github.com/typelevel/sbt-typelevel/blob/main/.scala-steward.conf was overwriting the config supplied by the repo https://github.com/typelevel/sbt-typelevel/blob/main/.scala-steward.conf
This became a problem after #3305 and resulted in a not wanted pull request: https://github.com/typelevel/sbt-typelevel/pull/703