### PR TITLE
Allow 3.4.x pull request for users already on Scala Next

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -30,16 +30,15 @@ postUpdateHooks = [
 updates.ignore = [
   // Artifacts below are ignored because they are not yet announced.
 
-  // No upgrades to non LTS versions
-  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { prefix = "3.4." } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { prefix = "3.4." } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { prefix = "3.4." } },
+  // Ignore the next Scala 3 Next version until it is announced.
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.4.2" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.4.2" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.4.2" } },
 
   // Ignore the next Scala 3 LTS version until it is announced.
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.4" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.4" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.4" } },
-
 
   // Ignore the 3.3.2 version as it is abandoned due to broken compatibility
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.2" } },


### PR DESCRIPTION
Re-enable Scala 3 Next PRs after #3328 got merged and is part of https://github.com/scala-steward-org/scala-steward/releases/tag/v0.30.0