### PR TITLE
Fix Scala 3 check

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/package.scala
@@ -37,5 +37,5 @@ package object data {
   val scalaLangModules: List[(GroupId, ArtifactId)] =
     scala2LangModules ++ scala3LangModules
 
-  val scalaNextMinVersion: Version = Version("3.4.0")
+  val scalaNextMinVersion: Version = Version("3.4.0-NIGHTLY")
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -79,13 +79,14 @@ object FilterAlg {
         val filteredVersions = update.newerVersions.filterNot(_ >= scalaNextMinVersion)
         if (filteredVersions.nonEmpty)
           Right(update.copy(newerVersions = Nel.fromListUnsafe(filteredVersions)))
-        else Left(IgnoreScalaNext(update))
+        else
+          Left(IgnoreScalaNext(update))
       }
     }
 
   def isScala3Lang(update: Update.ForArtifactId): Boolean =
     scala3LangModules.exists { case (g, a) =>
-      update.groupId == g && update.artifactIds.exists(_ == a)
+      update.groupId == g && update.artifactIds.exists(_.name == a.name)
     }
 
   private def globalFilter(update: Update.ForArtifactId, repoConfig: RepoConfig): FilterResult =

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -254,17 +254,26 @@ class FilterAlgTest extends FunSuite {
 
   test("scalaLTSFilter: LTS, filter versions") {
     val update =
-      ("org.scala-lang".g % "scala3-compiler".a % "3.3.2" %> Nel.of("3.3.3", "3.4.0")).single
+      ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.3.2" %> Nel.of(
+        "3.3.3",
+        "3.4.0"
+      )).single
     assertEquals(scalaLTSFilter(update), Right(update.copy(newerVersions = Nel.of("3.3.3".v))))
   }
 
   test("scalaLTSFilter: Next") {
-    val update = ("org.scala-lang".g % "scala3-compiler".a % "3.4.0" %> Nel.of("3.4.1")).single
+    val update =
+      ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.4.0" %> Nel.of(
+        "3.4.1"
+      )).single
     assertEquals(scalaLTSFilter(update), Right(update))
   }
 
   test("isScala3Lang: true") {
-    val update = ("org.scala-lang".g % "scala3-compiler".a % "3.3.3" %> Nel.of("3.4.0")).single
+    val update =
+      ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.3.3" %> Nel.of(
+        "3.4.0"
+      )).single
     assert(isScala3Lang(update))
   }
 


### PR DESCRIPTION
* the artifact contains a cross version, so only comparing the artifact name leads to the correct result 
* adapt lowest Scala 3 NEXT version

Tested with  https://github.com/playframework/play-json to prevent in the future pull requests like https://github.com/playframework/play-json/pull/1035