### PR TITLE
use foldMap instead of collectFold

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -91,7 +91,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
       plugin <- Resource.eval(stewardPlugin(pluginVersion))
       _ <- List
         .iterate(buildRootDir / project, metaBuilds + 1)(_ / project)
-        .collectFold(fileAlg.createTemporarily(_, plugin))
+        .foldMap(fileAlg.createTemporarily(_, plugin))
     } yield ()
 
   private def stewardPlugin(version: String): F[FileData] = {


### PR DESCRIPTION
since `fileAlg.createTemporarily` is a total function, it's a little better to use `foldMap` rather than `collectFold`