### PR TITLE
Fix ambiguous argument 'main'

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -121,7 +121,7 @@ final class FileGitAlg[F[_]](config: GitCfg)(implicit
     fileAlg.deleteForce(repo)
 
   override def resetHard(repo: File, base: Branch): F[Unit] =
-    git_("reset", "--hard", base.name)(repo).void
+    git_("reset", "--hard", base.name, "--")(repo).void
 
   override def setAuthor(repo: File, author: Author): F[Unit] =
     for {


### PR DESCRIPTION
When scala-steward attempts to update a PR and a file/folder in the repository has the same name as the branch that it is being run against, it fails with a fatal error: 
`fatal: ambiguous argument 'main': both revision and filename`
This change should fix the ambiguity
