### PR TITLE
Only return a failure exit code when all repos have failed

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -4,7 +4,7 @@ All command line arguments for the `scala-steward` application.
 
 ```
 Usage:
-    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>]
+    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>] [--exit-code-success-if-any-repo-succeeds]
     scala-steward validate-repo-config
 
 
@@ -94,6 +94,8 @@ Options and flags:
         default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>
         Period of time a failed build won't be triggered again; default: 0days
+    --exit-code-success-if-any-repo-succeeds
+        Whether the Scala Steward process should exit with success (exit code 0) if any repo succeeds; default: false
 
 Subcommands:
     validate-repo-config

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -63,7 +63,8 @@ final case class Config(
     githubApp: Option[GitHubApp],
     urlCheckerTestUrls: Nel[Uri],
     defaultResolver: Resolver,
-    refreshBackoffPeriod: FiniteDuration
+    refreshBackoffPeriod: FiniteDuration,
+    exitCodePolicy: ExitCodePolicy
 ) {
   def forgeSpecificCfg: ForgeSpecificCfg =
     forgeCfg.tpe match {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/ExitCodePolicy.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ExitCodePolicy.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2023 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.application
+
+import cats.effect.ExitCode
+
+trait ExitCodePolicy {
+  def exitCodeFor(runResults: RunResults): ExitCode
+}
+
+object ExitCodePolicy {
+  def successIf(isSuccess: RunResults => Boolean): ExitCodePolicy =
+    (runResults: RunResults) => if (isSuccess(runResults)) ExitCode.Success else ExitCode.Error
+
+  val SuccessIfAnyRepoSucceeds: ExitCodePolicy = successIf(_.successRepos.nonEmpty)
+
+  val SuccessOnlyIfAllReposSucceed: ExitCodePolicy = successIf(_.reposWithFailures.nonEmpty)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.data.Repo
 case class RunResults(results: List[Either[(Repo, Throwable), Repo]]) {
   val (reposWithFailures, successRepos) = results.separate
 
-  val exitCode: ExitCode = if (reposWithFailures.isEmpty) ExitCode.Success else ExitCode.Error
+  val exitCode: ExitCode = if (successRepos.nonEmpty) ExitCode.Success else ExitCode.Error
 
   val markdownSummary: String = {
     val failuresSummaryOpt = Option.when(reposWithFailures.nonEmpty) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
@@ -16,14 +16,11 @@
 
 package org.scalasteward.core.application
 
-import cats.effect.ExitCode
 import cats.syntax.all._
 import org.scalasteward.core.data.Repo
 
 case class RunResults(results: List[Either[(Repo, Throwable), Repo]]) {
   val (reposWithFailures, successRepos) = results.separate
-
-  val exitCode: ExitCode = if (successRepos.nonEmpty) ExitCode.Success else ExitCode.Error
 
   val markdownSummary: String = {
     val failuresSummaryOpt = Option.when(reposWithFailures.nonEmpty) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -98,7 +98,7 @@ final class StewardAlg[F[_]](config: Config)(implicit
               for {
                 summaryFile <- workspaceAlg.runSummaryFile
                 _ <- fileAlg.writeFile(summaryFile, runResults.markdownSummary)
-              } yield runResults.exitCode
+              } yield config.exitCodePolicy.exitCodeFor(runResults)
             }
       } yield exitCode
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -6,9 +6,14 @@ import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli.ParseResult._
 import org.scalasteward.core.application.Cli.{EnvVar, Usage}
+import org.scalasteward.core.application.ExitCodePolicy.{
+  SuccessIfAnyRepoSucceeds,
+  SuccessOnlyIfAllReposSucceed
+}
 import org.scalasteward.core.forge.ForgeType
 import org.scalasteward.core.forge.github.GitHubApp
 import org.scalasteward.core.util.Nel
+
 import scala.concurrent.duration._
 
 class CliTest extends FunSuite {
@@ -205,6 +210,19 @@ class CliTest extends FunSuite {
     )
     val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
     assert(!obtained.forgeCfg.addLabels)
+  }
+
+  test("parseArgs: exit code policy: --exit-code-success-if-any-repo-succeeds") {
+    val params = minimumRequiredParams ++ List(
+      List("--exit-code-success-if-any-repo-succeeds")
+    )
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    assert(obtained.exitCodePolicy == SuccessIfAnyRepoSucceeds)
+  }
+
+  test("parseArgs: exit code policy: default") {
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(minimumRequiredParams.flatten)
+    assert(obtained.exitCodePolicy == SuccessOnlyIfAllReposSucceed)
   }
 
   test("parseArgs: validate pull request labeling enabled") {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
@@ -8,6 +8,9 @@ import org.scalasteward.core.mock.{MockConfig, MockState}
 class StewardAlgTest extends CatsEffectSuite {
   test("runF") {
     val exitCode = stewardAlg.runF.runA(MockState.empty.addUris(MockConfig.reposFile -> ""))
-    assertIO(exitCode, ExitCode.Success)
+    assertIO(
+      exitCode,
+      ExitCode.Error
+    ) // We have not passed any repos to Scala Steward therefore it's reasonable that it will return error code.
   }
 }


### PR DESCRIPTION
When even one repository fails in a scala steward run the workspace is not persisted by GitHub Actions because GH Actions won't persist the workspace of a failing job. Persisting workspace is crucial for respecting `pullRequests.frequency` configuration because the workspace is how scala steward records that it has opened a pull request. This means that one failing repository can cause a lot of user annoyance because their configuration is no longer respected and they get too many PRs opened. This change aims to fix that by only returning a failure code if *all* repos have failed. So long as at least one repository succeeded the exit code will be success and the workspace will persist. If administrators need to know what repos are failing they can use the jobs summary introduced by: https://github.com/scala-steward-org/scala-steward/pull/3071

See more here: https://github.com/guardian/scala-steward-public-repos/issues/60

cc @alejandrohdezma