### PR TITLE
Fix exit code policy

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/ExitCodePolicy.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ExitCodePolicy.scala
@@ -28,5 +28,5 @@ object ExitCodePolicy {
 
   val SuccessIfAnyRepoSucceeds: ExitCodePolicy = successIf(_.successRepos.nonEmpty)
 
-  val SuccessOnlyIfAllReposSucceed: ExitCodePolicy = successIf(_.reposWithFailures.nonEmpty)
+  val SuccessOnlyIfAllReposSucceed: ExitCodePolicy = successIf(_.reposWithFailures.isEmpty)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
@@ -8,9 +8,6 @@ import org.scalasteward.core.mock.{MockConfig, MockState}
 class StewardAlgTest extends CatsEffectSuite {
   test("runF") {
     val exitCode = stewardAlg.runF.runA(MockState.empty.addUris(MockConfig.reposFile -> ""))
-    assertIO(
-      exitCode,
-      ExitCode.Error
-    ) // We have not passed any repos to Scala Steward therefore it's reasonable that it will return error code.
+    assertIO(exitCode, ExitCode.Success)
   }
 }


### PR DESCRIPTION
Aligning expectation that "all repos succeed" means there are no repos with failures.

This brings back the old behavior from RunResults:

    if (reposWithFailures.isEmpty) ExitCode.Success else ExitCode.Error

See:
https://github.com/scala-steward-org/scala-steward/compare/6259adb0...9d9460af