### PR TITLE
chore: Metaconfig has been moved to org.scalameta

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1349,4 +1349,34 @@ changes = [
     groupIdAfter = org.polyvariant
     artifactIdAfter = sttp-oauth2
   },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig-core
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig-hocon
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig-json
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig-sconfig
+  },
+  {
+    groupIdBefore = com.geirsson
+    groupIdAfter = org.scalameta
+    artifactIdAfter = metaconfig-typesafe-config
+  },
 ]


### PR DESCRIPTION
It was already in the github org for a while, but wasn't changed.

Should be merged once https://github.com/scalameta/metaconfig/actions/runs/10093438821 release is done.