### PR TITLE
Simplify KeyValueStore.modifyF

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/KeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/KeyValueStore.scala
@@ -28,7 +28,7 @@ trait KeyValueStore[F[_], K, V] {
     get(key).map(_.getOrElse(default))
 
   final def modifyF(key: K)(f: Option[V] => F[Option[V]])(implicit F: FlatMap[F]): F[Option[V]] =
-    get(key).flatMap(maybeValue => f(maybeValue).flatTap(set(key, _)))
+    get(key).flatMap(f).flatTap(set(key, _))
 
   final def put(key: K, value: V): F[Unit] =
     set(key, Some(value))


### PR DESCRIPTION
I came across this line, proved that `fa.flatMap(a => f(a).flatTap(g)) <-> fa.flatMap(f).flatTap(g)`, and applied it to this line. Hope this small change reduces complexity a bit.