### PR TITLE
Migrate com.github.valskalla:odin to dev.scalafreaks:odin

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1379,4 +1379,29 @@ changes = [
     groupIdAfter = org.scalameta
     artifactIdAfter = metaconfig-typesafe-config
   },
+  {
+    groupIdBefore = com.github.valskalla
+    groupIdAfter = dev.scalafreaks
+    artifactIdAfter = odin-core
+  },
+  {
+    groupIdBefore = com.github.valskalla
+    groupIdAfter = dev.scalafreaks
+    artifactIdAfter = odin-extras
+  },
+  {
+    groupIdBefore = com.github.valskalla
+    groupIdAfter = dev.scalafreaks
+    artifactIdAfter = odin-json
+  },
+  {
+    groupIdBefore = com.github.valskalla
+    groupIdAfter = dev.scalafreaks
+    artifactIdAfter = odin-slf4j
+  },
+  {
+    groupIdBefore = com.github.valskalla
+    groupIdAfter = dev.scalafreaks
+    artifactIdAfter = odin-zio
+  },
 ]


### PR DESCRIPTION
After more than two years without any activity and because original maintainers [didn't answer the questions](https://github.com/valskalla/odin/issues/499) about current status of the project, I decided to fork the project and start publishing it under `dev.scalafreaks` organization. The project is a fork a not an ownership transfer because it has not been possible to contact maintainers.

Some of the users have already migrated and are working with the new versions. I hope this explanation is enough to accept this PR 🙏🏽 
