### PR TITLE
Support more Mill buildfiles (build.mill, build.mill.scala)

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -38,7 +38,12 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
   override def containsBuild(buildRoot: BuildRoot): F[Boolean] =
     workspaceAlg
       .buildRootDir(buildRoot)
-      .flatMap(buildRootDir => fileAlg.isRegularFile(buildRootDir / "build.sc"))
+      .flatMap(buildRootDir =>
+        Seq("build.sc", "build.mill", "build.mill.scala")
+          .map(buildRootDir / _)
+          .filterA(f => fileAlg.isRegularFile(f))
+          .map(_.nonEmpty)
+      )
 
   private def runMill(buildRootDir: File) = {
     val command = Nel("mill", List("-i", "--import", cliPluginCoordinate, "show", extractDeps))

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -43,10 +43,14 @@ class BuildToolDispatcherTest extends FunSuite {
     val expectedState = initial.copy(trace =
       Cmd("test", "-f", s"$repoDir/pom.xml") +:
         Cmd("test", "-f", s"$repoDir/build.sc") +:
+        Cmd("test", "-f", s"$repoDir/build.mill") +:
+        Cmd("test", "-f", s"$repoDir/build.mill.scala") +:
         Cmd("test", "-f", s"$repoDir/build.sbt") +:
         allGreps ++:
         Cmd("test", "-f", s"$repoDir/mvn-build/pom.xml") +:
         Cmd("test", "-f", s"$repoDir/mvn-build/build.sc") +:
+        Cmd("test", "-f", s"$repoDir/mvn-build/build.mill") +:
+        Cmd("test", "-f", s"$repoDir/mvn-build/build.mill.scala") +:
         Cmd("test", "-f", s"$repoDir/mvn-build/build.sbt") +:
         allGreps ++:
         Log("Get dependencies in . from sbt") +:


### PR DESCRIPTION
Mill `0.12` will support more build file names.

* `build.sc`
* `build.mill`
* `build.mill.scala`

This change makes sure Scala Steward will detect these.

Fix https://github.com/scala-steward-org/scala-steward/issues/3409