### PR TITLE
Add dockerBuildxPlatforms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -394,6 +394,7 @@ lazy val dockerSettings = Def.settings(
     )
   },
   Docker / packageName := s"fthomas/${name.value}",
+  Docker / dockerBuildxPlatforms := List("linux/amd64", "linux/arm64"),
   dockerUpdateLatest := true,
   dockerAliases ++= {
     if (!isSnapshot.value) Seq(dockerAlias.value.withTag(Option("latest-release"))) else Nil


### PR DESCRIPTION
Continuing on https://github.com/scala-steward-org/scala-steward/issues/2590, this allegedly will trigger buildx during a CI build