### PR TITLE
add migration for bucket4j

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1405,61 +1405,51 @@ changes = [
     artifactIdAfter = odin-zio
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-core
     artifactIdAfter = bucket4j_jdk17-core
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-hazelcast
     artifactIdAfter = bucket4j_jdk17-hazelcast
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-jcache
     artifactIdAfter = bucket4j_jdk17-jcache
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-redis
     artifactIdAfter = bucket4j_jdk17-redis
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-redis-common
     artifactIdAfter = bucket4j_jdk17-redis-common
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-infinispan
     artifactIdAfter = bucket4j_jdk17-infinispan
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-postgresql
     artifactIdAfter = bucket4j_jdk17-postgresql
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-ignite
     artifactIdAfter = bucket4j_jdk17-ignite
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-coherence
     artifactIdAfter = bucket4j_jdk17-coherence
   },
   {
-    groupIdBefore = com.bucket4j
     groupIdAfter = com.bucket4j
     artifactIdBefore = bucket4j-oracle
     artifactIdAfter = bucket4j_jdk17-oracle

--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1404,4 +1404,64 @@ changes = [
     groupIdAfter = dev.scalafreaks
     artifactIdAfter = odin-zio
   },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-core
+    artifactIdAfter = bucket4j_jdk17-core
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-hazelcast
+    artifactIdAfter = bucket4j_jdk17-hazelcast
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-jcache
+    artifactIdAfter = bucket4j_jdk17-jcache
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-redis
+    artifactIdAfter = bucket4j_jdk17-redis
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-redis-common
+    artifactIdAfter = bucket4j_jdk17-redis-common
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-infinispan
+    artifactIdAfter = bucket4j_jdk17-infinispan
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-postgresql
+    artifactIdAfter = bucket4j_jdk17-postgresql
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-ignite
+    artifactIdAfter = bucket4j_jdk17-ignite
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-coherence
+    artifactIdAfter = bucket4j_jdk17-coherence
+  },
+  {
+    groupIdBefore = com.bucket4j
+    groupIdAfter = com.bucket4j
+    artifactIdBefore = bucket4j-oracle
+    artifactIdAfter = bucket4j_jdk17-oracle
+  }
 ]


### PR DESCRIPTION
bucket4j went for a versioning and deployment scheme split in 8+, 11+ and 17+. I moved to 17+ as that should be the most common, and the scalasteward user should now at least be notified of the option to update, allowing to override to a different one if wanted.