### PR TITLE
Block Scala 3.6.1

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -31,9 +31,9 @@ updates.ignore = [
   // Artifacts below are ignored because they are not yet announced.
 
   // Ignore the next Scala 3 Next version until it is announced.
-  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.6.0" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.6.0" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.6.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.6.1" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.6.1" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.6.1" } },
 
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.5.2" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.5.2" } },
@@ -43,6 +43,11 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.5" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.3.5" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.3.5" } },
+
+  // Ignore the 3.6.0 version as it is abandoned due to broken compatibility 
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.6.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.6.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.6.0" } },
 
   // Ignore the 3.3.2 version as it is abandoned due to broken compatibility
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.3.2" } },


### PR DESCRIPTION
Due to problem with Scala 3 release 3.6.0 should be forgotten. Do not recommend updates, block next release 3.6.1 hotfix that would shortly released.