### PR TITLE
Ignore Scala 3.7.0

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -30,6 +30,11 @@ postUpdateHooks = [
 updates.ignore = [
   // Artifacts below are ignored because they are not yet announced.
 
+  // Ignore the next Scala 3 Next (3.x.0) version until it is announced.
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.7.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.7.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { exact = "3.7.0" } },
+
   // Ignore the next Scala 3 Next version until it is announced.
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",     version = { exact = "3.6.1" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",      version = { exact = "3.6.1" } },


### PR DESCRIPTION
Ignore Scala 3.7.0 so we don't forget it, when the release comes closer.