### PR TITLE
Ignore doobie 1.0.0-RC6

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -225,4 +225,11 @@ updates.ignore = [
 
   // https://github.com/circe/circe-yaml/issues/402
   { groupId = "io.circe", artifactId="circe-yaml", version="1.15.0" },
+
+  // https://github.com/typelevel/doobie/issues/2104
+  { groupId = "org.tpolecat", artifactId="doobie-core", version="1.0.0-RC6" },
+  { groupId = "org.tpolecat", artifactId="doobie-postgres", version="1.0.0-RC6" },
+  { groupId = "org.tpolecat", artifactId="doobie-scalatest", version="1.0.0-RC6" },
+  { groupId = "org.tpolecat", artifactId="doobie-hikari", version="1.0.0-RC6" },
+  { groupId = "org.tpolecat", artifactId="doobie-postgres-circe", version="1.0.0-RC6" },
 ]


### PR DESCRIPTION
This release must be avoided according the changelog: https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC6

See issue https://github.com/scala-steward-org/scala-steward/issues/3442