### PR TITLE
Unlock Scala 3.5.2 updates

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -56,18 +56,6 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.6.1" } },
   { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.6.1" } },
 
-  { groupId = "org.scala-lang", artifactId = "scala3-compiler",                      version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library",                       version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1",                  version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "tasty-core",                           version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala2-library-cc-tasty-experimental", version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala2-library-tasty-experimental",    version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-language-server",               version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-presentation-compiler",         version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-staging",                       version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.5.2" } },
-  { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.5.2" } },
-
   // Ignore the next Scala 3 LTS version until it is announced.
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",              version = { exact = "3.3.5" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",               version = { exact = "3.3.5" } },


### PR DESCRIPTION
Scala 3.5.2 is officially available. The next release 3.6.1 and broken 3.6.0 is already blocked. 