### PR TITLE
Replace com-lihaoyi/mill/mill script with lefou/millw/millw

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,14 +356,10 @@ lazy val dockerSettings = Def.settings(
       s"tar -xf $sbtTgz",
       s"rm -f $sbtTgz"
     ).mkString(" && ")
-    val millVer = Dependencies.millScriptVersion
+    val millVer = Dependencies.millwScriptVersion
     val millBin = s"$binDir/mill"
-    val releasePageVersion = millVer.split("-") match {
-      case Array(v, m, _*) if m.startsWith("M") => s"${v}-${m}"
-      case Array(v, _*)                         => v
-    }
     val installMill = Seq(
-      s"$curl $millBin https://github.com/lihaoyi/mill/releases/download/${releasePageVersion}/$millVer",
+      s"$curl $millBin https://raw.githubusercontent.com/lefou/millw/refs/tags/${millVer}/millw",
       s"chmod +x $millBin"
     ).mkString(" && ")
     val csBin = s"$binDir/cs"

--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val dockerSettings = Def.settings(
     val millVer = Dependencies.millwScriptVersion
     val millBin = s"$binDir/mill"
     val installMill = Seq(
-      s"$curl $millBin https://raw.githubusercontent.com/lefou/millw/refs/tags/${millVer}/millw",
+      s"$curl $millBin https://github.com/lefou/millw/releases/download/${millVer}/millw-${millVer}",
       s"chmod +x $millBin"
     ).mkString(" && ")
     val csBin = s"$binDir/cs"

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -46,7 +46,8 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       )
 
   private def runMill(buildRootDir: File) = {
-    val command = Nel("mill", List("--no-server", "--import", cliPluginCoordinate, "show", extractDeps))
+    val command =
+      Nel("mill", List("--no-server", "--import", cliPluginCoordinate, "show", extractDeps))
     processAlg.execSandboxed(command, buildRootDir)
   }
   private def runMillUnder011(buildRootDir: File, millBuildVersion: Option[Version]) = {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -46,7 +46,7 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       )
 
   private def runMill(buildRootDir: File) = {
-    val command = Nel("mill", List("-i", "--import", cliPluginCoordinate, "show", extractDeps))
+    val command = Nel("mill", List("--no-server", "--import", cliPluginCoordinate, "show", extractDeps))
     processAlg.execSandboxed(command, buildRootDir)
   }
   private def runMillUnder011(buildRootDir: File, millBuildVersion: Option[Version]) = {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -39,7 +39,7 @@ class MillAlgTest extends FunSuite {
     val millCmd = Cmd.execSandboxed(
       repoDir,
       "mill",
-      "-i",
+      "--no-server",
       "--import",
       "ivy:org.scala-steward::scala-steward-mill-plugin::0.18.0",
       "show",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % "0.12.6"
   val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % jjwtApi.revision
   val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % jjwtApi.revision
-  val millScriptVersion = "0.11.0-M10"
+  val millwScriptVersion = "0.4.12"
   val monocleCore = "dev.optics" %% "monocle-core" % "3.3.0"
   val munit = "org.scalameta" %% "munit" % "1.0.2"
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect" % "2.0.0"


### PR DESCRIPTION
This replaces the `mill` script from the Mill project with the script from the dedicated [`millw`](https://github.com/lefou/millw) project.

There is no version of the former script, that properly support all Mill version that Scala Steward can handle.

The `lefou/millw` project supports all Mill version.

Hopefully fix https://github.com/scala-steward-org/scala-steward/issues/3463

I didn't test it locally due to not having set up a test environment for Scala steward. Let me know if that is a deal breaker for you.