### PR TITLE
Revert the base docker image back to JDK 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val dockerSettings = Def.settings(
   dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE"))
-    .getOrElse("eclipse-temurin:21-alpine"),
+    .getOrElse("eclipse-temurin:11-alpine"),
   dockerCommands ++= {
     val curl = "curl -fL --output"
     val binDir = "/usr/local/bin"


### PR DESCRIPTION
JDK 21 requires that `sbt` is of version 1.9.0 or greater. This poses problems to some projects. As the other changes to support a multi-platform docker image had flaws too, this change shouldn't be a problem.

Fixes: #3467