### PR TITLE
Remove trailing comments in parsed SBT module version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/ModulePositionScanner.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/ModulePositionScanner.scala
@@ -45,7 +45,7 @@ object ModulePositionScanner {
   private def sbtModuleIdRegex(dependency: Dependency): Regex = {
     val g = Regex.quote(dependency.groupId.value)
     val a = Regex.quote(dependency.artifactId.name)
-    raw""""($g)"\s*%+\s*"($a)"\s*%+\s*(.*)""".r
+    raw""""($g)"\s*%+\s*"($a)"\s*%+\s*([^\s/]*)""".r
   }
 
   private def findMillDependency(

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/update/ModulePositionScannerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/update/ModulePositionScannerTest.scala
@@ -34,6 +34,34 @@ class ModulePositionScannerTest extends FunSuite {
     assertEquals(obtained, expected)
   }
 
+  test("sbt module with version val and comment") {
+    val d = "org.typelevel".g % "cats-core".a % "2.9.0"
+    val fd = FileData("build.sbt", s""""${d.groupId}" %% "${d.artifactId.name}" % catsVersion // this is a comment""")
+    val obtained = ModulePositionScanner.findPositions(d, fd)
+    val expected = List(
+      ModulePosition(
+        Substring.Position(fd.path, 1, d.groupId.value),
+        Substring.Position(fd.path, 20, d.artifactId.name),
+        Substring.Position(fd.path, 33, "catsVersion")
+      )
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("sbt module with version val and end space") {
+    val d = "org.typelevel".g % "cats-core".a % "2.9.0"
+    val fd = FileData("build.sbt", s""""${d.groupId}" %% "${d.artifactId.name}" % catsVersion """)
+    val obtained = ModulePositionScanner.findPositions(d, fd)
+    val expected = List(
+      ModulePosition(
+        Substring.Position(fd.path, 1, d.groupId.value),
+        Substring.Position(fd.path, 20, d.artifactId.name),
+        Substring.Position(fd.path, 33, "catsVersion")
+      )
+    )
+    assertEquals(obtained, expected)
+  }
+
   test("sbt module where the artifactId is also part of the groupId") {
     val d = "com.typesafe.play".g % "play".a % "2.9.0"
     val fd = FileData("build.sbt", s""""com.typesafe.play" %% "play" % "2.9.0"""")


### PR DESCRIPTION
At $work we recently noticed that Scala Steward was not updating dependencies that have trailing comments like

```scala
"software.amazon.awssdk"                 % "dynamodb"                     % V.aws, // Overrides `scanamo` version
"software.amazon.awssdk"                 % "sso"                          % V.aws, // Needed for local dev!
"software.amazon.awssdk"                 % "sts"                          % V.aws  // Needed for EKS IAM!
```

these we're workarounding them by placing the comments elsewhere:

```scala
// The following comments are not inlined to avoid breaking Scala Steward!
// - Module `dynamodb` overrides `scanamo` version
// - Module `sso` is needed for local development
// - Module `sts` is needed for EKS IAM
"software.amazon.awssdk" % "dynamodb" % V.aws,
"software.amazon.awssdk" % "sso"      % V.aws,
"software.amazon.awssdk" % "sts"      % V.aws
```

but I think this can be easily avoided by changing the regex like in this PR.

I don't have any idea if this impacts anything else in the code (tests are green at least locally), so let's discuss it because I think the current behavior is not the expected one 🙏🏽 