### PR TITLE
Replace `deriveUnwrappedCodec` with handwritten de-/encoders

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
@@ -18,14 +18,16 @@ package org.scalasteward.core.buildtool.sbt.data
 
 import cats.Order
 import cats.syntax.all._
-import io.circe.Codec
-import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
 
 final case class SbtVersion(value: String)
 
 object SbtVersion {
-  implicit val sbtVersionCodec: Codec[SbtVersion] =
-    deriveUnwrappedCodec
+  implicit val sbtVersionDecoder: Decoder[SbtVersion] =
+    Decoder[String].map(SbtVersion.apply)
+
+  implicit val sbtVersionEncoder: Encoder[SbtVersion] =
+    Encoder[String].contramap(_.value)
 
   implicit val sbtVersionOrder: Order[SbtVersion] =
     Order[String].contramap(_.value)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
@@ -18,14 +18,16 @@ package org.scalasteward.core.buildtool.sbt.data
 
 import cats.Order
 import cats.syntax.all._
-import io.circe.Codec
-import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
 
 final case class ScalaVersion(value: String)
 
 object ScalaVersion {
-  implicit val scalaVersionCodec: Codec[ScalaVersion] =
-    deriveUnwrappedCodec
+  implicit val scalaVersionDecoder: Decoder[ScalaVersion] =
+    Decoder[String].map(ScalaVersion.apply)
+
+  implicit val scalaVersionEncoder: Encoder[ScalaVersion] =
+    Encoder[String].contramap(_.value)
 
   implicit val scalaVersionOrder: Order[ScalaVersion] =
     Order[String].contramap(_.value)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/CrossDependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/CrossDependency.scala
@@ -18,8 +18,7 @@ package org.scalasteward.core.data
 
 import cats.Order
 import cats.syntax.all._
-import io.circe.Codec
-import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.util.Nel
 
 /** A list of dependencies with the same groupId, (non-cross) artifactId, and version. */
@@ -44,9 +43,12 @@ object CrossDependency {
       .map(grouped => CrossDependency(grouped.sorted))
       .toList
 
-  implicit val crossDependencyCodec: Codec[CrossDependency] =
-    deriveUnwrappedCodec
+  implicit val crossDependencyDecoder: Decoder[CrossDependency] =
+    Decoder[Nel[Dependency]].map(CrossDependency.apply)
+
+  implicit val crossDependencyEncoder: Encoder[CrossDependency] =
+    Encoder[Nel[Dependency]].contramap(_.dependencies)
 
   implicit val crossDependencyOrder: Order[CrossDependency] =
-    Order.by((_: CrossDependency).dependencies)
+    Order.by(_.dependencies)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -19,8 +19,7 @@ package org.scalasteward.core.data
 import cats.Order
 import cats.implicits._
 import cats.parse.{Numbers, Parser, Rfc5234}
-import io.circe.Codec
-import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Version.startsWithDate
 
 final case class Version(value: String) {
@@ -128,8 +127,11 @@ object Version {
 
   val tagNames: List[Version => String] = List("v" + _, _.value, "release-" + _)
 
-  implicit val versionCodec: Codec[Version] =
-    deriveUnwrappedCodec
+  implicit val versionDecoder: Decoder[Version] =
+    Decoder[String].map(Version.apply)
+
+  implicit val versionEncoder: Encoder[Version] =
+    Encoder[String].contramap(_.value)
 
   implicit val versionOrder: Order[Version] =
     Order.from[Version] { (v1, v2) =>

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/PullRequestNumber.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/PullRequestNumber.scala
@@ -16,14 +16,16 @@
 
 package org.scalasteward.core.forge.data
 
-import io.circe.Codec
-import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
+import io.circe.{Decoder, Encoder}
 
 final case class PullRequestNumber(value: Int) {
   override def toString: String = value.toString
 }
 
 object PullRequestNumber {
-  implicit val pullRequestNumberCodec: Codec[PullRequestNumber] =
-    deriveUnwrappedCodec
+  implicit val pullRequestNumberDecoder: Decoder[PullRequestNumber] =
+    Decoder[Int].map(PullRequestNumber.apply)
+
+  implicit val pullRequestNumberEncoder: Encoder[PullRequestNumber] =
+    Encoder[Int].contramap(_.value)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -17,8 +17,7 @@
 package org.scalasteward.core.util
 
 import cats.Order
-import io.circe.Codec
-import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
+import io.circe.{Decoder, Encoder}
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
@@ -38,8 +37,11 @@ object Timestamp {
   def fromLocalDateTime(ldt: LocalDateTime): Timestamp =
     Timestamp(ldt.toInstant(ZoneOffset.UTC).toEpochMilli)
 
-  implicit val timestampCodec: Codec[Timestamp] =
-    deriveUnwrappedCodec
+  implicit val timestampDecoder: Decoder[Timestamp] =
+    Decoder[Long].map(Timestamp.apply)
+
+  implicit val timestampEncoder: Encoder[Timestamp] =
+    Encoder[Long].contramap(_.millis)
 
   implicit val timestampOrder: Order[Timestamp] =
     Order.by(_.millis)


### PR DESCRIPTION
`deriveUnwrappedCodec` is from circe-generic-extras which is not available for Scala 3. This is a small step towards replacing that library.