### PR TITLE
Make all values in config classes optional

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -36,9 +36,9 @@ class UpdatesConfigBenchmark {
     val update = Update.ForArtifactId(dependency, newerVersions)
 
     UpdatesConfig().keep(update)
-    UpdatesConfig(allow = List(UpdatePattern(groupId, None, None))).keep(update)
+    UpdatesConfig(allow = Some(List(UpdatePattern(groupId, None, None)))).keep(update)
     UpdatesConfig(allow =
-      List(UpdatePattern(groupId, None, Some(VersionPattern(prefix = Some("6.0")))))
+      Some(List(UpdatePattern(groupId, None, Some(VersionPattern(prefix = Some("6.0"))))))
     ).keep(update)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -119,8 +119,8 @@ final class EditAlg[F[_]](implicit
     } yield maybeCommit.map(UpdateEdit(update, _))
 
   private def reformatChangedFiles(data: RepoData): F[Unit] = {
-    val reformat =
-      data.config.scalafmt.runAfterUpgradingOrDefault && data.cache.dependsOn(List(scalafmtModule))
+    val reformat = data.config.scalafmtOrDefault.runAfterUpgradingOrDefault &&
+      data.cache.dependsOn(List(scalafmtModule))
     F.whenA(reformat) {
       data.config.buildRootsOrDefault(data.repo).traverse_ { buildRoot =>
         logger.attemptWarn.log_(s"Reformatting changed files failed in ${buildRoot.relativePath}") {

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -113,7 +113,7 @@ final class EditAlg[F[_]](implicit
         fileAlg.editFile(repoDir / path, Substring.Replacement.applyAll[F](replacements))
       }
       _ <- reformatChangedFiles(data)
-      msgTemplate = data.config.commits.messageOrDefault
+      msgTemplate = data.config.commitsOrDefault.messageOrDefault
       commitMsg = CommitMsg.replaceVariables(msgTemplate)(update, data.repo.branch)
       maybeCommit <- gitAlg.commitAllIfDirty(data.repo, commitMsg, data.config.signoffCommits)
     } yield maybeCommit.map(UpdateEdit(update, _))

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -173,7 +173,7 @@ object HookExecutor {
       useSandbox = false,
       commitMessage = update => CommitMsg(s"Reformat with scalafmt ${update.nextVersion}"),
       enabledByCache = _ => true,
-      enabledByConfig = _.scalafmt.runAfterUpgradingOrDefault,
+      enabledByConfig = _.scalafmtOrDefault.runAfterUpgradingOrDefault,
       addToGitBlameIgnoreRevs = true,
       signoffCommits = signoffCommits
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
@@ -66,7 +66,7 @@ final class ScannerAlg[F[_]](implicit
     Stream.eval(workspaceAlg.repoDir(repo)).flatMap { repoDir =>
       Stream
         .evalSeq(gitAlg.findFilesContaining(repo, string))
-        .filter(path => config.updates.fileExtensionsOrDefault.exists(path.endsWith))
+        .filter(path => config.updatesOrDefault.fileExtensionsOrDefault.exists(path.endsWith))
         .evalMapFilter(path => fileAlg.readFile(repoDir / path).map(_.map(FileData(path, _))))
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -270,7 +270,7 @@ object NewPullRequestData {
   ): NewPullRequestData =
     NewPullRequestData(
       title = CommitMsg
-        .replaceVariables(data.repoConfig.commits.messageOrDefault)(
+        .replaceVariables(data.repoConfig.commitsOrDefault.messageOrDefault)(
           data.update,
           data.repoData.repo.branch
         )

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -287,7 +287,7 @@ object NewPullRequestData {
       head = branchName,
       base = data.baseBranch,
       labels = if (addLabels) labels else List.empty,
-      assignees = data.repoConfig.assignees,
+      assignees = data.repoConfig.assigneesOrDefault,
       reviewers = data.repoConfig.reviewers
     )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -288,7 +288,7 @@ object NewPullRequestData {
       base = data.baseBranch,
       labels = if (addLabels) labels else List.empty,
       assignees = data.repoConfig.assigneesOrDefault,
-      reviewers = data.repoConfig.reviewers
+      reviewers = data.repoConfig.reviewersOrDefault
     )
 
   def updateTypeLabels(anUpdate: Update): List[String] = {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -80,7 +80,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
           val updateData = UpdateData(data, fork, update, baseBranch, baseSha1, updateBranch)
           processUpdate(updateData)
         }
-        .through(util.takeUntilMaybe(0, data.config.updates.limit.map(_.value)) {
+        .through(util.takeUntilMaybe(0, data.config.updatesOrDefault.limit.map(_.value)) {
           case Ignored    => 0
           case Updated    => 1
           case Created(_) => 1
@@ -310,7 +310,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
 
   def closeRetractedPullRequests(data: RepoData): F[Unit] =
     pullRequestRepository
-      .getRetractedPullRequests(data.repo, data.config.updates.retracted)
+      .getRetractedPullRequests(data.repo, data.config.updatesOrDefault.retracted)
       .flatMap {
         _.traverse_ { case (oldPr, retractedArtifact) =>
           closeRetractedPullRequest(data, oldPr, retractedArtifact)

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -51,7 +51,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       _ <- logger.info(s"Nurture ${data.repo.show}")
       baseBranch <- cloneAndSync(data.repo, fork)
       (grouped, notGrouped) = Update.groupByPullRequestGroup(
-        data.config.pullRequests.grouping,
+        data.config.pullRequests.groupingOrDefault,
         updates.toList
       )
       finalUpdates = Update.groupByGroupId(notGrouped) ++ grouped

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -51,7 +51,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       _ <- logger.info(s"Nurture ${data.repo.show}")
       baseBranch <- cloneAndSync(data.repo, fork)
       (grouped, notGrouped) = Update.groupByPullRequestGroup(
-        data.config.pullRequests.groupingOrDefault,
+        data.config.pullRequestsOrDefault.groupingOrDefault,
         updates.toList
       )
       finalUpdates = Update.groupByGroupId(notGrouped) ++ grouped
@@ -231,7 +231,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
           .flatTraverse(gitAlg.findFilesContaining(data.repo, _))
           .map(_.distinct)
       allLabels = labelsFor(data.update, edits, filesWithOldVersion, artifactIdToVersionScheme)
-      labels = filterLabels(allLabels, data.repoData.config.pullRequests.includeMatchedLabels)
+      labels =
+        filterLabels(allLabels, data.repoData.config.pullRequestsOrDefault.includeMatchedLabels)
     } yield NewPullRequestData.from(
       data = data,
       branchName = config.tpe.pullRequestHeadFor(data.fork, data.updateBranch),
@@ -240,7 +241,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       artifactIdToUpdateInfoUrls = artifactIdToUpdateInfoUrls.toMap,
       filesWithOldVersion = filesWithOldVersion,
       addLabels = config.addLabels,
-      labels = data.repoData.config.pullRequests.customLabelsOrDefault ++ labels
+      labels = data.repoData.config.pullRequestsOrDefault.customLabelsOrDefault ++ labels
     )
 
   private def createPullRequest(data: UpdateData, edits: List[EditAttempt]): F[ProcessResult] =

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -240,7 +240,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       artifactIdToUpdateInfoUrls = artifactIdToUpdateInfoUrls.toMap,
       filesWithOldVersion = filesWithOldVersion,
       addLabels = config.addLabels,
-      labels = data.repoData.config.pullRequests.customLabels ++ labels
+      labels = data.repoData.config.pullRequests.customLabelsOrDefault ++ labels
     )
 
   private def createPullRequest(data: UpdateData, edits: List[EditAttempt]): F[ProcessResult] =

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -310,7 +310,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
 
   def closeRetractedPullRequests(data: RepoData): F[Unit] =
     pullRequestRepository
-      .getRetractedPullRequests(data.repo, data.config.updatesOrDefault.retracted)
+      .getRetractedPullRequests(data.repo, data.config.updatesOrDefault.retractedOrDefault)
       .flatMap {
         _.traverse_ { case (oldPr, retractedArtifact) =>
           closeRetractedPullRequest(data, oldPr, retractedArtifact)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
@@ -21,7 +21,7 @@ import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 
 final case class CommitsConfig(
-    message: Option[String] = None
+    private val message: Option[String] = None
 ) {
   def messageOrDefault: String =
     message.getOrElse(CommitsConfig.defaultMessage)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CommitsConfig.scala
@@ -18,8 +18,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.{Eq, Monoid}
 import io.circe.Codec
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto._
+import io.circe.generic.semiauto.deriveCodec
 
 final case class CommitsConfig(
     message: Option[String] = None
@@ -34,11 +33,8 @@ object CommitsConfig {
   implicit val commitsConfigEq: Eq[CommitsConfig] =
     Eq.fromUniversalEquals
 
-  implicit val commitsConfigConfiguration: Configuration =
-    Configuration.default.withDefaults
-
   implicit val commitsConfigCodec: Codec[CommitsConfig] =
-    deriveConfiguredCodec
+    deriveCodec
 
   implicit val commitsConfigMonoid: Monoid[CommitsConfig] =
     Monoid.instance(CommitsConfig(), (x, y) => CommitsConfig(message = x.message.orElse(y.message)))

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
@@ -17,7 +17,6 @@
 package org.scalasteward.core.repoconfig
 
 import io.circe.Codec
-import io.circe.generic.extras.Configuration
 import io.circe.generic.semiauto.deriveCodec
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.string.indentLines
@@ -28,9 +27,6 @@ final case class GroupRepoConfig(
 )
 
 object GroupRepoConfig {
-  implicit val groupPullConfigCodecConfig: Configuration =
-    Configuration.default.withDefaults
-
   implicit val groupPullConfigCodec: Codec[GroupRepoConfig] =
     deriveCodec
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
@@ -17,8 +17,7 @@
 package org.scalasteward.core.repoconfig
 
 import io.circe.Codec
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+import io.circe.generic.semiauto.deriveCodec
 import org.scalasteward.core.data.{ArtifactId, GroupId}
 import org.scalasteward.core.edit.hooks.PostUpdateHook
 import org.scalasteward.core.git.CommitMsg
@@ -47,9 +46,6 @@ final case class PostUpdateHookConfig(
 }
 
 object PostUpdateHookConfig {
-  implicit val postUpdateHooksConfigConfiguration: Configuration =
-    Configuration.default.withDefaults
-
   implicit val postUpdateHooksConfigCodec: Codec[PostUpdateHookConfig] =
-    deriveConfiguredCodec
+    deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -19,19 +19,21 @@ package org.scalasteward.core.repoconfig
 import cats.implicits._
 import cats.{Eq, Monoid}
 import io.circe.Codec
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+import io.circe.generic.semiauto.deriveCodec
 import java.util.regex.PatternSyntaxException
 import scala.util.matching.Regex
 
 final case class PullRequestsConfig(
     frequency: Option[PullRequestFrequency] = None,
-    grouping: List[PullRequestGroup] = Nil,
+    grouping: Option[List[PullRequestGroup]] = None,
     includeMatchedLabels: Option[Regex] = None,
     customLabels: Option[List[String]] = None
 ) {
   def frequencyOrDefault: PullRequestFrequency =
     frequency.getOrElse(PullRequestsConfig.defaultFrequency)
+
+  def groupingOrDefault: List[PullRequestGroup] =
+    grouping.getOrElse(Nil)
 
   def customLabelsOrDefault: List[String] =
     customLabels.getOrElse(Nil)
@@ -43,16 +45,13 @@ object PullRequestsConfig {
   implicit val pullRequestsConfigEq: Eq[PullRequestsConfig] =
     Eq.fromUniversalEquals
 
-  implicit val pullRequestsConfigConfiguration: Configuration =
-    Configuration.default.withDefaults
-
   implicit val regexCodec: Codec[Regex] =
     Codec
       .from[String](implicitly, implicitly)
       .iemap(s => Either.catchOnly[PatternSyntaxException](s.r).leftMap(_.getMessage))(_.regex)
 
   implicit val pullRequestsConfigCodec: Codec[PullRequestsConfig] =
-    deriveConfiguredCodec
+    deriveCodec
 
   implicit val pullRequestsConfigMonoid: Monoid[PullRequestsConfig] =
     Monoid.instance(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -25,9 +25,9 @@ import scala.util.matching.Regex
 
 final case class PullRequestsConfig(
     frequency: Option[PullRequestFrequency] = None,
-    grouping: Option[List[PullRequestGroup]] = None,
+    private val grouping: Option[List[PullRequestGroup]] = None,
     includeMatchedLabels: Option[Regex] = None,
-    customLabels: Option[List[String]] = None
+    private val customLabels: Option[List[String]] = None
 ) {
   def frequencyOrDefault: PullRequestFrequency =
     frequency.getOrElse(PullRequestsConfig.defaultFrequency)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -21,7 +21,6 @@ import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
-
 import java.util.regex.PatternSyntaxException
 import scala.util.matching.Regex
 
@@ -29,10 +28,13 @@ final case class PullRequestsConfig(
     frequency: Option[PullRequestFrequency] = None,
     grouping: List[PullRequestGroup] = Nil,
     includeMatchedLabels: Option[Regex] = None,
-    customLabels: List[String] = Nil
+    customLabels: Option[List[String]] = None
 ) {
   def frequencyOrDefault: PullRequestFrequency =
     frequency.getOrElse(PullRequestsConfig.defaultFrequency)
+
+  def customLabelsOrDefault: List[String] =
+    customLabels.getOrElse(Nil)
 }
 
 object PullRequestsConfig {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -27,16 +27,16 @@ import org.scalasteward.core.edit.hooks.PostUpdateHook
 import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
 
 final case class RepoConfig(
-    commits: Option[CommitsConfig] = None,
-    pullRequests: Option[PullRequestsConfig] = None,
-    scalafmt: Option[ScalafmtConfig] = None,
-    updates: Option[UpdatesConfig] = None,
-    postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
-    updatePullRequests: Option[PullRequestUpdateStrategy] = None,
-    buildRoots: Option[List[BuildRootConfig]] = None,
-    assignees: Option[List[String]] = None,
-    reviewers: Option[List[String]] = None,
-    dependencyOverrides: Option[List[GroupRepoConfig]] = None,
+    private val commits: Option[CommitsConfig] = None,
+    private val pullRequests: Option[PullRequestsConfig] = None,
+    private val scalafmt: Option[ScalafmtConfig] = None,
+    private val updates: Option[UpdatesConfig] = None,
+    private val postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
+    private val updatePullRequests: Option[PullRequestUpdateStrategy] = None,
+    private val buildRoots: Option[List[BuildRootConfig]] = None,
+    private val assignees: Option[List[String]] = None,
+    private val reviewers: Option[List[String]] = None,
+    private val dependencyOverrides: Option[List[GroupRepoConfig]] = None,
     signoffCommits: Option[Boolean] = None
 ) {
   def commitsOrDefault: CommitsConfig =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -30,7 +30,7 @@ import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
 final case class RepoConfig(
     commits: CommitsConfig = CommitsConfig(),
     pullRequests: PullRequestsConfig = PullRequestsConfig(),
-    scalafmt: ScalafmtConfig = ScalafmtConfig(),
+    scalafmt: Option[ScalafmtConfig] = None,
     updates: UpdatesConfig = UpdatesConfig(),
     postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
@@ -40,6 +40,9 @@ final case class RepoConfig(
     dependencyOverrides: List[GroupRepoConfig] = List.empty,
     signoffCommits: Option[Boolean] = None
 ) {
+  def scalafmtOrDefault: ScalafmtConfig =
+    scalafmt.getOrElse(ScalafmtConfig())
+
   def buildRootsOrDefault(repo: Repo): List[BuildRoot] =
     buildRoots
       .map(_.filterNot(_.relativePath.contains("..")))

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,7 +31,7 @@ final case class RepoConfig(
     commits: Option[CommitsConfig] = None,
     pullRequests: Option[PullRequestsConfig] = None,
     scalafmt: Option[ScalafmtConfig] = None,
-    updates: UpdatesConfig = UpdatesConfig(),
+    updates: Option[UpdatesConfig] = None,
     postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
     buildRoots: Option[List[BuildRootConfig]] = None,
@@ -48,6 +48,9 @@ final case class RepoConfig(
 
   def scalafmtOrDefault: ScalafmtConfig =
     scalafmt.getOrElse(ScalafmtConfig())
+
+  def updatesOrDefault: UpdatesConfig =
+    updates.getOrElse(UpdatesConfig())
 
   def buildRootsOrDefault(repo: Repo): List[BuildRoot] =
     buildRoots

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -36,7 +36,7 @@ final case class RepoConfig(
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
     buildRoots: Option[List[BuildRootConfig]] = None,
     assignees: Option[List[String]] = None,
-    reviewers: List[String] = List.empty,
+    reviewers: Option[List[String]] = None,
     dependencyOverrides: List[GroupRepoConfig] = List.empty,
     signoffCommits: Option[Boolean] = None
 ) {
@@ -60,6 +60,9 @@ final case class RepoConfig(
 
   def assigneesOrDefault: List[String] =
     assignees.getOrElse(Nil)
+
+  def reviewersOrDefault: List[String] =
+    reviewers.getOrElse(Nil)
 
   def postUpdateHooksOrDefault: List[PostUpdateHook] =
     postUpdateHooks.getOrElse(Nil).map(_.toHook)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -35,7 +35,7 @@ final case class RepoConfig(
     postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
     updatePullRequests: Option[PullRequestUpdateStrategy] = None,
     buildRoots: Option[List[BuildRootConfig]] = None,
-    assignees: List[String] = List.empty,
+    assignees: Option[List[String]] = None,
     reviewers: List[String] = List.empty,
     dependencyOverrides: List[GroupRepoConfig] = List.empty,
     signoffCommits: Option[Boolean] = None
@@ -57,6 +57,9 @@ final case class RepoConfig(
       .map(_.filterNot(_.relativePath.contains("..")))
       .getOrElse(defaultBuildRoots)
       .map(cfg => BuildRoot(repo, cfg.relativePath))
+
+  def assigneesOrDefault: List[String] =
+    assignees.getOrElse(Nil)
 
   def postUpdateHooksOrDefault: List[PostUpdateHook] =
     postUpdateHooks.getOrElse(Nil).map(_.toHook)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -29,7 +29,7 @@ import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
 
 final case class RepoConfig(
     commits: Option[CommitsConfig] = None,
-    pullRequests: PullRequestsConfig = PullRequestsConfig(),
+    pullRequests: Option[PullRequestsConfig] = None,
     scalafmt: Option[ScalafmtConfig] = None,
     updates: UpdatesConfig = UpdatesConfig(),
     postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
@@ -42,6 +42,9 @@ final case class RepoConfig(
 ) {
   def commitsOrDefault: CommitsConfig =
     commits.getOrElse(CommitsConfig())
+
+  def pullRequestsOrDefault: PullRequestsConfig =
+    pullRequests.getOrElse(PullRequestsConfig())
 
   def scalafmtOrDefault: ScalafmtConfig =
     scalafmt.getOrElse(ScalafmtConfig())

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -28,7 +28,7 @@ import org.scalasteward.core.edit.hooks.PostUpdateHook
 import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
 
 final case class RepoConfig(
-    commits: CommitsConfig = CommitsConfig(),
+    commits: Option[CommitsConfig] = None,
     pullRequests: PullRequestsConfig = PullRequestsConfig(),
     scalafmt: Option[ScalafmtConfig] = None,
     updates: UpdatesConfig = UpdatesConfig(),
@@ -40,6 +40,9 @@ final case class RepoConfig(
     dependencyOverrides: List[GroupRepoConfig] = List.empty,
     signoffCommits: Option[Boolean] = None
 ) {
+  def commitsOrDefault: CommitsConfig =
+    commits.getOrElse(CommitsConfig())
+
   def scalafmtOrDefault: ScalafmtConfig =
     scalafmt.getOrElse(ScalafmtConfig())
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
@@ -21,7 +21,7 @@ import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 
 final case class ScalafmtConfig(
-    runAfterUpgrading: Option[Boolean] = None
+    private val runAfterUpgrading: Option[Boolean] = None
 ) {
   def runAfterUpgradingOrDefault: Boolean =
     runAfterUpgrading.getOrElse(ScalafmtConfig.defaultRunAfterUpgrading)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ScalafmtConfig.scala
@@ -18,8 +18,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.{Eq, Monoid}
 import io.circe.Codec
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+import io.circe.generic.semiauto.deriveCodec
 
 final case class ScalafmtConfig(
     runAfterUpgrading: Option[Boolean] = None
@@ -34,11 +33,8 @@ object ScalafmtConfig {
   implicit val scalafmtConfigEq: Eq[ScalafmtConfig] =
     Eq.fromUniversalEquals
 
-  implicit val scalafmtConfigConfiguration: Configuration =
-    Configuration.default.withDefaults
-
   implicit val scalafmtConfigCodec: Codec[ScalafmtConfig] =
-    deriveConfiguredCodec
+    deriveCodec
 
   implicit val scalafmtConfigMonoid: Monoid[ScalafmtConfig] =
     Monoid.instance(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -42,7 +42,7 @@ final case class UpdatesConfig(
     allow: List[UpdatePattern] = List.empty,
     allowPreReleases: List[UpdatePattern] = List.empty,
     ignore: Option[List[UpdatePattern]] = None,
-    retracted: List[RetractedArtifact] = List.empty,
+    retracted: Option[List[RetractedArtifact]] = None,
     limit: Option[NonNegInt] = defaultLimit,
     fileExtensions: Option[List[String]] = None
 ) {
@@ -51,6 +51,9 @@ final case class UpdatesConfig(
 
   private def ignoreOrDefault: List[UpdatePattern] =
     ignore.getOrElse(Nil)
+
+  def retractedOrDefault: List[RetractedArtifact] =
+    retracted.getOrElse(Nil)
 
   def fileExtensionsOrDefault: Set[String] =
     fileExtensions.fold(UpdatesConfig.defaultFileExtensions)(_.toSet)
@@ -132,7 +135,7 @@ object UpdatesConfig {
           allow = mergeAllow(x.allow, y.allow),
           allowPreReleases = mergeAllow(x.allowPreReleases, y.allowPreReleases),
           ignore = mergeIgnore(x.ignore, y.ignore),
-          retracted = x.retracted ::: y.retracted,
+          retracted = x.retracted |+| y.retracted,
           limit = x.limit.orElse(y.limit),
           fileExtensions = mergeFileExtensions(x.fileExtensions, y.fileExtensions)
         )

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -147,12 +147,11 @@ object UpdatesConfig {
   private[repoconfig] def mergePin(
       x: Option[List[UpdatePattern]],
       y: Option[List[UpdatePattern]]
-  ): Option[List[UpdatePattern]] =
-    combineOptions(x, y) { (x, y) =>
-      x.filterNot { p1 =>
-        y.exists(p2 => p1.groupId === p2.groupId && p1.artifactId === p2.artifactId)
-      } ::: y
-    }
+  ): Option[List[UpdatePattern]] = combineOptions(x, y) { (x, y) =>
+    x.filterNot { p1 =>
+      y.exists(p2 => p1.groupId === p2.groupId && p1.artifactId === p2.artifactId)
+    } ::: y
+  }
 
   private[repoconfig] val nonExistingUpdatePattern: List[UpdatePattern] =
     List(UpdatePattern(GroupId("non-exist"), None, None))
@@ -162,28 +161,27 @@ object UpdatesConfig {
   private[repoconfig] def mergeAllow(
       x: Option[List[UpdatePattern]],
       y: Option[List[UpdatePattern]]
-  ): Option[List[UpdatePattern]] =
-    combineOptions(x, y) { (x, y) =>
-      (x, y) match {
-        case (Nil, second) => second
-        case (first, Nil)  => first
-        case _             =>
-          //  remove duplicates first by calling .distinct
-          val xm: Map[GroupId, List[UpdatePattern]] = x.distinct.groupBy(_.groupId)
-          val ym: Map[GroupId, List[UpdatePattern]] = y.distinct.groupBy(_.groupId)
-          val builder = new collection.mutable.ListBuffer[UpdatePattern]()
+  ): Option[List[UpdatePattern]] = combineOptions(x, y) { (x, y) =>
+    (x, y) match {
+      case (Nil, second) => second
+      case (first, Nil)  => first
+      case _             =>
+        //  remove duplicates first by calling .distinct
+        val xm: Map[GroupId, List[UpdatePattern]] = x.distinct.groupBy(_.groupId)
+        val ym: Map[GroupId, List[UpdatePattern]] = y.distinct.groupBy(_.groupId)
+        val builder = new collection.mutable.ListBuffer[UpdatePattern]()
 
-          //  first of all, we only allow intersection (superset)
-          val keys = xm.keySet.intersect(ym.keySet)
+        //  first of all, we only allow intersection (superset)
+        val keys = xm.keySet.intersect(ym.keySet)
 
-          keys.foreach { groupId =>
-            builder ++= mergeAllowGroupId(xm(groupId), ym(groupId))
-          }
+        keys.foreach { groupId =>
+          builder ++= mergeAllowGroupId(xm(groupId), ym(groupId))
+        }
 
-          if (builder.isEmpty) nonExistingUpdatePattern
-          else builder.distinct.toList
-      }
+        if (builder.isEmpty) nonExistingUpdatePattern
+        else builder.distinct.toList
     }
+  }
 
   //  merge UpdatePattern for same group id
   private def mergeAllowGroupId(
@@ -225,8 +223,9 @@ object UpdatesConfig {
   private[repoconfig] def mergeIgnore(
       x: Option[List[UpdatePattern]],
       y: Option[List[UpdatePattern]]
-  ): Option[List[UpdatePattern]] =
-    combineOptions(x, y)((x, y) => x ::: y.filterNot(x.contains))
+  ): Option[List[UpdatePattern]] = combineOptions(x, y) { (x, y) =>
+    x ::: y.filterNot(x.contains)
+  }
 
   private[repoconfig] def mergeFileExtensions(
       x: Option[List[String]],

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -37,13 +37,13 @@ import org.scalasteward.core.update.FilterAlg.{
 import org.scalasteward.core.util.{combineOptions, intellijThisImportIsUsed, Nel}
 
 final case class UpdatesConfig(
-    pin: Option[List[UpdatePattern]] = None,
-    allow: Option[List[UpdatePattern]] = None,
-    allowPreReleases: Option[List[UpdatePattern]] = None,
-    ignore: Option[List[UpdatePattern]] = None,
-    retracted: Option[List[RetractedArtifact]] = None,
+    private val pin: Option[List[UpdatePattern]] = None,
+    private val allow: Option[List[UpdatePattern]] = None,
+    private val allowPreReleases: Option[List[UpdatePattern]] = None,
+    private val ignore: Option[List[UpdatePattern]] = None,
+    private val retracted: Option[List[RetractedArtifact]] = None,
     limit: Option[NonNegInt] = defaultLimit,
-    fileExtensions: Option[List[String]] = None
+    private val fileExtensions: Option[List[String]] = None
 ) {
   private[repoconfig] def pinOrDefault: List[UpdatePattern] =
     pin.getOrElse(Nil)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -66,7 +66,10 @@ object FilterAlg {
   final case class IgnoreScalaNext(update: Update.ForArtifactId) extends RejectionReason
 
   def localFilter(update: Update.ForArtifactId, repoConfig: RepoConfig): FilterResult =
-    repoConfig.updates.keep(update).flatMap(scalaLTSFilter).flatMap(globalFilter(_, repoConfig))
+    repoConfig.updatesOrDefault
+      .keep(update)
+      .flatMap(scalaLTSFilter)
+      .flatMap(globalFilter(_, repoConfig))
 
   def scalaLTSFilter(update: Update.ForArtifactId): FilterResult =
     if (!isScala3Lang(update))
@@ -107,7 +110,7 @@ object FilterAlg {
       repoConfig: RepoConfig
   ): FilterResult = {
     val newerVersions = update.newerVersions.toList
-    val maybeNext = repoConfig.updates.preRelease(update) match {
+    val maybeNext = repoConfig.updatesOrDefault.preRelease(update) match {
       case Left(_)  => update.currentVersion.selectNext(newerVersions)
       case Right(_) => update.currentVersion.selectNext(newerVersions, allowPreReleases = true)
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -174,7 +174,7 @@ final class PruningAlg[F[_]](implicit
             (groupRepoConfig.pullRequests.frequency, artifactLastPrCreatedAt)
           )
         }
-        .getOrElse((repoConfig.pullRequests.frequency, repoLastPrCreatedAt))
+        .getOrElse((repoConfig.pullRequestsOrDefault.frequency, repoLastPrCreatedAt))
     val frequency = frequencyz.getOrElse(PullRequestFrequency.Asap)
 
     val dep = dependencyOutdated.crossDependency.head

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -166,7 +166,7 @@ final class PruningAlg[F[_]](implicit
       repoConfig: RepoConfig
   ): F[Boolean] = {
     val (frequencyz: Option[PullRequestFrequency], lastPrCreatedAt: Option[Timestamp]) =
-      repoConfig.dependencyOverrides
+      repoConfig.dependencyOverridesOrDefault
         .collectFirstSome { groupRepoConfig =>
           val matchResult = UpdatePattern
             .findMatch(List(groupRepoConfig.dependency), dependencyOutdated.update, include = true)

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -152,7 +152,7 @@ object TestInstances {
       } yield UpdatesConfig(
         pin = pin,
         allow = allow,
-        ignore = ignore,
+        ignore = Some(ignore),
         limit = limit,
         fileExtensions = fileExtensions
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -163,7 +163,7 @@ object TestInstances {
       for {
         commits <- Arbitrary.arbitrary[CommitsConfig]
         pullRequests <- Arbitrary.arbitrary[PullRequestsConfig]
-        scalafmt <- Arbitrary.arbitrary[ScalafmtConfig]
+        scalafmt <- Arbitrary.arbitrary[Option[ScalafmtConfig]]
         updates <- Arbitrary.arbitrary[UpdatesConfig]
         updatePullRequests <- Arbitrary.arbitrary[Option[PullRequestUpdateStrategy]]
       } yield RepoConfig(

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -151,7 +151,7 @@ object TestInstances {
         fileExtensions <- Arbitrary.arbitrary[Option[List[String]]]
       } yield UpdatesConfig(
         pin = Some(pin),
-        allow = allow,
+        allow = Some(allow),
         ignore = Some(ignore),
         limit = limit,
         fileExtensions = fileExtensions

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -161,7 +161,7 @@ object TestInstances {
   implicit val repoConfigArbitrary: Arbitrary[RepoConfig] =
     Arbitrary(
       for {
-        commits <- Arbitrary.arbitrary[CommitsConfig]
+        commits <- Arbitrary.arbitrary[Option[CommitsConfig]]
         pullRequests <- Arbitrary.arbitrary[PullRequestsConfig]
         scalafmt <- Arbitrary.arbitrary[Option[ScalafmtConfig]]
         updates <- Arbitrary.arbitrary[UpdatesConfig]

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -164,7 +164,7 @@ object TestInstances {
         commits <- Arbitrary.arbitrary[Option[CommitsConfig]]
         pullRequests <- Arbitrary.arbitrary[Option[PullRequestsConfig]]
         scalafmt <- Arbitrary.arbitrary[Option[ScalafmtConfig]]
-        updates <- Arbitrary.arbitrary[UpdatesConfig]
+        updates <- Arbitrary.arbitrary[Option[UpdatesConfig]]
         updatePullRequests <- Arbitrary.arbitrary[Option[PullRequestUpdateStrategy]]
       } yield RepoConfig(
         commits = commits,

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -162,7 +162,7 @@ object TestInstances {
     Arbitrary(
       for {
         commits <- Arbitrary.arbitrary[Option[CommitsConfig]]
-        pullRequests <- Arbitrary.arbitrary[PullRequestsConfig]
+        pullRequests <- Arbitrary.arbitrary[Option[PullRequestsConfig]]
         scalafmt <- Arbitrary.arbitrary[Option[ScalafmtConfig]]
         updates <- Arbitrary.arbitrary[UpdatesConfig]
         updatePullRequests <- Arbitrary.arbitrary[Option[PullRequestUpdateStrategy]]

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -150,7 +150,7 @@ object TestInstances {
         limit <- Arbitrary.arbitrary[Option[NonNegInt]]
         fileExtensions <- Arbitrary.arbitrary[Option[List[String]]]
       } yield UpdatesConfig(
-        pin = pin,
+        pin = Some(pin),
         allow = allow,
         ignore = Some(ignore),
         limit = limit,

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -93,7 +93,7 @@ class HookExecutorTest extends CatsEffectSuite {
 
   test("scalafmt: disabled by config") {
     val repoConfig =
-      RepoConfig.empty.copy(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(false)))
+      RepoConfig.empty.copy(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(false)).some)
     val data = RepoData(repo, dummyRepoCache, repoConfig)
     val update = (scalafmtGroupId % scalafmtArtifactId % "2.7.4" %> "2.7.5").single
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -11,8 +11,8 @@ import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.forge.data.NewPullRequestData._
 import org.scalasteward.core.git.{Branch, Commit}
 import org.scalasteward.core.nurture.UpdateInfoUrl
-import org.scalasteward.core.util.Nel
 import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.util.Nel
 
 class NewPullRequestDataTest extends FunSuite {
   test("bodyFor()") {
@@ -736,7 +736,7 @@ class NewPullRequestDataTest extends FunSuite {
       repoData = RepoData(
         repo = Repo("foo", "bar"),
         cache = dummyRepoCache,
-        config = RepoConfig(assignees = List("foo"), reviewers = List("bar"))
+        config = RepoConfig(assignees = Some(List("foo")), reviewers = List("bar"))
       ),
       fork = Repo("scala-steward", "bar"),
       update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
@@ -844,7 +844,7 @@ class NewPullRequestDataTest extends FunSuite {
       repoData = RepoData(
         repo = Repo("foo", "bar"),
         cache = dummyRepoCache,
-        config = RepoConfig(assignees = List("foo"), reviewers = List("bar"))
+        config = RepoConfig(assignees = Some(List("foo")), reviewers = List("bar"))
       ),
       fork = Repo("scala-steward", "bar"),
       update = update,

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -736,7 +736,7 @@ class NewPullRequestDataTest extends FunSuite {
       repoData = RepoData(
         repo = Repo("foo", "bar"),
         cache = dummyRepoCache,
-        config = RepoConfig(assignees = Some(List("foo")), reviewers = List("bar"))
+        config = RepoConfig(assignees = Some(List("foo")), reviewers = Some(List("bar")))
       ),
       fork = Repo("scala-steward", "bar"),
       update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
@@ -844,7 +844,7 @@ class NewPullRequestDataTest extends FunSuite {
       repoData = RepoData(
         repo = Repo("foo", "bar"),
         cache = dummyRepoCache,
-        config = RepoConfig(assignees = Some(List("foo")), reviewers = List("bar"))
+        config = RepoConfig(assignees = Some(List("foo")), reviewers = Some(List("bar")))
       ),
       fork = Repo("scala-steward", "bar"),
       update = update,

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -23,7 +23,7 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       List(List(DependencyInfo(dependency, Nil)).withMavenCentral)
     )
     val repoData =
-      RepoData(repo, repoCache, RepoConfig(assignees = List("foo"), reviewers = List("bar")))
+      RepoData(repo, repoCache, RepoConfig(assignees = List("foo").some, reviewers = List("bar")))
     val fork = Repo("scala-steward", "scala-steward")
     val update = (dependency %> "3.4.0").single
     val baseBranch = Branch("main")
@@ -135,7 +135,7 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       List(List(DependencyInfo(dependency, Nil)).withMavenCentral)
     )
     val repoData =
-      RepoData(repo, repoCache, RepoConfig(assignees = List("foo"), reviewers = List("bar")))
+      RepoData(repo, repoCache, RepoConfig(assignees = List("foo").some, reviewers = List("bar")))
     val fork = Repo("scala-steward", "scala-steward")
     val update = (dependency %> "3.4.0").single
     val baseBranch = Branch("main")

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -173,7 +173,7 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
         cache = dummyRepoCache,
         config = RepoConfig(
           pullRequests = PullRequestsConfig(
-            customLabels = customLabels
+            customLabels = customLabels.some
           )
         )
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -22,8 +22,11 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val repoCache = dummyRepoCache.copy(dependencyInfos =
       List(List(DependencyInfo(dependency, Nil)).withMavenCentral)
     )
-    val repoData =
-      RepoData(repo, repoCache, RepoConfig(assignees = List("foo").some, reviewers = List("bar")))
+    val repoData = RepoData(
+      repo,
+      repoCache,
+      RepoConfig(assignees = List("foo").some, reviewers = List("bar").some)
+    )
     val fork = Repo("scala-steward", "scala-steward")
     val update = (dependency %> "3.4.0").single
     val baseBranch = Branch("main")
@@ -134,8 +137,11 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val repoCache = dummyRepoCache.copy(dependencyInfos =
       List(List(DependencyInfo(dependency, Nil)).withMavenCentral)
     )
-    val repoData =
-      RepoData(repo, repoCache, RepoConfig(assignees = List("foo").some, reviewers = List("bar")))
+    val repoData = RepoData(
+      repo,
+      repoCache,
+      RepoConfig(assignees = List("foo").some, reviewers = List("bar").some)
+    )
     val fork = Repo("scala-steward", "scala-steward")
     val update = (dependency %> "3.4.0").single
     val baseBranch = Branch("main")

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -171,11 +171,8 @@ class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       RepoData(
         repo = Repo("scala-steward-org", "scala-steward"),
         cache = dummyRepoCache,
-        config = RepoConfig(
-          pullRequests = PullRequestsConfig(
-            customLabels = customLabels.some
-          )
-        )
+        config =
+          RepoConfig(pullRequests = PullRequestsConfig(customLabels = customLabels.some).some)
       )
     val update = (dependency %> "3.4.0").single
     val baseBranch = Branch("main")

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -111,7 +111,7 @@ class RepoConfigAlgTest extends FunSuite {
             )
           )
         ).some
-      ),
+      ).some,
       updates = UpdatesConfig(
         allow = List(UpdatePattern("eu.timepit".g, None, None)),
         pin = List(
@@ -213,7 +213,9 @@ class RepoConfigAlgTest extends FunSuite {
     val content = """pullRequests.frequency = "@asap" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     val expected =
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Asap)))
+      RepoConfig(pullRequests =
+        PullRequestsConfig(frequency = Some(PullRequestFrequency.Asap)).some
+      )
     assertEquals(config, Right(expected))
   }
 
@@ -221,7 +223,7 @@ class RepoConfigAlgTest extends FunSuite {
     val content = """pullRequests.frequency = "@daily" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     val expected = RepoConfig(pullRequests =
-      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(1.day)))
+      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(1.day))).some
     )
     assertEquals(config, Right(expected))
   }
@@ -230,7 +232,7 @@ class RepoConfigAlgTest extends FunSuite {
     val content = """pullRequests.frequency = "@monthly" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     val expected = RepoConfig(pullRequests =
-      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(30.days)))
+      PullRequestsConfig(frequency = Some(PullRequestFrequency.Timespan(30.days))).some
     )
     assertEquals(config, Right(expected))
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -128,7 +128,7 @@ class RepoConfigAlgTest extends FunSuite {
             Some(VersionPattern(Some("0.8."), Some("jre")))
           )
         ),
-        ignore = List(UpdatePattern("org.acme".g, None, Some(VersionPattern(Some("1.0"))))),
+        ignore = List(UpdatePattern("org.acme".g, None, Some(VersionPattern(Some("1.0"))))).some,
         allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)),
         limit = Some(NonNegInt.unsafeFrom(4)),
         fileExtensions = Some(List(".txt"))
@@ -345,8 +345,9 @@ class RepoConfigAlgTest extends FunSuite {
     val config = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
-    val expected =
-      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, Some("b"), None))).some)
+    val expected = RepoConfig(updates =
+      UpdatesConfig(ignore = List(UpdatePattern("a".g, Some("b"), None)).some).some
+    )
     assertEquals(config, expected)
   }
 
@@ -356,7 +357,7 @@ class RepoConfigAlgTest extends FunSuite {
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
     val expected =
-      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, None, None))).some)
+      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, None, None)).some).some)
     assertEquals(config, expected)
   }
 
@@ -372,7 +373,7 @@ class RepoConfigAlgTest extends FunSuite {
         List(
           UpdatePattern(groupId = "a".g, artifactId = "b".some, None),
           UpdatePattern(groupId = "c".g, artifactId = "d".some, None)
-        )
+        ).some
       ).some
     )
     assertEquals(config, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -160,7 +160,7 @@ class RepoConfigAlgTest extends FunSuite {
             frequency = Some(PullRequestFrequency.Timespan(7.days))
           )
         )
-      ),
+      ).some,
       assignees = List("scala.steward").some,
       reviewers = List("scala.steward").some
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -161,7 +161,7 @@ class RepoConfigAlgTest extends FunSuite {
           )
         )
       ),
-      assignees = List("scala.steward"),
+      assignees = List("scala.steward").some,
       reviewers = List("scala.steward")
     )
     assertEquals(obtained, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -113,7 +113,7 @@ class RepoConfigAlgTest extends FunSuite {
         ).some
       ).some,
       updates = UpdatesConfig(
-        allow = List(UpdatePattern("eu.timepit".g, None, None)),
+        allow = List(UpdatePattern("eu.timepit".g, None, None)).some,
         pin = List(
           UpdatePattern("eu.timepit".g, Some("refined.1"), Some(VersionPattern(Some("0.8.")))),
           UpdatePattern("eu.timepit".g, Some("refined.2"), Some(VersionPattern(Some("0.8.")))),
@@ -129,7 +129,7 @@ class RepoConfigAlgTest extends FunSuite {
           )
         ).some,
         ignore = List(UpdatePattern("org.acme".g, None, Some(VersionPattern(Some("1.0"))))).some,
-        allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)),
+        allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)).some,
         limit = Some(NonNegInt.unsafeFrom(4)),
         fileExtensions = Some(List(".txt"))
       ).some,

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -110,7 +110,7 @@ class RepoConfigAlgTest extends FunSuite {
               PullRequestUpdateFilter("*".some).getOrElse(fail("Should not be called"))
             )
           )
-        )
+        ).some
       ),
       updates = UpdatesConfig(
         allow = List(UpdatePattern("eu.timepit".g, None, None)),

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -135,7 +135,7 @@ class RepoConfigAlgTest extends FunSuite {
       ),
       commits = CommitsConfig(
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
-      ),
+      ).some,
       buildRoots = Some(List(BuildRootConfig.repoRoot, BuildRootConfig("subfolder/subfolder"))),
       dependencyOverrides = List(
         GroupRepoConfig(

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -132,7 +132,7 @@ class RepoConfigAlgTest extends FunSuite {
         allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)),
         limit = Some(NonNegInt.unsafeFrom(4)),
         fileExtensions = Some(List(".txt"))
-      ),
+      ).some,
       commits = CommitsConfig(
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
       ).some,
@@ -346,7 +346,7 @@ class RepoConfigAlgTest extends FunSuite {
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
     val expected =
-      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, Some("b"), None))))
+      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, Some("b"), None))).some)
     assertEquals(config, expected)
   }
 
@@ -356,7 +356,7 @@ class RepoConfigAlgTest extends FunSuite {
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
     val expected =
-      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, None, None))))
+      RepoConfig(updates = UpdatesConfig(ignore = List(UpdatePattern("a".g, None, None))).some)
     assertEquals(config, expected)
   }
 
@@ -373,7 +373,7 @@ class RepoConfigAlgTest extends FunSuite {
           UpdatePattern(groupId = "a".g, artifactId = "b".some, None),
           UpdatePattern(groupId = "c".g, artifactId = "d".some, None)
         )
-      )
+      ).some
     )
     assertEquals(config, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -238,7 +238,7 @@ class RepoConfigAlgTest extends FunSuite {
   test("config with 'scalafmt.runAfterUpgrading = true'") {
     val content = "scalafmt.runAfterUpgrading = true"
     val config = RepoConfigAlg.parseRepoConfig(content)
-    val expected = RepoConfig(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(true)))
+    val expected = RepoConfig(scalafmt = ScalafmtConfig(runAfterUpgrading = Some(true)).some)
     assertEquals(config, Right(expected))
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -162,7 +162,7 @@ class RepoConfigAlgTest extends FunSuite {
         )
       ),
       assignees = List("scala.steward").some,
-      reviewers = List("scala.steward")
+      reviewers = List("scala.steward").some
     )
     assertEquals(obtained, expected)
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -127,7 +127,7 @@ class RepoConfigAlgTest extends FunSuite {
             Some("refined.4"),
             Some(VersionPattern(Some("0.8."), Some("jre")))
           )
-        ),
+        ).some,
         ignore = List(UpdatePattern("org.acme".g, None, Some(VersionPattern(Some("1.0"))))).some,
         allowPreReleases = List(UpdatePattern("eu.timepit".g, None, None)),
         limit = Some(NonNegInt.unsafeFrom(4)),

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
@@ -38,7 +38,7 @@ class RepoConfigLoaderTest extends FunSuite {
       .getOrElse(None)
     assert(clue(repoConfig).isDefined)
     assertEquals(
-      repoConfig.get.updatesOrDefault.pin.head.version,
+      repoConfig.get.updatesOrDefault.pinOrDefault.head.version,
       Some(VersionPattern(Some("3.4.")))
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
@@ -37,6 +37,9 @@ class RepoConfigLoaderTest extends FunSuite {
       .unsafeRunSync()
       .getOrElse(None)
     assert(clue(repoConfig).isDefined)
-    assertEquals(repoConfig.get.updates.pin.head.version, Some(VersionPattern(Some("3.4."))))
+    assertEquals(
+      repoConfig.get.updatesOrDefault.pin.head.version,
+      Some(VersionPattern(Some("3.4.")))
+    )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -88,10 +88,13 @@ class UpdatesConfigTest extends DisciplineSuite {
   }
 
   test("mergeIgnore: basic checks") {
-    assertEquals(UpdatesConfig.mergeIgnore(Nil, Nil), Nil)
-    assertEquals(UpdatesConfig.mergeIgnore(List(a00), Nil), List(a00))
-    assertEquals(UpdatesConfig.mergeIgnore(Nil, List(b00)), List(b00))
-    assertEquals(UpdatesConfig.mergeIgnore(List(aa1, b00), List(aa1, aa2)), List(aa1, b00, aa2))
+    assertEquals(UpdatesConfig.mergeIgnore(Some(Nil), Some(Nil)), Some(Nil))
+    assertEquals(UpdatesConfig.mergeIgnore(Some(List(a00)), Some(Nil)), Some(List(a00)))
+    assertEquals(UpdatesConfig.mergeIgnore(Some(Nil), Some(List(b00))), Some(List(b00)))
+    assertEquals(
+      UpdatesConfig.mergeIgnore(Some(List(aa1, b00)), Some(List(aa1, aa2))),
+      Some(List(aa1, b00, aa2))
+    )
   }
 
   test("mergeFileExtensions: basic checks") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -59,33 +59,48 @@ class UpdatesConfigTest extends DisciplineSuite {
   }
 
   test("mergeAllow: basic checks") {
-    assertEquals(UpdatesConfig.mergeAllow(Nil, Nil), Nil)
-    assertEquals(UpdatesConfig.mergeAllow(List(a00), Nil), List(a00))
-    assertEquals(UpdatesConfig.mergeAllow(Nil, List(a00)), List(a00))
+    assertEquals(UpdatesConfig.mergeAllow(Nil.some, Nil.some), Nil.some)
+    assertEquals(UpdatesConfig.mergeAllow(List(a00).some, Nil.some), List(a00).some)
+    assertEquals(UpdatesConfig.mergeAllow(Nil.some, List(a00).some), List(a00).some)
 
-    assertEquals(UpdatesConfig.mergeAllow(List(a00), List(a00)), List(a00))
+    assertEquals(UpdatesConfig.mergeAllow(List(a00).some, List(a00).some), List(a00).some)
     assertEquals(
-      UpdatesConfig.mergeAllow(List(a00), List(b00)),
-      UpdatesConfig.nonExistingUpdatePattern
+      UpdatesConfig.mergeAllow(List(a00).some, List(b00).some),
+      UpdatesConfig.nonExistingUpdatePattern.some
     )
 
-    assertEquals(UpdatesConfig.mergeAllow(List(a00), List(aa1, ab0, ac3)), List(aa1, ab0, ac3))
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1, ab0, ac3), List(a00)), List(aa1, ab0, ac3))
-
-    assertEquals(UpdatesConfig.mergeAllow(List(aa0), List(aa1, aa2)), List(aa1, aa2))
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1, aa2), List(aa0)), List(aa1, aa2))
-
-    assertEquals(UpdatesConfig.mergeAllow(List(aa0), List(aa0, ab0)), List(aa0))
-    assertEquals(UpdatesConfig.mergeAllow(List(aa0, ab0), List(aa0, ab0)), List(aa0, ab0))
-
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1), List(aa1)), List(aa1))
     assertEquals(
-      UpdatesConfig.mergeAllow(List(aa1), List(aa2)),
-      UpdatesConfig.nonExistingUpdatePattern
+      UpdatesConfig.mergeAllow(List(a00).some, List(aa1, ab0, ac3).some),
+      List(aa1, ab0, ac3).some
     )
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1, ab0, ac0), List(aa2, ac0)), List(ac0))
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1, aa2), List(aa1, aa2)), List(aa1, aa2))
-    assertEquals(UpdatesConfig.mergeAllow(List(aa1, aa2), List(aa1, ac3)), List(aa1))
+    assertEquals(
+      UpdatesConfig.mergeAllow(List(aa1, ab0, ac3).some, List(a00).some),
+      List(aa1, ab0, ac3).some
+    )
+
+    assertEquals(UpdatesConfig.mergeAllow(List(aa0).some, List(aa1, aa2).some), List(aa1, aa2).some)
+    assertEquals(UpdatesConfig.mergeAllow(List(aa1, aa2).some, List(aa0).some), List(aa1, aa2).some)
+
+    assertEquals(UpdatesConfig.mergeAllow(List(aa0).some, List(aa0, ab0).some), List(aa0).some)
+    assertEquals(
+      UpdatesConfig.mergeAllow(List(aa0, ab0).some, List(aa0, ab0).some),
+      List(aa0, ab0).some
+    )
+
+    assertEquals(UpdatesConfig.mergeAllow(List(aa1).some, List(aa1).some), List(aa1).some)
+    assertEquals(
+      UpdatesConfig.mergeAllow(List(aa1).some, List(aa2).some),
+      UpdatesConfig.nonExistingUpdatePattern.some
+    )
+    assertEquals(
+      UpdatesConfig.mergeAllow(List(aa1, ab0, ac0).some, List(aa2, ac0).some),
+      List(ac0).some
+    )
+    assertEquals(
+      UpdatesConfig.mergeAllow(List(aa1, aa2).some, List(aa1, aa2).some),
+      List(aa1, aa2).some
+    )
+    assertEquals(UpdatesConfig.mergeAllow(List(aa1, aa2).some, List(aa1, ac3).some), List(aa1).some)
   }
 
   test("mergeIgnore: basic checks") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
+import cats.syntax.all._
 import munit.DisciplineSuite
 import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.data.GroupId
@@ -23,15 +24,15 @@ class UpdatesConfigTest extends DisciplineSuite {
   private val b00 = UpdatePattern(groupIdB, None, None)
 
   test("mergePin: basic checks") {
-    assertEquals(UpdatesConfig.mergePin(Nil, Nil), Nil)
-    assertEquals(UpdatesConfig.mergePin(List(a00), Nil), List(a00))
-    assertEquals(UpdatesConfig.mergePin(Nil, List(b00)), List(b00))
-    assertEquals(UpdatesConfig.mergePin(List(a00), List(b00)), List(a00, b00))
+    assertEquals(UpdatesConfig.mergePin(Nil.some, Nil.some), Nil.some)
+    assertEquals(UpdatesConfig.mergePin(List(a00).some, Nil.some), List(a00).some)
+    assertEquals(UpdatesConfig.mergePin(Nil.some, List(b00).some), List(b00).some)
+    assertEquals(UpdatesConfig.mergePin(List(a00).some, List(b00).some), List(a00, b00).some)
 
-    assertEquals(UpdatesConfig.mergePin(List(aa1), List(aa1, ac3)), List(aa1, ac3))
+    assertEquals(UpdatesConfig.mergePin(List(aa1).some, List(aa1, ac3).some), List(aa1, ac3).some)
 
-    assertEquals(UpdatesConfig.mergePin(List(aa1), List(aa2)), List(aa2))
-    assertEquals(UpdatesConfig.mergePin(List(aa2), List(aa1)), List(aa1))
+    assertEquals(UpdatesConfig.mergePin(List(aa1).some, List(aa2).some), List(aa2).some)
+    assertEquals(UpdatesConfig.mergePin(List(aa2).some, List(aa1).some), List(aa1).some)
   }
 
   test("mergePin: scala 3 LTS") {
@@ -45,7 +46,7 @@ class UpdatesConfigTest extends DisciplineSuite {
         default: List[UpdatePattern],
         local: List[UpdatePattern]
     ): List[UpdatePattern] =
-      UpdatesConfig.mergePin(default, local)
+      UpdatesConfig.mergePin(default.some, local.some).getOrElse(Nil)
 
     assertEquals(mergeDefaultWithLocal(default = List(s33), local = Nil), List(s33))
     assertEquals(mergeDefaultWithLocal(default = List(s33), local = List(s34)), List(s34))

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -53,9 +53,9 @@ class FilterAlgTest extends FunSuite {
   test("localFilter: allowed update to pre-releases of a different series") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("2.0.1-M3")).single
     val allowedPreReleases = UpdatePattern("com.jsuereth".g, Some("sbt-pgp"), None) ::
-      config.updatesOrDefault.allowPreReleases
+      config.updatesOrDefault.allowPreReleasesOrDefault
     val configWithAllowed = config.copy(updates =
-      config.updatesOrDefault.copy(allowPreReleases = allowedPreReleases).some
+      config.updatesOrDefault.copy(allowPreReleases = allowedPreReleases.some).some
     )
 
     val expected = Right(update.copy(newerVersions = Nel.of("2.0.1-M3".v)))
@@ -149,7 +149,7 @@ class FilterAlgTest extends FunSuite {
           UpdatePattern(GroupId("org.my1"), None, Some(VersionPattern(Some("0.8")))),
           UpdatePattern(GroupId("org.my2"), None, None),
           UpdatePattern(GroupId("org.my3"), Some("artifact"), None)
-        )
+        ).some
       ).some
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -65,7 +65,9 @@ class FilterAlgTest extends FunSuite {
   test("ignore update via config updates.ignore") {
     val update = ("eu.timepit".g % "refined".a % "0.8.0" %> "0.8.1").single
     val config = RepoConfig(updates =
-      UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None))).some
+      UpdatesConfig(ignore =
+        List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None)).some
+      ).some
     )
 
     val initialState = MockState.empty
@@ -90,7 +92,7 @@ class FilterAlgTest extends FunSuite {
             Some("scala-compiler"),
             Some(VersionPattern(exact = Some("2.13.8")))
           )
-        )
+        ).some
       ).some
     )
     val expected = Right(update.copy(newerVersions = Nel.of("2.13.7".v)))
@@ -201,7 +203,7 @@ class FilterAlgTest extends FunSuite {
             Some(update.artifactId.name),
             Some(VersionPattern(suffix = Some("jre11")))
           )
-        )
+        ).some
       ).some
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -112,7 +112,7 @@ class FilterAlgTest extends FunSuite {
             Some("refined"),
             Some(VersionPattern(Some("0.8")))
           )
-        )
+        ).some
       ).some
     )
 
@@ -183,7 +183,7 @@ class FilterAlgTest extends FunSuite {
             Some(update.artifactId.name),
             Some(VersionPattern(suffix = Some("jre8")))
           )
-        )
+        ).some
       ).some
     )
 
@@ -223,7 +223,7 @@ class FilterAlgTest extends FunSuite {
             Some(update.artifactId.name),
             Some(VersionPattern(Some("7.2."), Some("jre8")))
           )
-        )
+        ).some
       ).some
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -52,10 +52,11 @@ class FilterAlgTest extends FunSuite {
 
   test("localFilter: allowed update to pre-releases of a different series") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("2.0.1-M3")).single
-    val allowedPreReleases =
-      UpdatePattern("com.jsuereth".g, Some("sbt-pgp"), None) :: config.updates.allowPreReleases
-    val configWithAllowed =
-      config.copy(updates = config.updates.copy(allowPreReleases = allowedPreReleases))
+    val allowedPreReleases = UpdatePattern("com.jsuereth".g, Some("sbt-pgp"), None) ::
+      config.updatesOrDefault.allowPreReleases
+    val configWithAllowed = config.copy(updates =
+      config.updatesOrDefault.copy(allowPreReleases = allowedPreReleases).some
+    )
 
     val expected = Right(update.copy(newerVersions = Nel.of("2.0.1-M3".v)))
     assertEquals(localFilter(update, configWithAllowed), expected)
@@ -64,7 +65,7 @@ class FilterAlgTest extends FunSuite {
   test("ignore update via config updates.ignore") {
     val update = ("eu.timepit".g % "refined".a % "0.8.0" %> "0.8.1").single
     val config = RepoConfig(updates =
-      UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None)))
+      UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None))).some
     )
 
     val initialState = MockState.empty
@@ -90,7 +91,7 @@ class FilterAlgTest extends FunSuite {
             Some(VersionPattern(exact = Some("2.13.8")))
           )
         )
-      )
+      ).some
     )
     val expected = Right(update.copy(newerVersions = Nel.of("2.13.7".v)))
     assertEquals(localFilter(update, config), expected)
@@ -110,7 +111,7 @@ class FilterAlgTest extends FunSuite {
             Some(VersionPattern(Some("0.8")))
           )
         )
-      )
+      ).some
     )
 
     val filtered1 = filterAlg
@@ -147,7 +148,7 @@ class FilterAlgTest extends FunSuite {
           UpdatePattern(GroupId("org.my2"), None, None),
           UpdatePattern(GroupId("org.my3"), Some("artifact"), None)
         )
-      )
+      ).some
     )
 
     included.foreach { update =>
@@ -181,7 +182,7 @@ class FilterAlgTest extends FunSuite {
             Some(VersionPattern(suffix = Some("jre8")))
           )
         )
-      )
+      ).some
     )
 
     val filtered = localFilter(update, config)
@@ -201,7 +202,7 @@ class FilterAlgTest extends FunSuite {
             Some(VersionPattern(suffix = Some("jre11")))
           )
         )
-      )
+      ).some
     )
 
     val filtered = localFilter(update, config)
@@ -221,7 +222,7 @@ class FilterAlgTest extends FunSuite {
             Some(VersionPattern(Some("7.2."), Some("jre8")))
           )
         )
-      )
+      ).some
     )
 
     assertEquals(localFilter(update, config), Left(VersionPinnedByConfig(update)))


### PR DESCRIPTION
This changes `RepoConfig` and the other `*Config` classes such that all values are optional and there are no default parameter values except `None`s. This allows us to get rid of circe-generic-extras' `Configuration.default.withDefaults` and `deriveConfiguredCodec` since missing `Option` values do not cause an error during decoding. So `{}` can still be decoded into a `RepoConfig`, and there are a lot of tests in `RepoConfigAlgTest` that ensure that sparse configurations with a lot of missing values can still be decoded. 

Another benefit of this change is that `RepoConfig.show` can now use `deepDropNullValues` so that logged `RepoConfig`s only include stuff which was actually set by a user. For example, before this change, logging a `RepoConfig` was similar to this:
```
INFO  Parsed repo config {
   "commits" : {
     "message" : null
   },
   "pullRequests" : {
     "frequency" : null,
     "grouping" : [
     ],
     "includeMatchedLabels" : null,
     "customLabels" : [
     ]
   },
   "scalafmt" : {
     "runAfterUpgrading" : null
   },
   "updates" : {
     "pin" : [
     ],
     "allow" : [
     ],
     "allowPreReleases" : [
     ],
     "ignore" : [
     ],
     "limit" : null,
     "fileExtensions" : null
   },
   "postUpdateHooks" : null,
   "updatePullRequests" : "always",
   "buildRoots" : null,
   "assignees" : [
   ],
   "reviewers" : [
   ],
   "dependencyOverrides" : [
   ]
 }
```
The same `RepoConfig` is now logged as:
```
INFO  Parsed repo config {
   "updatePullRequests" : "always"
 }
```

Before merging this PR, I'll squash the commits and provide a better commit message, but for potential reviewers, it should be easier to look at each commit individually.

This continues the work started in #3514 of getting rid of circe-generic-extras so that Scala Steward can be built with Scala 3.