### PR TITLE
Add parentheses around lambda parameters

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -294,11 +294,11 @@ class VersionTest extends DisciplineSuite {
   }
 
   test("Component: round-trip") {
-    forAll { str: String => assertEquals(Component.render(Component.parse(str)), str) }
+    forAll((str: String) => assertEquals(Component.render(Component.parse(str)), str))
   }
 
   test("Component: round-trip using Version") {
-    forAll { v: Version => assertEquals(Component.render(Component.parse(v.value)), v.value) }
+    forAll((v: Version) => assertEquals(Component.render(Component.parse(v.value)), v.value))
   }
 
   test("Component: round-trip example") {

--- a/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.update.show
 class gitTest extends ScalaCheckSuite {
   test("commitMsgFor should work with static message") {
     val commitsConfig = CommitsConfig(Some("Static message"))
-    forAll { update: Update.Single =>
+    forAll { (update: Update.Single) =>
       assertEquals(commitMsgFor(update, commitsConfig, None).title, "Static message")
     }
   }
@@ -18,7 +18,7 @@ class gitTest extends ScalaCheckSuite {
   test("commitMsgFor adds branch if provided") {
     val commitsConfig = CommitsConfig(Some(s"$${default}"))
     val branch = Branch("some-branch")
-    forAll { update: Update.Single =>
+    forAll { (update: Update.Single) =>
       val expected = s"Update ${show.oneLiner(update)} to ${update.nextVersion} in ${branch.name}"
       assertEquals(commitMsgFor(update, commitsConfig, Some(branch)).title, expected)
     }
@@ -26,7 +26,7 @@ class gitTest extends ScalaCheckSuite {
 
   test("commitMsgFor should work with default message") {
     val commitsConfig = CommitsConfig(Some(s"$${default}"))
-    forAll { update: Update.Single =>
+    forAll { (update: Update.Single) =>
       val expected = s"Update ${show.oneLiner(update)} to ${update.nextVersion}"
       assertEquals(commitMsgFor(update, commitsConfig, None).title, expected)
     }
@@ -35,7 +35,7 @@ class gitTest extends ScalaCheckSuite {
   test("commitMsgFor should work with templated message") {
     val commitsConfig =
       CommitsConfig(Some(s"Update $${artifactName} from $${currentVersion} to $${nextVersion}"))
-    forAll { update: Update.Single =>
+    forAll { (update: Update.Single) =>
       val expected =
         s"Update ${show.oneLiner(update)} from ${update.currentVersion} to ${update.nextVersion}"
       assertEquals(commitMsgFor(update, commitsConfig, None).title, expected)
@@ -50,7 +50,7 @@ class gitTest extends ScalaCheckSuite {
         )
       )
     val branch = Branch("some-branch")
-    forAll { update: Update.Single =>
+    forAll { (update: Update.Single) =>
       val expected =
         s"Update ${show.oneLiner(update)} from ${update.currentVersion} to ${update.nextVersion} in ${branch.name}"
       assertEquals(commitMsgFor(update, commitsConfig, Some(branch)).title, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
@@ -48,7 +48,7 @@ class stringTest extends ScalaCheckSuite {
   }
 
   property("splitBetweenLowerAndUpperChars(s).mkString == s") {
-    forAll(Gen.asciiStr) { s: String =>
+    forAll(Gen.asciiStr) { (s: String) =>
       assertEquals(string.splitBetweenLowerAndUpperChars(s).mkString, s)
     }
   }


### PR DESCRIPTION
This is in preparation for compiling with Scala 3.

See https://docs.scala-lang.org/scala3/guides/migration/incompat-syntactic.html#parentheses-around-lambda-parameter