### PR TITLE
Import `MockEffOps` to fix compile errors with Scala 3

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/application/ReposFilesLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/ReposFilesLoaderTest.scala
@@ -4,7 +4,7 @@ import munit.CatsEffectSuite
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockContext.context.reposFilesLoader
-import org.scalasteward.core.mock.{MockConfig, MockState}
+import org.scalasteward.core.mock.{MockConfig, MockEffOps, MockState}
 import org.scalasteward.core.util.Nel
 
 class ReposFilesLoaderTest extends CatsEffectSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.application
 import cats.effect.ExitCode
 import munit.CatsEffectSuite
 import org.scalasteward.core.mock.MockContext.context.stewardAlg
-import org.scalasteward.core.mock.{GitHubAuth, MockConfig, MockState}
+import org.scalasteward.core.mock.{GitHubAuth, MockConfig, MockEffOps, MockState}
 
 class StewardAlgTest extends CatsEffectSuite {
   test("runF") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -3,14 +3,14 @@ package org.scalasteward.core.buildtool
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.scalacli.ScalaCliAlg
 import org.scalasteward.core.data._
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{BuildRootConfig, RepoConfig}
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.scalafmt.scalafmtConfName
-import org.scalasteward.core.buildtool.scalacli.ScalaCliAlg
 
 class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 
 class MavenAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
 import org.scalasteward.core.data.{Repo, Version}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 
 class MillAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -7,7 +7,7 @@ import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Repo, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -1,16 +1,15 @@
 package org.scalasteward.core.buildtool.scalacli
 
+import cats.syntax.parallel._
 import munit.CatsEffectSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Repo, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.util.Nel
-
-import cats.syntax.parallel._
 
 class ScalaCliAlgTest extends CatsEffectSuite {
   test("containsBuild: directive in non-source file") {

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.Resolver
 import org.scalasteward.core.mock.MockContext.context.coursierAlg
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 
 class CoursierAlgTest extends CatsEffectSuite {
   private val resolvers = List(Resolver.mavenCentral)

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -8,7 +8,7 @@ import org.scalasteward.core.buildtool.sbt.{sbtArtifactId, sbtGroupId}
 import org.scalasteward.core.data._
 import org.scalasteward.core.edit.scalafix.ScalafixCli.scalafixBinary
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.TestInstances.dummyRepoCache
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{Repo, RepoData, Update}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtConfName
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.git.gitBlameIgnoreRevsName
 import org.scalasteward.core.io.process.ProcessFailedException
 import org.scalasteward.core.io.{process, FileAlgTest}
 import org.scalasteward.core.mock.MockContext.context.{hookExecutor, workspaceAlg}
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repoconfig.{PostUpdateHookConfig, RepoConfig, ScalafmtConfig}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
@@ -11,6 +11,7 @@ import org.scalasteward.core.git.Author
 import org.scalasteward.core.mock.MockConfig.mockRoot
 import org.scalasteward.core.mock.MockContext.context.scalafixMigrationsLoader
 import org.scalasteward.core.mock.MockContext.mockState
+import org.scalasteward.core.mock.MockEffOps
 import org.scalasteward.core.util.Nel
 
 class ScalafixMigrationsLoaderTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
@@ -7,9 +7,9 @@ import org.scalasteward.core.forge.data.{RepoOut, UserOut}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.{gitAlg, logger, workspaceAlg}
-import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
-import org.scalasteward.core.mock.{MockConfig, MockEff, MockState}
+import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockConfig, MockEff, MockEffOps, MockState}
 
 class ForgeRepoAlgTest extends CatsEffectSuite {
   private val repo = Repo("fthomas", "datapackage")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
@@ -13,7 +13,7 @@ import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class AzureReposApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val repo = Repo("scala-steward-org", "scala-steward")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
@@ -14,8 +14,8 @@ import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git._
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
-import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class BitbucketApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val httpApp = HttpApp[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -12,8 +12,8 @@ import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
-import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class BitbucketServerApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   object FilterTextMatcher extends QueryParamDecoderMatcher[String]("filterText")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
@@ -2,10 +2,10 @@ package org.scalasteward.core.forge.gitea
 
 import io.circe.literal._
 import munit.CatsEffectSuite
+import org.http4s.HttpApp
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.implicits._
-import org.http4s.HttpApp
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GiteaCfg
 import org.scalasteward.core.data.Repo
@@ -14,8 +14,8 @@ import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
-import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class GiteaApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val repo = Repo("foo", "baz")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -2,13 +2,13 @@ package org.scalasteward.core.forge.github
 
 import cats.effect.IO
 import cats.syntax.all._
-import io.circe.literal._
 import io.circe.Json
+import io.circe.literal._
 import munit.CatsEffectSuite
+import org.http4s.HttpApp
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.implicits._
-import org.http4s.HttpApp
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GitHubCfg
 import org.scalasteward.core.data.Repo
@@ -18,7 +18,7 @@ import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class GitHubApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val httpApp = HttpApp[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
@@ -3,15 +3,14 @@ package org.scalasteward.core.forge.github
 import better.files.File
 import io.circe.literal.JsonStringContext
 import munit.CatsEffectSuite
-import org.http4s.{AuthScheme, Credentials, HttpApp, Request}
-import org.http4s.dsl.Http4sDsl
 import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Authorization
 import org.http4s.implicits.http4sLiteralsSyntax
+import org.http4s.{AuthScheme, Credentials, HttpApp, Request}
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.mock.{MockEff, MockState}
-import org.scalasteward.core.mock.MockContext.context.httpJsonClient
-import org.scalasteward.core.mock.MockContext.context.logger
+import org.scalasteward.core.mock.MockContext.context.{httpJsonClient, logger}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.typelevel.ci.CIStringSyntax
 import scala.concurrent.duration._
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
@@ -21,7 +21,7 @@ import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
 
 class GitLabApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -9,8 +9,8 @@ import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.mock.MockConfig.mockRoot
 import org.scalasteward.core.mock.MockContext.context.fileAlg
-import org.scalasteward.core.mock.{MockEff, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class FileAlgTest extends CatsEffectSuite {
   test("createTemporarily") {

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -8,7 +8,7 @@ import org.scalasteward.core.TestInstances._
 import org.scalasteward.core.application.Config.{ProcessCfg, SandboxCfg}
 import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
 import org.scalasteward.core.mock.MockConfig.{config, mockRoot}
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.util.Nel
 import scala.concurrent.duration.Duration

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -11,7 +11,7 @@ import org.scalasteward.core.edit.EditAttempt.UpdateEdit
 import org.scalasteward.core.forge.data.NewPullRequestData
 import org.scalasteward.core.git.{Branch, Commit}
 import org.scalasteward.core.mock.MockContext.context
-import org.scalasteward.core.mock.{GitHubAuth, MockConfig, MockEff, MockState}
+import org.scalasteward.core.mock.{GitHubAuth, MockConfig, MockEff, MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{PullRequestsConfig, RepoConfig}
 
 class NurtureAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -2,6 +2,7 @@ package org.scalasteward.core.nurture
 
 import cats.Id
 import cats.effect.unsafe.implicits.global
+import java.util.concurrent.atomic.AtomicInteger
 import munit.FunSuite
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
@@ -13,11 +14,9 @@ import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.pullRequestRepository
 import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{RetractedArtifact, UpdatePattern, VersionPattern}
 import org.scalasteward.core.util.Nel
-
-import java.util.concurrent.atomic.AtomicInteger
 
 class PullRequestRepositoryTest extends FunSuite {
   private def checkTrace(state: MockState, trace: Vector[TraceEntry]): Unit =

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -12,7 +12,7 @@ import org.scalasteward.core.forge.ForgeType._
 import org.scalasteward.core.forge.github.Repository
 import org.scalasteward.core.forge.{ForgeRepo, ForgeType}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockState}
+import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockEffOps, MockState}
 import org.scalasteward.core.nurture.UpdateInfoUrl._
 import org.scalasteward.core.nurture.UpdateInfoUrlFinder._
 

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class JsonKeyValueStoreTest extends FunSuite {
   test("put, get") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
@@ -4,7 +4,7 @@ import cats.syntax.all._
 import munit.CatsEffectSuite
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context.refreshErrorAlg
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class RefreshErrorAlgTest extends CatsEffectSuite {
   test("skipIfFailedRecently: not failed") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
@@ -13,7 +13,7 @@ import org.scalasteward.core.forge.data.{RepoOut, UserOut}
 import org.scalasteward.core.forge.github.Repository
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockContext.context.{repoCacheAlg, repoConfigAlg, workspaceAlg}
-import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockState}
+import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockEffOps, MockState}
 import org.scalasteward.core.util.intellijThisImportIsUsed
 
 class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -8,7 +8,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{GroupId, Repo, SemVer, Update}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.util.Nel
 import scala.concurrent.duration._

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigLoaderTest.scala
@@ -7,6 +7,7 @@ import org.scalasteward.core.application.Config.RepoConfigCfg
 import org.scalasteward.core.mock.MockConfig.mockRoot
 import org.scalasteward.core.mock.MockContext.context.{fileAlg, logger}
 import org.scalasteward.core.mock.MockContext.mockState
+import org.scalasteward.core.mock.MockEffOps
 
 class RepoConfigLoaderTest extends FunSuite {
   test("config file merging order") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlgTest.scala
@@ -4,7 +4,7 @@ import cats.effect.ExitCode
 import munit.CatsEffectSuite
 import org.scalasteward.core.mock.MockConfig.mockRoot
 import org.scalasteward.core.mock.MockContext.validateRepoConfigContext.validateRepoConfigAlg
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 
 class ValidateRepoConfigAlgTest extends CatsEffectSuite {
   test("accepts valid config") {

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.{Repo, Version}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 
 class ScalafmtAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.mock.MockContext.context.filterAlg
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.repoconfig._
 import org.scalasteward.core.update.FilterAlg._

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.data.Resolver.MavenRepository
 import org.scalasteward.core.data.{DependencyInfo, Repo, RepoData, Scope}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.pruningAlg
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.RepoConfig

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.{GroupId, Resolver, Scope}
 import org.scalasteward.core.mock.MockContext.context.updateAlg
-import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.UpdateAlg
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoaderTest.scala
@@ -8,6 +8,7 @@ import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.mock.MockConfig.mockRoot
 import org.scalasteward.core.mock.MockContext.context.artifactMigrationsLoader
 import org.scalasteward.core.mock.MockContext.mockState
+import org.scalasteward.core.mock.MockEffOps
 
 class ArtifactMigrationsLoaderTest extends FunSuite {
   val migrationsUri: Uri = Uri.unsafeFromString(s"$mockRoot/extra-migrations.conf")

--- a/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
@@ -7,7 +7,7 @@ import org.http4s.headers.{Link, LinkValue}
 import org.http4s.syntax.all._
 import org.http4s.{HttpApp, HttpVersion, Status}
 import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class HttpJsonClientTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("getAll") {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -5,7 +5,7 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.mock.MockContext.context._
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
-import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.util.logger.{showUpdates, LoggerOps}
 
 class loggerTest extends CatsEffectSuite {


### PR DESCRIPTION
This is in preparation for compiling with Scala 3 and fixes errors like this:
```
 -- [E008] Not Found Error: modules/core/src/test/scala/org/scalasteward/core/BuiltinConfigFilesTest.scala:38:9
 36 |      val migrations = artifactMigrationsLoader
 37 |        .loadAll(ArtifactCfg(List(), disableDefaults = false))
 38 |        .runA(initialState)
    |                       ^
    |value runA is not a member of org.scalasteward.core.mock.MockEff[
    |  List[org.scalasteward.core.update.artifact.ArtifactChange]], but could be made available as an extension method.
    |
    |The following import might fix the problem:
    |
    |  import org.scalasteward.core.mock.MockEffOps
```

I think the change in the Scala 3 compiler that makes this import necessary, is ["3. Package prefixes no longer contribute to the implicit search scope of a type"](https://docs.scala-lang.org/scala3/reference/changed-features/implicit-resolution.html).