### PR TITLE
Annotate pattern bindings with refutable patterns

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -40,7 +40,7 @@ class CliTest extends FunSuite {
         List("--refresh-backoff-period", "1 day"),
         List("--bitbucket-use-default-reviewers")
       ).flatten
-    )
+    ): @unchecked
 
     assertEquals(obtained.workspace, File("a"))
     assertEquals(obtained.reposFiles, Nel.one(uri"b"))
@@ -85,7 +85,7 @@ class CliTest extends FunSuite {
   test("parseArgs: minimal example") {
     val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       minimumRequiredParams.flatten
-    )
+    ): @unchecked
 
     assert(!obtained.processCfg.sandboxCfg.enableSandbox)
     assertEquals(obtained.workspace, File("a"))
@@ -105,7 +105,7 @@ class CliTest extends FunSuite {
         List("--git-ask-pass", "f"),
         List("--enable-sandbox")
       ).flatten
-    )
+    ): @unchecked
 
     assert(obtained.processCfg.sandboxCfg.enableSandbox)
   }
@@ -121,7 +121,7 @@ class CliTest extends FunSuite {
         List("--enable-sandbox"),
         List("--disable-sandbox")
       ).flatten
-    )
+    ): @unchecked
 
     assert(clue(obtained).startsWith("Unexpected option"))
   }
@@ -136,23 +136,23 @@ class CliTest extends FunSuite {
         List("--git-ask-pass", "f"),
         List("--disable-sandbox")
       ).flatten
-    )
+    ): @unchecked
 
     assert(!obtained.processCfg.sandboxCfg.enableSandbox)
   }
 
   test("parseArgs: fail if required option not provided") {
-    val Error(obtained) = Cli.parseArgs(Nil)
+    val Error(obtained) = Cli.parseArgs(Nil): @unchecked
     assert(clue(obtained).startsWith("Missing expected"))
   }
 
   test("parseArgs: unrecognized argument") {
-    val Error(obtained) = Cli.parseArgs(List("--foo"))
+    val Error(obtained) = Cli.parseArgs(List("--foo")): @unchecked
     assert(clue(obtained).startsWith("Unexpected option"))
   }
 
   test("parseArgs: --help") {
-    val Help(obtained) = Cli.parseArgs(List("--help"))
+    val Help(obtained) = Cli.parseArgs(List("--help")): @unchecked
     assert(clue(obtained).startsWith("Usage"))
   }
 
@@ -161,7 +161,7 @@ class CliTest extends FunSuite {
       List("--gitlab-merge-when-pipeline-succeeds"),
       List("--gitlab-required-reviewers", "5")
     )
-    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten): @unchecked
 
     assert(obtained.gitLabCfg.mergeWhenPipelineSucceeds)
     assertEquals(obtained.gitLabCfg.requiredReviewers, Some(5))
@@ -172,7 +172,7 @@ class CliTest extends FunSuite {
       List("--gitlab-merge-when-pipeline-succeeds"),
       List("--gitlab-required-reviewers", "-3")
     )
-    val Error(errorMsg) = Cli.parseArgs(params.flatten)
+    val Error(errorMsg) = Cli.parseArgs(params.flatten): @unchecked
 
     assert(clue(errorMsg).startsWith("Required reviewers must be non-negative"))
   }
@@ -182,7 +182,7 @@ class CliTest extends FunSuite {
       List(
         List("validate-repo-config", "file.conf")
       ).flatten
-    )
+    ): @unchecked
 
     assertEquals(file, File("file.conf"))
   }
@@ -192,7 +192,7 @@ class CliTest extends FunSuite {
       List("--forge-type", "azure-repos"),
       List("--do-not-fork")
     )
-    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten): @unchecked
     assert(obtained.forgeCfg.doNotFork)
   }
 
@@ -200,7 +200,7 @@ class CliTest extends FunSuite {
     val params = minimumRequiredParams ++ List(
       List("--forge-type", "azure-repos")
     )
-    val Error(errorMsg) = Cli.parseArgs(params.flatten)
+    val Error(errorMsg) = Cli.parseArgs(params.flatten): @unchecked
     assert(clue(errorMsg).startsWith("azure-repos, bitbucket-server do not support fork mode"))
   }
 
@@ -208,7 +208,7 @@ class CliTest extends FunSuite {
     val params = minimumRequiredParams ++ List(
       List("--forge-type", "bitbucket")
     )
-    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten): @unchecked
     assert(!obtained.forgeCfg.addLabels)
   }
 
@@ -216,12 +216,12 @@ class CliTest extends FunSuite {
     val params = minimumRequiredParams ++ List(
       List("--exit-code-success-if-any-repo-succeeds")
     )
-    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(params.flatten): @unchecked
     assert(obtained.exitCodePolicy == SuccessIfAnyRepoSucceeds)
   }
 
   test("parseArgs: exit code policy: default") {
-    val Success(Usage.Regular(obtained)) = Cli.parseArgs(minimumRequiredParams.flatten)
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(minimumRequiredParams.flatten): @unchecked
     assert(obtained.exitCodePolicy == SuccessOnlyIfAllReposSucceed)
   }
 
@@ -230,7 +230,7 @@ class CliTest extends FunSuite {
       List("--forge-type", "bitbucket"),
       List("--add-labels")
     )
-    val Error(errorMsg) = Cli.parseArgs(params.flatten)
+    val Error(errorMsg) = Cli.parseArgs(params.flatten): @unchecked
     assert(
       clue(errorMsg).startsWith("bitbucket, bitbucket-server do not support pull request labels")
     )
@@ -255,7 +255,7 @@ class CliTest extends FunSuite {
         List("--forge-type", "azure-repos"),
         List("--azure-repos-organization")
       )).flatten
-    )
+    ): @unchecked
     assert(error.startsWith("Missing value for option: --azure-repos-organization"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillDepParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillDepParserTest.scala
@@ -128,7 +128,7 @@ class MillDepParserTest extends FunSuite {
         |  ]
         |}
         |""".stripMargin
-    val Right(result) = parser.parseModules(data)
+    val Right(result) = parser.parseModules(data): @unchecked
 
     val dep12 = List("com.lihaoyi".g % ("geny", "geny_2.12").a % "0.6.0")
 

--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -38,14 +38,14 @@ class processTest extends FunSuite {
   }
 
   test("echo: fail, buffer size exceeded") {
-    val Left(t) =
-      slurp3(Nel.of("echo", "-n", "1\n2\n3\n4\n5\n6"), 4, Set.empty).attempt.unsafeRunSync()
+    val Left(t) = slurp3(Nel.of("echo", "-n", "1\n2\n3\n4\n5\n6"), 4, Set.empty).attempt
+      .unsafeRunSync(): @unchecked
     assert(clue(t).isInstanceOf[ProcessBufferOverflowException])
   }
 
   test("echo: fail, line length > buffer size") {
     val Left(t) =
-      slurp3(Nel.of("echo", "-n", "123456"), 4, Set.empty).attempt.unsafeRunSync()
+      slurp3(Nel.of("echo", "-n", "123456"), 4, Set.empty).attempt.unsafeRunSync(): @unchecked
     assert(clue(t).isInstanceOf[ProcessLineTooLongException])
   }
 
@@ -54,7 +54,7 @@ class processTest extends FunSuite {
   }
 
   test("ls: fail, non-zero exit code") {
-    val Left(t) = slurp1(Nel.of("ls", "--foo")).attempt.unsafeRunSync()
+    val Left(t) = slurp1(Nel.of("ls", "--foo")).attempt.unsafeRunSync(): @unchecked
     assert(clue(t).isInstanceOf[ProcessFailedException])
   }
 
@@ -66,7 +66,7 @@ class processTest extends FunSuite {
     val timeout = 500.milliseconds
     val sleep = timeout * 2
     val p = slurp2(Nel.of("sleep", sleep.toSeconds.toInt.toString), timeout).attempt
-    val (Left(t), fd) = DateTimeAlg.create[IO].timed(p).unsafeRunSync()
+    val (Left(t), fd) = DateTimeAlg.create[IO].timed(p).unsafeRunSync(): @unchecked
 
     assert(clue(t).isInstanceOf[ProcessTimedOutException])
     assert(clue(fd) > timeout)

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -32,5 +32,5 @@ object MockConfig {
     s"--github-app-key-file=$key",
     "--refresh-backoff-period=1hour"
   )
-  val Success(Cli.Usage.Regular(config)) = Cli.parseArgs(args)
+  val Success(Cli.Usage.Regular(config)) = Cli.parseArgs(args): @unchecked
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -10,34 +10,34 @@ class PullRequestFrequencyTest extends FunSuite {
   val epoch: Timestamp = Timestamp(0L)
 
   test("onSchedule") {
-    val Right(thursday) = PullRequestFrequency.fromString("0 * ? * THU")
-    val Right(notThursday) = PullRequestFrequency.fromString("0 * ? * MON-WED,FRI-SUN")
+    val Right(thursday) = PullRequestFrequency.fromString("0 * ? * THU"): @unchecked
+    val Right(notThursday) = PullRequestFrequency.fromString("0 * ? * MON-WED,FRI-SUN"): @unchecked
     assert(thursday.onSchedule(epoch))
     assert(!notThursday.onSchedule(epoch))
   }
 
   test("waitingTime: @asap") {
-    val Right(freq) = PullRequestFrequency.fromString("@asap")
+    val Right(freq) = PullRequestFrequency.fromString("@asap"): @unchecked
     assertEquals(freq.waitingTime(epoch, Timestamp(18.hours.toMillis)), None)
   }
 
   test("waitingTime: @daily") {
-    val Right(freq) = PullRequestFrequency.fromString("@daily")
+    val Right(freq) = PullRequestFrequency.fromString("@daily"): @unchecked
     assertEquals(freq.waitingTime(epoch, Timestamp(18.hours.toMillis)), Some(6.hours))
   }
 
   test("waitingTime: timespan") {
-    val Right(freq) = PullRequestFrequency.fromString("14 days")
+    val Right(freq) = PullRequestFrequency.fromString("14 days"): @unchecked
     assertEquals(freq.waitingTime(epoch, Timestamp(18.hours.toMillis)), Some(6.hours + 13.days))
   }
 
   test("waitingTime: cron expr") {
-    val Right(freq) = PullRequestFrequency.fromString("0 1 ? * *")
+    val Right(freq) = PullRequestFrequency.fromString("0 1 ? * *"): @unchecked
     assertEquals(freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)), Some(40.minutes))
   }
 
   test("CronExpr encode and then decode") {
-    val Right(freq) = PullRequestFrequency.fromString("0 0 1,15 * ?")
+    val Right(freq) = PullRequestFrequency.fromString("0 0 1,15 * ?"): @unchecked
     assertEquals(parser.decode[PullRequestFrequency](freq.asJson.spaces2), Right(freq))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -28,7 +28,7 @@ class PruningAlgTest extends FunSuite {
           |    }
           |  }
           |}""".stripMargin
-    )
+    ): @unchecked
     val pullRequestsFile =
       config.workspace / "store/pull_requests/v2/github/fthomas/scalafix-test/pull_requests.json"
     val pullRequestsContent =
@@ -116,7 +116,7 @@ class PruningAlgTest extends FunSuite {
           |    }
           |  }
           |}""".stripMargin
-    )
+    ): @unchecked
     val pullRequestsFile =
       config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     val pullRequestsContent =
@@ -261,7 +261,7 @@ class PruningAlgTest extends FunSuite {
           |    }
           |  }
           |}""".stripMargin
-    )
+    ): @unchecked
     val pullRequestsFile =
       config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     val timestampNow = Instant.now().toEpochMilli
@@ -373,7 +373,7 @@ class PruningAlgTest extends FunSuite {
           |    }
           |  }
           |}""".stripMargin
-    )
+    ): @unchecked
     val pullRequestsFile =
       config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"
     val pullRequestsContent =
@@ -488,7 +488,7 @@ class PruningAlgTest extends FunSuite {
           |    }
           |  }
           |}""".stripMargin
-    )
+    ): @unchecked
     val timestampNow = Instant.now().toEpochMilli
     val pullRequestsFile =
       config.workspace / s"store/pull_requests/v2/github/${repo.toPath}/pull_requests.json"


### PR DESCRIPTION
This is in preparation for compiling with Scala 3 and prevents warnings about pattern bindings with refutable patterns like this:
```
 -- Warning: modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala:218:27
 218 |    val Right(repoCache) = decode[RepoCache](
     |                           ^
     |pattern's type Right[io.circe.Error, org.scalasteward.core.repocache.RepoCache] is more specialized than the right hand side expression's type Either[io.circe.Error, org.scalasteward.core.repocache.RepoCache]
     |
     |If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
     |which may result in a MatchError at runtime.
     |This patch can be rewritten automatically under -rewrite -source 3.2-migration.
```
The changes here we done by the Scala 3 compiler by using the `-rewrite -source 3.2-migration` options. They are another large chunk of #2065 that have been cherry-picked from that branch.

Relevant documentation: https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html