### PR TITLE
Harmonize imports for http4s and circe literals

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -23,7 +23,7 @@ import cats.{ApplicativeError, MonadThrow}
 import fs2.Stream
 import org.apache.commons.io.FileUtils
 import org.http4s.Uri
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.typelevel.log4cats.Logger
 import scala.io.Source
 

--- a/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
@@ -8,7 +8,7 @@ import munit.CatsEffectSuite
 import org.http4s.HttpRoutes
 import org.http4s.client._
 import org.http4s.headers.{`Retry-After`, `User-Agent`, Location}
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.typelevel.ci._
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/DependencyMetadataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/DependencyMetadataTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.coursier
 import cats.Id
 import cats.syntax.all._
 import munit.FunSuite
-import org.http4s.implicits.http4sLiteralsSyntax
+import org.http4s.syntax.literals._
 
 class DependencyMetadataTest extends FunSuite {
   test("filterUrls") {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.forge
 
 import munit.FunSuite
 import org.http4s.Uri
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.forge.ForgeType._
 
 /** As much as possible, uris in this test suite should aim to be real, clickable, uris that

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.forge.azurerepos
 
 import munit.CatsEffectSuite
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.AzureReposCfg

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
@@ -5,7 +5,7 @@ import munit.CatsEffectSuite
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketCfg
 import org.scalasteward.core.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.forge.bitbucketserver
 
 import munit.CatsEffectSuite
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketServerCfg

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
@@ -5,7 +5,7 @@ import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GiteaCfg
 import org.scalasteward.core.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -8,7 +8,7 @@ import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GitHubCfg
 import org.scalasteward.core.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
@@ -1,12 +1,12 @@
 package org.scalasteward.core.forge.github
 
 import better.files.File
-import io.circe.literal.JsonStringContext
+import io.circe.literal._
 import munit.CatsEffectSuite
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Authorization
-import org.http4s.implicits.http4sLiteralsSyntax
+import org.http4s.syntax.literals._
 import org.http4s.{AuthScheme, Credentials, HttpApp, Request}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context.{httpJsonClient, logger}

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
@@ -9,7 +9,7 @@ import org.http4s.HttpApp
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Allow
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestInstances.{dummyRepoCache, ioLogger}
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.Config.GitLabCfg

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -4,7 +4,7 @@ import cats.syntax.all._
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.coursier.DependencyMetadata
 import org.scalasteward.core.data.Version


### PR DESCRIPTION
This is in preparation for compiling with Scala 3 and prevents errors like
```
 -- [E008] Not Found Error: modules/core/src/test/scala/org/scalasteward/core/coursier/DependencyMetadataTest.scala:7:28
 7 |import org.http4s.implicits.http4sLiteralsSyntax
   |                            ^^^^^^^^^^^^^^^^^^^^
   | value http4sLiteralsSyntax is not a member of object org.http4s.implicits
```
and
```

 -- [E008] Not Found Error: modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala:4:24
 4 |import io.circe.literal.JsonStringContext
   |                        ^^^^^^^^^^^^^^^^^
   |               value JsonStringContext is not a member of io.circe.literal
```
It also prefers importing `org.http4s.syntax.literals._` over `org.http4s.implicits._` so that we import less and are more explicit about what the import is about.