### PR TITLE
Properly indent `InitialCommandsTest`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import scala.util.Properties
-import scala.reflect.io.Path
 import com.typesafe.sbt.packager.docker.*
 import sbtcrossproject.{CrossProject, CrossType, Platform}
 import org.typelevel.sbt.gha.JavaSpec.Distribution.Temurin
@@ -196,24 +194,23 @@ lazy val core = myCrossProject("core")
       BuildInfoKey("millPluginVersion" -> Dependencies.scalaStewardMillPlugin.revision)
     ),
     buildInfoPackage := moduleRootPkg.value,
-    initialCommands += s"""
-      import ${moduleRootPkg.value}._
-      import ${moduleRootPkg.value}.data._
-      import ${moduleRootPkg.value}.util._
-      import better.files.File
-      import cats.effect.IO
-      import org.http4s.client.Client
-      import org.typelevel.log4cats.Logger
-      import org.typelevel.log4cats.slf4j.Slf4jLogger
-
-      implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
-    """,
+    initialCommands +=
+      s"""import ${moduleRootPkg.value}._
+         |import ${moduleRootPkg.value}.data._
+         |import ${moduleRootPkg.value}.util._
+         |import better.files.File
+         |import cats.effect.IO
+         |import org.http4s.client.Client
+         |import org.typelevel.log4cats.Logger
+         |import org.typelevel.log4cats.slf4j.Slf4jLogger
+         |implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+         |""".stripMargin,
     // Inspired by https://stackoverflow.com/a/41978937/460387
     Test / sourceGenerators += Def.task {
       val file = (Test / sourceManaged).value / "InitialCommandsTest.scala"
       val content =
         s"""object InitialCommandsTest {
-           |  ${initialCommands.value}
+           |  ${initialCommands.value.linesIterator.mkString("\n  ")}
            |  // prevent warnings
            |  intellijThisImportIsUsed(Client); intellijThisImportIsUsed(File);
            |  intellijThisImportIsUsed(Nel); intellijThisImportIsUsed(Repo);


### PR DESCRIPTION
The Scala 3 compiler complains about the indentation of `InitialCommandsTest`. This fixes it.