### PR TITLE
Fix "Scala 2 syntax with -Xsource:3" warnings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,3 +5,4 @@ align.openParenCallSite = false
 align.openParenDefnSite = false
 maxColumn = 100
 rewrite.rules = [AvoidInfix, PreferCurlyFors, RedundantBraces, SortImports, SortModifiers]
+rewrite.scala3.convertToNewSyntax = true

--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -18,7 +18,7 @@ package org.scalasteward.benchmark
 
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.repoconfig.{UpdatePattern, UpdatesConfig, VersionPattern}
 import org.scalasteward.core.util.Nel
 

--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/VersionPositionScannerBenchmark.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.benchmark
 
 import java.util.concurrent.TimeUnit
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.edit.update.VersionPositionScanner
 import org.scalasteward.core.io.FileData

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -19,12 +19,12 @@ package org.scalasteward.core.application
 import better.files.File
 import cats.data.Validated
 import cats.effect.ExitCode
-import cats.syntax.all._
+import cats.syntax.all.*
+import com.monovore.decline.*
 import com.monovore.decline.Opts.{flag, option, options}
-import com.monovore.decline._
 import org.http4s.Uri
-import org.http4s.syntax.literals._
-import org.scalasteward.core.application.Config._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.application.Config.*
 import org.scalasteward.core.application.ExitCodePolicy.{
   SuccessIfAnyRepoSucceeds,
   SuccessOnlyIfAllReposSucceed
@@ -36,8 +36,7 @@ import org.scalasteward.core.forge.github.GitHubApp
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.dateTime.renderFiniteDuration
-
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object Cli {
   final case class EnvVar(name: String, value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.application
 import better.files.File
 import org.http4s.Uri
 import org.scalasteward.core.application.Cli.EnvVar
-import org.scalasteward.core.application.Config._
+import org.scalasteward.core.application.Config.*
 import org.scalasteward.core.data.Resolver
 import org.scalasteward.core.forge.ForgeType
 import org.scalasteward.core.forge.github.GitHubApp

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.application
 
-import cats.effect._
-import cats.effect.implicits._
-import cats.syntax.all._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosInt
 import org.http4s.Uri
 import org.http4s.client.Client
@@ -34,20 +34,20 @@ import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.edit.hooks.HookExecutor
-import org.scalasteward.core.edit.scalafix._
+import org.scalasteward.core.edit.scalafix.*
 import org.scalasteward.core.edit.update.ScannerAlg
 import org.scalasteward.core.forge.{ForgeApiAlg, ForgeAuthAlg, ForgeRepoAlg, ForgeSelection}
 import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository, UpdateInfoUrlFinder}
 import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
-import org.scalasteward.core.repocache._
+import org.scalasteward.core.repocache.*
 import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader}
 import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.update.artifact.{ArtifactMigrationsFinder, ArtifactMigrationsLoader}
 import org.scalasteward.core.update.{FilterAlg, PruningAlg, UpdateAlg}
-import org.scalasteward.core.util._
-import org.scalasteward.core.util.uri._
+import org.scalasteward.core.util.*
+import org.scalasteward.core.util.uri.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/modules/core/src/main/scala/org/scalasteward/core/application/ReposFilesLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ReposFilesLoader.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.application
 
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.Stream
 import org.http4s.Uri
 import org.scalasteward.core.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/RunResults.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.application
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.data.Repo
 
 case class RunResults(results: List[Either[(Repo, Throwable), Repo]]) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.application
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.edit.scalafix.ScalafixCli
 import org.scalasteward.core.edit.scalafix.ScalafixCli.scalafixBinary
 import org.scalasteward.core.git.GitAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.application
 
 import cats.effect.{ExitCode, Sync}
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.Stream
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeAuthAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/ValidateRepoConfigContext.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.application
 
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.io.FileAlg
 import org.scalasteward.core.repoconfig.ValidateRepoConfigAlg
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.buildtool
 
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.maven.MavenAlg
 import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.SbtAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -18,10 +18,10 @@ package org.scalasteward.core.buildtool.maven
 
 import better.files.File
 import cats.effect.{MonadCancelThrow, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.buildtool.maven
 
 import cats.parse.Rfc5234.wsp
 import cats.parse.{Parser, Parser0}
-import cats.syntax.all._
-import org.scalasteward.core.data._
+import cats.syntax.all.*
+import org.scalasteward.core.data.*
 
 object parser {
   private val colon: Parser[Char] =

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -18,10 +18,10 @@ package org.scalasteward.core.buildtool.mill
 
 import better.files.File
 import cats.effect.MonadCancelThrow
-import cats.syntax.all._
-import org.scalasteward.core.buildtool.mill.MillAlg._
+import cats.syntax.all.*
+import org.scalasteward.core.buildtool.mill.MillAlg.*
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/parser.scala
@@ -18,9 +18,9 @@ package org.scalasteward.core.buildtool.mill
 
 import cats.parse.Parser
 import cats.parse.Rfc5234.sp
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, DecodingFailure}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import scala.util.Try
 
 object parser {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -19,9 +19,9 @@ package org.scalasteward.core.buildtool.sbt
 import better.files.File
 import cats.data.OptionT
 import cats.effect.{Concurrent, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.command.*
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.coursier.VersionsCache
 import org.scalasteward.core.data.{Dependency, Scope, Version}

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.buildtool.sbt.data
 
 import cats.Order
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 
 final case class SbtVersion(value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.buildtool.sbt.data
 
 import cats.Order
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 
 final case class ScalaVersion(value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.buildtool
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.io.FileData
 
 package object sbt {

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.buildtool.sbt
 
-import cats.implicits._
+import cats.implicits.*
 import io.circe.Decoder
-import io.circe.parser._
-import org.scalasteward.core.data._
+import io.circe.parser.*
+import org.scalasteward.core.data.*
 
 object parser {
   private val regex = """sbt.version\s*=\s*(\S+)""".r

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.buildtool.scalacli
 
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.data.Scope

--- a/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
@@ -16,17 +16,17 @@
 
 package org.scalasteward.core.client
 
-import cats.effect._
-import cats.syntax.all._
+import cats.effect.*
+import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosInt
 import java.net.http.HttpClient
 import java.net.http.HttpClient.Builder
 import org.http4s.Response
-import org.http4s.client._
+import org.http4s.client.*
 import org.http4s.headers.`User-Agent`
 import org.http4s.jdkhttpclient.JdkHttpClient
-import org.typelevel.ci._
-import scala.concurrent.duration._
+import org.typelevel.ci.*
+import scala.concurrent.duration.*
 
 object ClientConfiguration {
   type BuilderMiddleware = Builder => Builder

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.coursier
 
 import cats.Parallel
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import coursier.cache.{CachePolicy, FileCache}
 import coursier.core.{Authentication, Project}
 import coursier.{Fetch, Module, ModuleName, Organization}

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/DependencyMetadata.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.coursier
 
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.forge.ForgeRepo

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.coursier
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{MonadThrow, Parallel}
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.{Codec, KeyEncoder}

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import cats.Parallel
 import cats.effect.Async
-import cats.syntax.all._
+import cats.syntax.all.*
 import java.util.concurrent.ExecutorService
 import scala.concurrent.ExecutionContext
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/CrossDependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/CrossDependency.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.data
 
 import cats.Order
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.util.Nel
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.data
 
 import cats.Order
 import io.circe.Codec
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 
 final case class Dependency(

--- a/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.data
 
 import cats.Order
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 
 final case class GroupId(value: String) extends AnyVal {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Resolver.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Resolver.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.data
 
 import cats.Order
 import io.circe.Codec
-import io.circe.generic.semiauto._
-import org.scalasteward.core.data.Resolver._
+import io.circe.generic.semiauto.*
+import org.scalasteward.core.data.Resolver.*
 
 sealed trait Resolver extends Product with Serializable {
   val path: String = {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Scope.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Scope.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.data
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Eval, Order, Traverse}
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.{Codec, Decoder, Encoder}

--- a/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.data
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Codec, Decoder, Encoder}
-import org.scalasteward.core.data.SemVer.Change._
+import org.scalasteward.core.data.SemVer.Change.*
 import scala.annotation.tailrec
 
 final case class SemVer(

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.data
 
 import cats.Order
-import cats.implicits._
-import io.circe.generic.semiauto._
-import io.circe.syntax._
+import cats.implicits.*
+import io.circe.generic.semiauto.*
+import io.circe.syntax.*
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.data
 
 import cats.Order
-import cats.implicits._
+import cats.implicits.*
 import cats.parse.{Numbers, Parser, Rfc5234}
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Version.startsWithDate

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.data.{Repo, RepoData, Update}
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
@@ -29,7 +29,7 @@ import org.scalasteward.core.git.{CommitMsg, GitAlg}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.{scalafmtModule, ScalafmtAlg}
-import org.scalasteward.core.util.logger._
+import org.scalasteward.core.util.logger.*
 import org.typelevel.log4cats.Logger
 
 final class EditAlg[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -18,14 +18,14 @@ package org.scalasteward.core.edit.hooks
 
 import better.files.File
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.sbt.{
   sbtArtifactId,
   sbtGroupId,
   sbtScalafixArtifactId,
   sbtScalafixGroupId
 }
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.edit.EditAttempt
 import org.scalasteward.core.edit.EditAttempt.HookEdit
 import org.scalasteward.core.git.{gitBlameIgnoreRevsName, Commit, CommitMsg, GitAlg}
@@ -34,7 +34,7 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.util.logger._
+import org.scalasteward.core.util.logger.*
 import org.typelevel.log4cats.Logger
 
 final class HookExecutor[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.edit.hooks
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.git.CommitMsg
 import org.scalasteward.core.repocache.RepoCache

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixCli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixCli.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.edit.scalafix
 
 import better.files.File
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.edit.scalafix.ScalafixCli.scalafixBinary
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{ProcessAlg, WorkspaceAlg}

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.edit.scalafix
 
 import cats.Eq
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.{ExecutionOrder, Target}
 import org.scalasteward.core.git.{Author, CommitMsg}

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrations.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrations.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit.scalafix
 
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 
 final case class ScalafixMigrations(migrations: List[ScalafixMigration])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinder.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.edit.scalafix
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import java.util.regex.Pattern
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.scalafix.ScalafixMigration.ExecutionOrder

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoader.scala
@@ -17,11 +17,11 @@
 package org.scalasteward.core.edit.scalafix
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.config.parser.decode
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.ScalafixCfg
-import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader._
+import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader.*
 import org.scalasteward.core.io.FileAlg
 import org.typelevel.log4cats.Logger
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/ScannerAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit.update
 
 import cats.effect.Concurrent
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.Stream
 import org.scalasteward.core.data.{Dependency, Repo, Version}
 import org.scalasteward.core.edit.update.data.{ModulePosition, VersionPosition}

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
@@ -17,13 +17,13 @@
 package org.scalasteward.core.edit.update
 
 import cats.Foldable
-import cats.syntax.all._
+import cats.syntax.all.*
 import java.util.regex.Pattern
 import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.{buildPropertiesName, isSbtUpdate}
 import org.scalasteward.core.data.{Dependency, Update}
-import org.scalasteward.core.edit.update.data.VersionPosition._
-import org.scalasteward.core.edit.update.data._
+import org.scalasteward.core.edit.update.data.*
+import org.scalasteward.core.edit.update.data.VersionPosition.*
 import org.scalasteward.core.scalafmt.{isScalafmtCoreUpdate, scalafmtConfName}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/VersionPositionScanner.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/VersionPositionScanner.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit.update
 
 import org.scalasteward.core.data.Version
-import org.scalasteward.core.edit.update.data.VersionPosition._
+import org.scalasteward.core.edit.update.data.VersionPosition.*
 import org.scalasteward.core.edit.update.data.{Substring, VersionPosition}
 import org.scalasteward.core.io.FileData
 import scala.util.matching.Regex

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/BasicAuthAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/BasicAuthAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.forge
 
 import better.files.File
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri.UserInfo
 import org.http4s.headers.Authorization
 import org.http4s.{BasicCredentials, Request, Uri}

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.forge
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{ApplicativeThrow, MonadThrow}
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.Branch
 
 trait ForgeApiAlg[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeAuthAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeAuthAlg.scala
@@ -20,7 +20,7 @@ import cats.effect.Sync
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.ForgeType._
+import org.scalasteward.core.forge.ForgeType.*
 import org.scalasteward.core.forge.bitbucketserver.BitbucketServerAuthAlg
 import org.scalasteward.core.forge.github.GitHubAuthAlg
 import org.scalasteward.core.forge.gitlab.GitLabAuthAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeRepoAlg.scala
@@ -17,13 +17,13 @@
 package org.scalasteward.core.forge
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeType.GitHub
 import org.scalasteward.core.forge.data.RepoOut
 import org.scalasteward.core.git.{updateBranchPrefix, Branch, GitAlg}
-import org.scalasteward.core.util.logger._
+import org.scalasteward.core.util.logger.*
 import org.typelevel.log4cats.Logger
 
 final class ForgeRepoAlg[F[_]](config: Config)(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeSelection.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.forge
 
-import cats.effect.Temporal
 import cats.Parallel
+import cats.effect.Temporal
 import org.http4s.Request
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.application.Config.{ForgeCfg, ForgeSpecificCfg}

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -17,15 +17,14 @@
 package org.scalasteward.core.forge
 
 import cats.Eq
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.ForgeType._
+import org.scalasteward.core.forge.ForgeType.*
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.unexpectedString
-
 import scala.annotation.nowarn
 
 sealed trait ForgeType extends Product with Serializable {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
@@ -17,13 +17,13 @@
 package org.scalasteward.core.forge.azurerepos
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config.AzureReposCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
-import org.scalasteward.core.forge.azurerepos.JsonCodec._
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.azurerepos.JsonCodec.*
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/JsonCodec.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/JsonCodec.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.forge.azurerepos
 
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.http4s.Uri
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.unexpectedString
 import org.scalasteward.core.util.uri.uriDecoder

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
@@ -17,13 +17,13 @@
 package org.scalasteward.core.forge.bitbucket
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.{Request, Status}
 import org.scalasteward.core.application.Config.{BitbucketCfg, ForgeCfg}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
-import org.scalasteward.core.forge.bitbucket.json._
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.bitbucket.json.*
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.{HttpJsonClient, UnexpectedResponse}
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/RepositoryResponse.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/RepositoryResponse.scala
@@ -16,14 +16,13 @@
 
 package org.scalasteward.core.forge.bitbucket
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{ACursor, Decoder, DecodingFailure, Json}
 import org.http4s.Uri
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data.UserOut
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.util.uri._
-
+import org.scalasteward.core.util.uri.*
 import scala.annotation.tailrec
 
 final private[bitbucket] case class RepositoryResponse(

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/json.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.forge.bitbucket
 
 import io.circe.Decoder
 import org.http4s.Uri
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.unexpectedString
 import org.scalasteward.core.util.uri.uriDecoder

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.forge.bitbucketserver
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config.BitbucketServerCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
 import org.scalasteward.core.forge.bitbucketserver.Json.{PR, Reviewer, User}
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.data.PullRequestState.Open
-import org.scalasteward.core.forge.data._
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerAuthAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerAuthAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.forge.bitbucketserver
 
 import better.files.File
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri.UserInfo
 import org.http4s.headers.Authorization
 import org.http4s.{BasicCredentials, Header, Request, Uri}

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/Json.scala
@@ -21,7 +21,7 @@ import cats.data.NonEmptyList
 import io.circe.generic.semiauto.{deriveCodec, deriveDecoder, deriveEncoder}
 import io.circe.{Codec, Decoder, Encoder}
 import org.http4s.Uri
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.util.intellijThisImportIsUsed

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/BranchOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/BranchOut.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.forge.data
 
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.git.Branch
 
 final case class BranchOut(

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/CommitOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/CommitOut.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.forge.data
 
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.git.Sha1
 
 final case class CommitOut(

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -16,19 +16,18 @@
 
 package org.scalasteward.core.forge.data
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Json
-import io.circe.syntax._
+import io.circe.syntax.*
 import org.http4s.Uri
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.edit.EditAttempt
 import org.scalasteward.core.edit.EditAttempt.ScalafixEdit
 import org.scalasteward.core.git.{Branch, CommitMsg}
 import org.scalasteward.core.nurture.UpdateInfoUrl
-import org.scalasteward.core.nurture.UpdateInfoUrl._
+import org.scalasteward.core.nurture.UpdateInfoUrl.*
 import org.scalasteward.core.repoconfig.{GroupRepoConfig, RepoConfigAlg}
 import org.scalasteward.core.util.{Details, Nel}
-
 import scala.util.matching.Regex
 
 final case class NewPullRequestData(

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/PullRequestOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/PullRequestOut.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.forge.data
 
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.http4s.Uri
 import org.scalasteward.core.util.intellijThisImportIsUsed
 import org.scalasteward.core.util.uri.uriDecoder

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/RepoOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/RepoOut.scala
@@ -18,13 +18,12 @@ package org.scalasteward.core.forge.data
 
 import cats.ApplicativeThrow
 import io.circe.Codec
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.http4s.Uri
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.intellijThisImportIsUsed
-import org.scalasteward.core.util.uri.uriDecoder
-import org.scalasteward.core.util.uri.uriEncoder
+import org.scalasteward.core.util.uri.{uriDecoder, uriEncoder}
 
 final case class RepoOut(
     name: String,
@@ -49,4 +48,5 @@ object RepoOut {
   implicit val repoOutDecoder: Codec[RepoOut] = deriveCodec
 
   intellijThisImportIsUsed(uriDecoder)
+  intellijThisImportIsUsed(uriEncoder)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/UserOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/UserOut.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.forge.data
 
 import io.circe.Codec
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 
 final case class UserOut(
     login: String

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
@@ -16,18 +16,18 @@
 
 package org.scalasteward.core.forge.gitea
 
-import cats._
-import cats.implicits._
-import io.circe._
+import cats.*
+import cats.implicits.*
+import io.circe.*
 import io.circe.generic.semiauto.{deriveCodec, deriveEncoder}
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
-import org.scalasteward.core.forge.data._
-import org.scalasteward.core.forge.gitea.GiteaApiAlg._
+import org.scalasteward.core.forge.data.*
+import org.scalasteward.core.forge.gitea.GiteaApiAlg.*
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.util.uri._
+import org.scalasteward.core.util.uri.*
 import org.scalasteward.core.util.{intellijThisImportIsUsed, HttpJsonClient}
 import org.typelevel.log4cats.Logger
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/Url.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.forge.gitea
 
 import org.http4s.Uri
-import org.scalasteward.core.git.Branch
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data.PullRequestNumber
+import org.scalasteward.core.git.Branch
 
 class Url(apiHost: Uri) {
   def repoBranch(repo: Repo, branch: Branch): Uri =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -17,13 +17,13 @@
 package org.scalasteward.core.forge.github
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Json
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
-import org.scalasteward.core.forge.data._
-import org.scalasteward.core.forge.github.GitHubException._
+import org.scalasteward.core.forge.data.*
+import org.scalasteward.core.forge.github.GitHubException.*
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubAppApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubAppApiAlg.scala
@@ -17,10 +17,10 @@
 package org.scalasteward.core.forge.github
 
 import cats.effect.Concurrent
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.{Header, Uri}
 import org.scalasteward.core.util.HttpJsonClient
-import org.typelevel.ci._
+import org.typelevel.ci.*
 
 class GitHubAppApiAlg[F[_]](
     gitHubApiHost: Uri

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubAuthAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubAuthAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.forge.github
 
 import better.files.File
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import io.jsonwebtoken.Jwts
 import java.io.FileReader
 import java.security.spec.PKCS8EncodedKeySpec
@@ -32,12 +32,12 @@ import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Header, Request, Uri}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeAuthAlg
+import org.scalasteward.core.util
 import org.scalasteward.core.util.HttpJsonClient
 import org.typelevel.ci.CIStringSyntax
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Using
-import org.scalasteward.core.util
 
 final class GitHubAuthAlg[F[_]](
     apiUri: Uri,

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/InstallationOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/InstallationOut.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.forge.github
 
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 
 case class InstallationOut(id: Long)
 object InstallationOut {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -18,15 +18,15 @@ package org.scalasteward.core.forge.gitlab
 
 import cats.Parallel
 import cats.effect.Temporal
-import cats.syntax.all._
-import io.circe._
-import io.circe.generic.semiauto._
-import io.circe.syntax._
+import cats.syntax.all.*
+import io.circe.*
+import io.circe.generic.semiauto.*
+import io.circe.syntax.*
 import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.application.Config.{ForgeCfg, GitLabCfg}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.ForgeApiAlg
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.uri.uriDecoder
 import org.scalasteward.core.util.{intellijThisImportIsUsed, HttpJsonClient, UnexpectedResponse}
@@ -166,7 +166,7 @@ final class GitLabApiAlg[F[_]: Parallel](
     logger: Logger[F],
     F: Temporal[F]
 ) extends ForgeApiAlg[F] {
-  import GitLabJsonCodec._
+  import GitLabJsonCodec.*
 
   private val url = new Url(forgeCfg.apiHost)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabAuthAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabAuthAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.forge.gitlab
 
 import better.files.File
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri.UserInfo
 import org.http4s.{Header, Request, Uri}
 import org.scalasteward.core.forge.BasicAuthAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.git
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.update.show
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -18,10 +18,10 @@ package org.scalasteward.core.git
 
 import better.files.File
 import cats.effect.MonadCancelThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.forge.ForgeType._
+import org.scalasteward.core.forge.ForgeType.*
 import org.scalasteward.core.git.FileGitAlg.{dotdot, gitCmd}
 import org.scalasteward.core.io.process.{ProcessFailedException, SlurpOptions}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.git
 
 import cats.effect.{MonadCancel, MonadCancelThrow}
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{FlatMap, Monad}
 import org.http4s.Uri
 import org.scalasteward.core.application.Config

--- a/modules/core/src/main/scala/org/scalasteward/core/git/Sha1.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Sha1.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.git
 
 import cats.Eq
-import cats.syntax.all._
+import cats.syntax.all.*
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.{And, Or}
 import eu.timepit.refined.char.Digit
 import eu.timepit.refined.collection.{Forall, Size}
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.numeric.Interval
-import io.circe.refined._
+import io.circe.refined.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.git.Sha1.HexString
 

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -18,12 +18,12 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.effect.{Resource, Sync}
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{ApplicativeError, MonadThrow}
 import fs2.Stream
 import org.apache.commons.io.FileUtils
 import org.http4s.Uri
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.typelevel.log4cats.Logger
 import scala.io.Source
 

--- a/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/ProcessAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.effect.Async
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config.ProcessCfg
 import org.scalasteward.core.io.process.{Args, SlurpOption, SlurpOptions}
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
@@ -17,12 +17,12 @@
 package org.scalasteward.core.io
 
 import better.files.File
-import cats.effect._
-import cats.syntax.all._
+import cats.effect.*
+import cats.syntax.all.*
 import fs2.Stream
 import java.io.{IOException, InputStream}
 import org.scalasteward.core.application.Cli
-import org.scalasteward.core.util._
+import org.scalasteward.core.util.*
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -17,15 +17,15 @@
 package org.scalasteward.core.nurture
 
 import cats.effect.Concurrent
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Applicative, Id}
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.coursier.CoursierAlg
+import org.scalasteward.core.data.*
 import org.scalasteward.core.data.ProcessResult.{Created, Ignored, Updated}
-import org.scalasteward.core.data._
 import org.scalasteward.core.edit.{EditAlg, EditAttempt}
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.data.NewPullRequestData.{filterLabels, labelsFor}
-import org.scalasteward.core.forge.data._
 import org.scalasteward.core.forge.{ForgeApiAlg, ForgeRepoAlg}
 import org.scalasteward.core.git.{Branch, Commit, GitAlg}
 import org.scalasteward.core.repoconfig.{PullRequestUpdateStrategy, RetractedArtifact}

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -16,12 +16,12 @@
 
 package org.scalasteward.core.nurture
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Id, Monad}
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.http4s.Uri
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestState}
 import org.scalasteward.core.git
 import org.scalasteward.core.git.{Branch, Sha1}

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinder.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.nurture
 
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.coursier.DependencyMetadata
 import org.scalasteward.core.data.Version
 import org.scalasteward.core.forge.ForgeRepo
-import org.scalasteward.core.forge.ForgeType._
-import org.scalasteward.core.nurture.UpdateInfoUrl._
+import org.scalasteward.core.forge.ForgeType.*
+import org.scalasteward.core.nurture.UpdateInfoUrl.*
 import org.scalasteward.core.nurture.UpdateInfoUrlFinder.possibleUpdateInfoUrls
 import org.scalasteward.core.util.UrlChecker
 

--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/CachingKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/CachingKeyValueStore.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.persistence
 
 import cats.effect.{Ref, Sync}
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Eq, Monad}
 
 final class CachingKeyValueStore[F[_], K, V](

--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/JsonKeyValueStore.scala
@@ -18,9 +18,9 @@ package org.scalasteward.core.persistence
 
 import better.files.File
 import cats.Monad
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.parser.decode
-import io.circe.syntax._
+import io.circe.syntax.*
 import io.circe.{Decoder, Encoder, KeyEncoder}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/KeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/KeyValueStore.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.persistence
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{FlatMap, Functor}
 
 trait KeyValueStore[F[_], K, V] {

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.repocache
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.scalasteward.core.data.Repo
@@ -25,7 +25,7 @@ import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.repocache.RefreshErrorAlg.Entry
 import org.scalasteward.core.util.dateTime.showDuration
 import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.util.control.NoStackTrace
 
 final class RefreshErrorAlg[F[_]](

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.repocache
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Codec
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.data.{ArtifactId, DependencyInfo, GroupId, Scope}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.repoconfig.RepoConfig

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repocache
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{MonadThrow, Parallel}
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.BuildToolDispatcher

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -17,14 +17,14 @@
 package org.scalasteward.core.repoconfig
 
 import cats.Eq
-import cats.syntax.all._
-import cron4s.lib.javatime._
-import cron4s.syntax.cron._
+import cats.syntax.all.*
+import cron4s.lib.javatime.*
+import cron4s.syntax.cron.*
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.repoconfig.PullRequestFrequency._
+import org.scalasteward.core.repoconfig.PullRequestFrequency.*
 import org.scalasteward.core.util.Timestamp
 import org.scalasteward.core.util.dateTime.parseFiniteDuration
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 sealed trait PullRequestFrequency {
   def render: String

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.Eq
 import cats.data.NonEmptyList
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Update
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilter.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.repoconfig
 
 import cats.Eq
-import cats.syntax.all._
-import io.circe._
-import io.circe.syntax._
+import cats.syntax.all.*
+import io.circe.*
+import io.circe.syntax.*
 import org.scalasteward.core.data.{SemVer, Update}
 import scala.util.matching.Regex
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Eq, Monoid}
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -16,11 +16,11 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Eq, Monoid}
 import io.circe.Codec
-import io.circe.generic.semiauto._
-import io.circe.syntax._
+import io.circe.generic.semiauto.*
+import io.circe.syntax.*
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.hooks.PostUpdateHook

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -17,12 +17,12 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Functor, Monad, MonadThrow}
 import io.circe.config.parser
 import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.repoconfig.RepoConfigAlg._
+import org.scalasteward.core.repoconfig.RepoConfigAlg.*
 import org.typelevel.log4cats.Logger
 
 final class RepoConfigAlg[F[_]](maybeGlobalRepoConfig: Option[RepoConfig])(implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigLoader.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.repoconfig
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.RepoConfigCfg
 import org.scalasteward.core.io.FileAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Codec
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 import org.scalasteward.core.data.{GroupId, Update, Version}
 
 final case class UpdatePattern(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -16,11 +16,11 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Eq, Monoid}
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe.generic.semiauto.deriveCodec
-import io.circe.refined._
+import io.circe.refined.*
 import io.circe.{Codec, Decoder}
 import org.scalasteward.core.buildtool.maven.pomXmlName
 import org.scalasteward.core.buildtool.mill.MillAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/ValidateRepoConfigAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repoconfig
 import better.files.File
 import cats.MonadThrow
 import cats.effect.ExitCode
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{CursorOp, DecodingFailure, ParsingFailure}
 import org.scalasteward.core.io.FileAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg.ConfigParsingResult

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/VersionPattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/VersionPattern.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.repoconfig
 
 import cats.Eq
-import cats.syntax.all._
-import io.circe.generic.semiauto._
+import cats.syntax.all.*
+import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 
 final case class VersionPattern(

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.scalafmt
 
 import cats.Monad
 import cats.data.OptionT
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.ParsingFailure
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.{Resolver, Scope, Version}

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 
 package object scalafmt {
   val scalafmtGroupId: GroupId =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -16,11 +16,11 @@
 
 package org.scalasteward.core.update
 
-import cats.syntax.all._
 import cats.Monad
-import org.scalasteward.core.data._
+import cats.syntax.all.*
+import org.scalasteward.core.data.*
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.update.FilterAlg._
+import org.scalasteward.core.update.FilterAlg.*
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -17,18 +17,18 @@
 package org.scalasteward.core.update
 
 import cats.Monad
-import cats.implicits._
-import org.scalasteward.core.data._
+import cats.implicits.*
+import org.scalasteward.core.data.*
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.{PullRequestFrequency, RepoConfig, UpdatePattern}
-import org.scalasteward.core.update.PruningAlg._
+import org.scalasteward.core.update.PruningAlg.*
 import org.scalasteward.core.update.data.UpdateState
-import org.scalasteward.core.update.data.UpdateState._
+import org.scalasteward.core.update.data.UpdateState.*
 import org.scalasteward.core.util
 import org.scalasteward.core.util.{dateTime, DateTimeAlg, Nel, Timestamp}
 import org.typelevel.log4cats.Logger
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 final class PruningAlg[F[_]](implicit
     dateTimeAlg: DateTimeAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -17,10 +17,10 @@
 package org.scalasteward.core.update
 
 import cats.data.OptionT
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Monad, Parallel}
 import org.scalasteward.core.coursier.VersionsCache
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.UpdateAlg.migrateDependency
 import org.scalasteward.core.update.artifact.{ArtifactChange, ArtifactMigrationsFinder}

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactChanges.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactChanges.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.update.artifact
 
 import io.circe.Decoder
-import io.circe.generic.semiauto._
+import io.circe.generic.semiauto.*
 
 final case class ArtifactChanges(changes: List[ArtifactChange])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinder.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.update.artifact
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.data.Dependency
 
 final class ArtifactMigrationsFinder(migrations: List[ArtifactChange]) {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoader.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsLoader.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.update.artifact
 
 import cats.MonadThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.config.parser.decode
 import org.http4s.Uri
 import org.scalasteward.core.application.Config.ArtifactCfg

--- a/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.update
 
 import cats.Traverse
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/main/scala/org/scalasteward/core/util/DateTimeAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/DateTimeAlg.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.util
 
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Functor, Monad}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration

--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -17,12 +17,12 @@
 package org.scalasteward.core.util
 
 import cats.effect.Concurrent
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.Stream
 import io.circe.{Decoder, Encoder}
+import org.http4s.*
 import org.http4s.Method.{GET, PATCH, POST, PUT}
 import org.http4s.Status.Successful
-import org.http4s._
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.Client
 import org.http4s.headers.{Accept, Link, MediaRangeAndQValue}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/UrlChecker.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/UrlChecker.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.util
 
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.http4s.client.Client
 import org.http4s.{Method, Request, Status, Uri}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.util
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object dateTime {
   def parseFiniteDuration(s: String): Either[Throwable, FiniteDuration] =

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.util
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Monad, MonadThrow}
 import org.scalasteward.core.data.Update
 import org.typelevel.log4cats.Logger

--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core
 
-import cats._
-import cats.syntax.all._
+import cats.*
+import cats.syntax.all.*
 import fs2.Pipe
 import scala.collection.mutable.ListBuffer
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.util
 
 import cats.Foldable
-import cats.syntax.all._
+import cats.syntax.all.*
 import scala.util.matching.Regex
 
 object string {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/uri.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.util
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 import monocle.Optional
 import org.http4s.Uri

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -1,15 +1,15 @@
 package org.scalasteward.core
 
 import cats.effect.IO
-import eu.timepit.refined.scalacheck.numeric._
+import eu.timepit.refined.scalacheck.numeric.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data._
+import org.scalasteward.core.TestSyntax.*
+import org.scalasteward.core.data.*
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.repocache.RepoCache
+import org.scalasteward.core.repoconfig.*
 import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
-import org.scalasteward.core.repoconfig._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration.FiniteDuration

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core
 
+import org.scalasteward.core.data.*
 import org.scalasteward.core.data.Resolver.IvyRepository
-import org.scalasteward.core.data._
 import org.scalasteward.core.util.Nel
 
 object TestSyntax {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -3,8 +3,8 @@ package org.scalasteward.core.application
 import better.files.File
 import cats.data.Validated.Valid
 import munit.FunSuite
-import org.http4s.syntax.literals._
-import org.scalasteward.core.application.Cli.ParseResult._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.application.Cli.ParseResult.*
 import org.scalasteward.core.application.Cli.{EnvVar, Usage}
 import org.scalasteward.core.application.ExitCodePolicy.{
   SuccessIfAnyRepoSucceeds,
@@ -13,8 +13,7 @@ import org.scalasteward.core.application.ExitCodePolicy.{
 import org.scalasteward.core.forge.ForgeType
 import org.scalasteward.core.forge.github.GitHubApp
 import org.scalasteward.core.util.Nel
-
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class CliTest extends FunSuite {
   test("parseArgs: example") {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/RunResultsTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/RunResultsTest.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.application
 
 import munit.FunSuite
 import org.scalasteward.core.data.Repo
-
 import scala.io.Source
 class RunResultsTest extends FunSuite {
   private val repo1 = Repo("scala-steward-org", "scala-steward")

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -2,12 +2,12 @@ package org.scalasteward.core.buildtool
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.command.*
 import org.scalasteward.core.buildtool.scalacli.ScalaCliAlg
-import org.scalasteward.core.data._
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.data.*
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{BuildRootConfig, RepoConfig}
 import org.scalasteward.core.scalafmt
 import org.scalasteward.core.scalafmt.scalafmtConfName

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -4,9 +4,9 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 
 class MavenAlgTest extends FunSuite {
   test("getDependencies") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.buildtool.maven
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Resolver.MavenRepository
 
 class parserTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -5,9 +5,9 @@ import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.buildtool.mill.MillAlg.extractDeps
 import org.scalasteward.core.data.{Repo, Version}
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 
 class MillAlgTest extends FunSuite {
   test("getDependencies, version < 0.11") {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillDepParserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillDepParserTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.buildtool.mill
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Resolver
 
 class MillDepParserTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -3,12 +3,12 @@ package org.scalasteward.core.buildtool.sbt
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.command.*
 import org.scalasteward.core.data.{GroupId, Repo, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.util.Nel
 
 class SbtAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.buildtool.sbt
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
-import org.scalasteward.core.buildtool.sbt.parser._
+import org.scalasteward.core.buildtool.sbt.parser.*
 import org.scalasteward.core.data.Resolver.{Credentials, IvyRepository, MavenRepository}
 import org.scalasteward.core.data.{Resolver, Scope, Version}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -1,14 +1,14 @@
 package org.scalasteward.core.buildtool.scalacli
 
-import cats.syntax.parallel._
+import cats.syntax.parallel.*
 import munit.CatsEffectSuite
 import org.scalasteward.core.buildtool.BuildRoot
-import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.command.*
 import org.scalasteward.core.data.{GroupId, Repo, Version}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.util.Nel
 
 class ScalaCliAlgTest extends CatsEffectSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/client/ClientConfigurationTest.scala
@@ -1,18 +1,17 @@
 package org.scalasteward.core.client
 
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import eu.timepit.refined.types.numeric.PosInt
 import munit.CatsEffectSuite
 import org.http4s.HttpRoutes
-import org.http4s.client._
+import org.http4s.client.*
 import org.http4s.headers.{`Retry-After`, `User-Agent`, Location}
-import org.http4s.syntax.literals._
-import org.typelevel.ci._
+import org.http4s.syntax.literals.*
+import org.typelevel.ci.*
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory
-
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class ClientConfigurationTest extends CatsEffectSuite {
 
@@ -21,7 +20,7 @@ class ClientConfigurationTest extends CatsEffectSuite {
     `User-Agent`.parse(1)(userAgentValue).getOrElse(fail("unable to create user agent"))
 
   private val routes: HttpRoutes[IO] = {
-    import org.http4s.dsl.io._
+    import org.http4s.dsl.io.*
     HttpRoutes.of[IO] {
       case req @ GET -> Root / "user-agent" =>
         req.headers.get(ci"user-agent") match {
@@ -53,8 +52,8 @@ class ClientConfigurationTest extends CatsEffectSuite {
   }
 
   test("setUserAgent add a specific user agent to requests") {
-    import org.http4s.Method._
-    import org.http4s.client.dsl.io._
+    import org.http4s.Method.*
+    import org.http4s.client.dsl.io.*
 
     val initialClient = Client.fromHttpApp[IO](routes.orNotFound)
     val setUserAgent = ClientConfiguration.setUserAgent[IO](dummyUserAgent)
@@ -73,9 +72,9 @@ class ClientConfigurationTest extends CatsEffectSuite {
   }
 
   test("disableFollowRedirect does not follow redirect") {
-    import org.http4s.Method._
-    import org.http4s.ember.server._
-    import org.http4s.client.dsl.io._
+    import org.http4s.Method.*
+    import org.http4s.client.dsl.io.*
+    import org.http4s.ember.server.*
 
     implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
@@ -106,8 +105,8 @@ class ClientConfigurationTest extends CatsEffectSuite {
   }
 
   test("retries on retry-after response header") {
-    import org.http4s.Method._
-    import org.http4s.client.dsl.io._
+    import org.http4s.Method.*
+    import org.http4s.client.dsl.io.*
 
     def clientWithMaxAttempts(maxAttempts: PosInt): Client[IO] = {
       val initialClient = Client.fromHttpApp[IO](routes.orNotFound)

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.coursier
 
 import munit.CatsEffectSuite
-import org.http4s.syntax.literals._
-import org.scalasteward.core.TestSyntax._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.Resolver
 import org.scalasteward.core.mock.MockContext.context.coursierAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/DependencyMetadataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/DependencyMetadataTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.coursier
 
 import cats.Id
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 
 class DependencyMetadataTest extends FunSuite {
   test("filterUrls") {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.data
 import cats.data.NonEmptyList
 import cats.implicits.catsSyntaxOptionId
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.repoconfig.{PullRequestGroup, PullRequestUpdateFilter}
 
 class GroupedUpdateTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/ScopeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/ScopeTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.data
 import cats.kernel.laws.discipline.OrderTests
 import cats.laws.discipline.TraverseTests
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 
 class ScopeTest extends DisciplineSuite {
   checkAll("Traverse[Scope]", TraverseTests[Scope].traverse[Int, Int, Int, Int, Option, Option])

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.data
 
 import io.circe.Json
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.util.Nel
 
 class UpdateTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.data
 
-import cats.implicits._
+import cats.implicits.*
 import cats.kernel.laws.discipline.OrderTests
 import munit.DisciplineSuite
-import org.scalacheck.Prop._
-import org.scalasteward.core.TestInstances._
+import org.scalacheck.Prop.*
+import org.scalasteward.core.TestInstances.*
 import org.scalasteward.core.data.Version.Component
 import scala.util.Random
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -3,13 +3,13 @@ package org.scalasteward.core.edit
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.buildtool.sbt.{sbtArtifactId, sbtGroupId}
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.edit.scalafix.ScalafixCli.scalafixBinary
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtBinary, scalafmtConfName, scalafmtDependency}
@@ -87,7 +87,7 @@ class EditAlgTest extends FunSuite {
         Cmd.gitGrep(repoDir, update.groupId.value),
         Cmd("read", scalafmtConf.pathAsString),
         Cmd("write", scalafmtConf.pathAsString),
-        Cmd.exec(repoDir, scalafmtBinary :: opts.nonInteractive :: opts.modeChanged: _*),
+        Cmd.exec(repoDir, (scalafmtBinary :: opts.nonInteractive :: opts.modeChanged)*),
         Cmd.gitStatus(repoDir),
         Cmd.gitCommit(repoDir, "Update scalafmt-core to 2.1.0"),
         Cmd.gitLatestSha1(repoDir),

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -3,9 +3,9 @@ package org.scalasteward.core.edit
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{Repo, RepoData, Update}
-import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.scalafmt.scalafmtConfName
@@ -958,7 +958,7 @@ class RewriteTest extends FunSuite {
     val filesInRepoDir = files.map { case (file, content) => repoDir / file -> content }
     val state = MockState.empty
       .copy(execCommands = true)
-      .initGitRepo(repoDir, filesInRepoDir.toSeq: _*)
+      .initGitRepo(repoDir, filesInRepoDir.toSeq*)
       .flatMap(editAlg.applyUpdate(data, update).runS)
       .unsafeRunSync()
     val obtained = state.files

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -1,17 +1,17 @@
 package org.scalasteward.core.edit.hooks
 
 import cats.data.NonEmptyList
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.scalasteward.core.TestInstances.{dummyRepoCache, dummySha1}
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{Repo, RepoData}
 import org.scalasteward.core.git.gitBlameIgnoreRevsName
 import org.scalasteward.core.io.process.ProcessFailedException
 import org.scalasteward.core.io.{process, FileAlgTest}
 import org.scalasteward.core.mock.MockContext.context.{hookExecutor, workspaceAlg}
-import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{PostUpdateHookConfig, RepoConfig, ScalafmtConfig}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit.scalafix
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.mock.MockContext.context.scalafixMigrationsFinder
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/update/ModulePositionScannerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/update/ModulePositionScannerTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit.update
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.edit.update.data.{ModulePosition, Substring}
 import org.scalasteward.core.io.FileData
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/update/VersionPositionScannerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/update/VersionPositionScannerTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.edit.update
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.edit.update.data.Substring
-import org.scalasteward.core.edit.update.data.VersionPosition._
+import org.scalasteward.core.edit.update.data.VersionPosition.*
 import org.scalasteward.core.io.FileData
 
 class VersionPositionScannerTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.forge
 
 import munit.CatsEffectSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data.{RepoOut, UserOut}
 import org.scalasteward.core.git.Branch

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeRepoTest.scala
@@ -2,8 +2,8 @@ package org.scalasteward.core.forge
 
 import munit.FunSuite
 import org.http4s.Uri
-import org.http4s.syntax.literals._
-import org.scalasteward.core.forge.ForgeType._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.forge.ForgeType.*
 
 /** As much as possible, uris in this test suite should aim to be real, clickable, uris that
   * actually go to real pages, allowing developers working against this test suite to verify that

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeTypeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeTypeTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.forge
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.forge.ForgeType.{GitHub, GitLab}
 import org.scalasteward.core.git

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
@@ -2,12 +2,12 @@ package org.scalasteward.core.forge.azurerepos
 
 import munit.CatsEffectSuite
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.AzureReposCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/JsonCodecTest.scala
@@ -1,13 +1,13 @@
 package org.scalasteward.core.forge.azurerepos
 
-import io.circe.literal._
-import io.circe.syntax._
+import io.circe.literal.*
+import io.circe.syntax.*
 import munit.FunSuite
 import org.scalasteward.core.forge.data.NewPullRequestData
 import org.scalasteward.core.git.Branch
 
 class JsonCodecTest extends FunSuite {
-  import JsonCodec._
+  import JsonCodec.*
 
   private val data = NewPullRequestData(
     title = "Test MR title",

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/UrlTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.forge.azurerepos
 
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data.PullRequestNumber
 import org.scalasteward.core.git.Branch

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
@@ -1,17 +1,17 @@
 package org.scalasteward.core.forge.bitbucket
 
-import io.circe.literal._
+import io.circe.literal.*
 import munit.CatsEffectSuite
-import org.http4s._
-import org.http4s.circe._
+import org.http4s.*
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
-import org.scalasteward.core.git._
+import org.scalasteward.core.git.*
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.httpJsonClient
 import org.scalasteward.core.mock.MockForgeAuthAlg.noAuth

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/JsonCodecTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.forge.bitbucket
 
 import io.circe.Json
-import io.circe.parser._
+import io.circe.parser.*
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestOut, PullRequestState}
 
 class JsonCodecTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -2,12 +2,12 @@ package org.scalasteward.core.forge.bitbucketserver
 
 import munit.CatsEffectSuite
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.BitbucketServerCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -1,14 +1,14 @@
 package org.scalasteward.core.forge.data
 
 import munit.FunSuite
-import org.http4s.syntax.literals._
-import org.scalasteward.core.TestInstances._
-import org.scalasteward.core.TestSyntax._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.TestInstances.*
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
-import org.scalasteward.core.data._
+import org.scalasteward.core.data.*
 import org.scalasteward.core.edit.EditAttempt.{ScalafixEdit, UpdateEdit}
 import org.scalasteward.core.edit.scalafix.ScalafixMigration
-import org.scalasteward.core.forge.data.NewPullRequestData._
+import org.scalasteward.core.forge.data.NewPullRequestData.*
 import org.scalasteward.core.git.{Branch, Commit}
 import org.scalasteward.core.nurture.UpdateInfoUrl
 import org.scalasteward.core.repoconfig.RepoConfig

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/PullRequestOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/PullRequestOutTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.forge.data
 
 import io.circe.parser
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.forge.data.PullRequestState.Open
 import scala.io.Source
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/PullRequestStateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/PullRequestStateTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.forge.data
 
 import io.circe.Decoder
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.FunSuite
 import org.scalasteward.core.forge.data.PullRequestState.{Closed, Open}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/RepoOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/RepoOutTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import io.circe.parser
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.git.Branch
 import scala.io.Source

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/GiteaApiAlgTest.scala
@@ -1,15 +1,15 @@
 package org.scalasteward.core.forge.gitea
 
-import io.circe.literal._
+import io.circe.literal.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
-import org.http4s.circe._
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GiteaCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitea/UrlTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.forge.gitea
 
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.forge.data.PullRequestNumber
 import org.scalasteward.core.git.Branch

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubApiAlgTest.scala
@@ -1,18 +1,18 @@
 package org.scalasteward.core.forge.github
 
 import cats.effect.IO
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Json
-import io.circe.literal._
+import io.circe.literal.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
-import org.http4s.circe._
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.application.Config.GitHubCfg
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.forge.data._
+import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/GitHubAuthAlgTest.scala
@@ -1,18 +1,18 @@
 package org.scalasteward.core.forge.github
 
 import better.files.File
-import io.circe.literal._
+import io.circe.literal.*
 import munit.CatsEffectSuite
-import org.http4s.circe._
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Authorization
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.http4s.{AuthScheme, Credentials, HttpApp, Request}
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context.{httpJsonClient, logger}
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.typelevel.ci.CIStringSyntax
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class GitHubAuthAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   object PerPageMatcher extends QueryParamDecoderMatcher[Int]("per_page")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/JsonCodecTest.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.forge.github
 
+import io.circe.literal.*
+import io.circe.syntax.*
 import munit.FunSuite
-import io.circe.literal._
-import io.circe.syntax._
 import org.scalasteward.core.git.Branch
 
 class JsonCodecTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/github/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/github/UrlTest.scala
@@ -1,14 +1,14 @@
 package org.scalasteward.core.forge.github
 
 import munit.FunSuite
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.data.Repo
-import org.scalasteward.core.git.Branch
 import org.scalasteward.core.forge.data.PullRequestNumber
+import org.scalasteward.core.git.Branch
 
 class UrlTest extends FunSuite {
   private val url = new Url(uri"https://api.github.com")
-  import url._
+  import url.*
 
   private val repo = Repo("fthomas", "refined")
   private val branch = Branch("master")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
@@ -1,21 +1,21 @@
 package org.scalasteward.core.forge.gitlab
 
-import cats.syntax.semigroupk._
+import cats.syntax.semigroupk.*
 import io.circe.Json
-import io.circe.literal._
-import io.circe.parser._
+import io.circe.literal.*
+import io.circe.parser.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
-import org.http4s.circe._
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Allow
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.TestInstances.{dummyRepoCache, ioLogger}
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.application.Config.GitLabCfg
 import org.scalasteward.core.data.{Repo, RepoData, UpdateData}
-import org.scalasteward.core.forge.data._
-import org.scalasteward.core.forge.gitlab.GitLabJsonCodec._
+import org.scalasteward.core.forge.data.*
+import org.scalasteward.core.forge.gitlab.GitLabJsonCodec.*
 import org.scalasteward.core.forge.{ForgeSelection, ForgeType}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockConfig.config

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/MergeRequestPayloadTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/MergeRequestPayloadTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.forge.gitlab
 
-import io.circe.literal._
-import io.circe.syntax._
+import io.circe.literal.*
+import io.circe.syntax.*
 import munit.FunSuite
 import org.scalasteward.core.forge.data.NewPullRequestData
-import org.scalasteward.core.forge.gitlab.GitLabJsonCodec._
+import org.scalasteward.core.forge.gitlab.GitLabJsonCodec.*
 import org.scalasteward.core.git.Branch
 
 class MergeRequestPayloadTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.git
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Update
 
 class CommitMsgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/FileGitAlgTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.git
 import better.files.File
 import cats.Monad
 import cats.effect.IO
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.git.FileGitAlgTest.{
@@ -214,7 +214,7 @@ object FileGitAlgTest {
       F: Monad[F]
   ) {
     def git(args: String*)(repo: File): F[Unit] =
-      processAlg.exec(Nel.of("git", args: _*), repo).void
+      processAlg.exec(Nel.of("git", args*), repo).void
 
     def createRepo(repo: File): F[Unit] =
       for {

--- a/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.git
 
 import munit.ScalaCheckSuite
-import org.scalacheck.Prop._
-import org.scalasteward.core.TestInstances._
+import org.scalacheck.Prop.*
+import org.scalasteward.core.TestInstances.*
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.repoconfig.CommitsConfig
 import org.scalasteward.core.update.show

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
@@ -6,7 +6,7 @@ import cats.effect.{IO, Resource}
 import fs2.Stream
 import org.http4s.Uri
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
-import org.scalasteward.core.mock._
+import org.scalasteward.core.mock.*
 
 class MockFileAlg extends FileAlg[MockEff] {
   override def deleteForce(file: File): MockEff[Unit] =

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.io
 
-import cats.syntax.all._
 import cats.data.Kleisli
 import cats.effect.IO
+import cats.syntax.all.*
 import org.scalasteward.core.application.Config.ProcessCfg
 import org.scalasteward.core.mock.MockEff
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -4,12 +4,12 @@ import better.files.File
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 import org.scalasteward.core.application.Config.{ProcessCfg, SandboxCfg}
 import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
 import org.scalasteward.core.mock.MockConfig.{config, mockRoot}
-import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.util.Nel
 import scala.concurrent.duration.Duration
 

--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -3,9 +3,9 @@ package org.scalasteward.core.io
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.scalasteward.core.io.process._
+import org.scalasteward.core.io.process.*
 import org.scalasteward.core.util.{DateTimeAlg, Nel}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class processTest extends FunSuite {
   def slurp1(cmd: Nel[String]): IO[List[String]] =

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/GitHubAuth.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/GitHubAuth.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.mock
 
 import io.circe.syntax.EncoderOps
-import org.http4s.dsl.Http4sDsl
 import org.http4s.HttpApp
+import org.http4s.dsl.Http4sDsl
 import org.scalasteward.core.forge.github.{InstallationOut, RepositoriesOut, Repository, TokenOut}
 
 object GitHubAuth extends Http4sDsl[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -6,8 +6,8 @@ import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
 import org.scalasteward.core.application.{Config, Context, ValidateRepoConfigContext}
 import org.scalasteward.core.edit.scalafix.ScalafixMigrationsLoader
+import org.scalasteward.core.io.*
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
-import org.scalasteward.core.io._
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.repoconfig.RepoConfigLoader
 import org.scalasteward.core.update.artifact.ArtifactMigrationsLoader

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.mock
 
 import better.files.File
 import cats.effect.{IO, Ref}
-import cats.syntax.all._
+import cats.syntax.all.*
 import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.git.FileGitAlg
 import org.scalasteward.core.git.FileGitAlgTest.ioAuxGitAlg
@@ -29,15 +29,15 @@ final case class MockState(
   def initGitRepo(repoDir: File, files: (File, String)*): IO[MockState] =
     for {
       _ <- ioAuxGitAlg.createRepo(repoDir)
-      state <- addFiles(files: _*)
-      _ <- ioAuxGitAlg.addFiles(repoDir, files.map { case (file, _) => file }: _*)
+      state <- addFiles(files*)
+      _ <- ioAuxGitAlg.addFiles(repoDir, files.map { case (file, _) => file }*)
     } yield state
 
   def rmFile(file: File): IO[MockState] =
     ioFileAlg.deleteForce(file).as(copy(files = files - file))
 
   def exec(cmd: String*): MockState =
-    appendTraceEntry(Cmd(cmd: _*))
+    appendTraceEntry(Cmd(cmd*))
 
   def log(maybeThrowable: Option[Throwable], msg: String): MockState =
     appendTraceEntry(Log((maybeThrowable, msg)))
@@ -93,7 +93,7 @@ object MockState {
           "commit" :: "--all" :: "--no-gpg-sign" :: "--no-signoff" :: messages.toList.flatMap(m =>
             List("-m", m)
           )
-        git(repoDir, args: _*)
+        git(repoDir, args*)
       }
 
       def gitGrep(repoDir: File, string: String): Cmd =

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/package.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core
 
 import cats.data.Kleisli
 import cats.effect.{Async, IO, Ref}
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{~>, FlatMap}
 
 package object mock {

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/NurtureAlgTest.scala
@@ -1,11 +1,11 @@
 package org.scalasteward.core.nurture
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.dsl.Http4sDsl
-import org.scalasteward.core.TestInstances._
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestInstances.*
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{DependencyInfo, Repo, RepoData, UpdateData}
 import org.scalasteward.core.edit.EditAttempt.UpdateEdit
 import org.scalasteward.core.forge.data.NewPullRequestData

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -4,8 +4,8 @@ import cats.Id
 import cats.effect.unsafe.implicits.global
 import java.util.concurrent.atomic.AtomicInteger
 import munit.FunSuite
-import org.http4s.syntax.literals._
-import org.scalasteward.core.TestSyntax._
+import org.http4s.syntax.literals.*
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.forge.data.PullRequestState.Open
 import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestState}

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -1,20 +1,20 @@
 package org.scalasteward.core.nurture
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.coursier.DependencyMetadata
 import org.scalasteward.core.data.Version
-import org.scalasteward.core.forge.ForgeType._
+import org.scalasteward.core.forge.ForgeType.*
 import org.scalasteward.core.forge.github.Repository
 import org.scalasteward.core.forge.{ForgeRepo, ForgeType}
-import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockEffOps, MockState}
-import org.scalasteward.core.nurture.UpdateInfoUrl._
-import org.scalasteward.core.nurture.UpdateInfoUrlFinder._
+import org.scalasteward.core.nurture.UpdateInfoUrl.*
+import org.scalasteward.core.nurture.UpdateInfoUrlFinder.*
 
 class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val httpApp = HttpApp[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.persistence
 
 import cats.effect.unsafe.implicits.global
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.FunSuite
 import org.scalasteward.core.mock.MockConfig.config
-import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RefreshErrorAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.repocache
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.mock.MockContext.context.refreshErrorAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
@@ -1,12 +1,12 @@
 package org.scalasteward.core.repocache
 
 import cats.implicits.toSemigroupKOps
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
-import org.http4s.circe._
+import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.all._
+import org.http4s.syntax.all.*
 import org.scalasteward.core.TestInstances.dummySha1
 import org.scalasteward.core.data.{Repo, RepoData}
 import org.scalasteward.core.forge.data.{RepoOut, UserOut}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CommitsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CommitsConfigTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 
 class CommitsConfigTest extends DisciplineSuite {
   checkAll("Monoid[CommitsConfig]", MonoidTests[CommitsConfig].monoid)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.repoconfig
 
 import io.circe.parser
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.FunSuite
 import org.scalasteward.core.util.Timestamp
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class PullRequestFrequencyTest extends FunSuite {
   val epoch: Timestamp = Timestamp(0L)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 
 class PullRequestsConfigTest extends DisciplineSuite {
   checkAll("Monoid[PullRequestsConfig]", MonoidTests[PullRequestsConfig].monoid)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -2,16 +2,16 @@ package org.scalasteward.core.repoconfig
 
 import cats.data.NonEmptyList
 import cats.effect.unsafe.implicits.global
-import cats.syntax.all._
+import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{GroupId, Repo, SemVer, Update}
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.util.Nel
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class RepoConfigAlgTest extends FunSuite {
   test("default config is not empty") {

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 
 class RepoConfigTest extends DisciplineSuite {
   checkAll("Monoid[RepoConfig]", MonoidTests[RepoConfig].monoid)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RetractedArtifactTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RetractedArtifactTest.scala
@@ -1,8 +1,7 @@
 package org.scalasteward.core.repoconfig
 
-import org.scalasteward.core.TestSyntax._
-
 import munit.FunSuite
+import org.scalasteward.core.TestSyntax.*
 
 class RetractedArtifactTest extends FunSuite {
   private val retractedArtifact = RetractedArtifact(

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ScalafmtConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/ScalafmtConfigTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 
 class ScalafmtConfigTest extends DisciplineSuite {
   checkAll("Monoid[ScalafmtConfig]", MonoidTests[ScalafmtConfig].monoid)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/UpdatesConfigTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.repoconfig
 
 import cats.kernel.laws.discipline.MonoidTests
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.DisciplineSuite
-import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.TestInstances.*
 import org.scalasteward.core.data.GroupId
 
 class UpdatesConfigTest extends DisciplineSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -4,9 +4,9 @@ import cats.effect.unsafe.implicits.global
 import munit.FunSuite
 import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.{Repo, Version}
-import org.scalasteward.core.mock.MockContext.context._
-import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 
 class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on unquoted version") {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -1,15 +1,15 @@
 package org.scalasteward.core.update
 
 import cats.effect.unsafe.implicits.global
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.mock.MockContext.context.filterAlg
-import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
-import org.scalasteward.core.repoconfig._
-import org.scalasteward.core.update.FilterAlg._
+import org.scalasteward.core.mock.{MockEffOps, MockState}
+import org.scalasteward.core.repoconfig.*
+import org.scalasteward.core.update.FilterAlg.*
 import org.scalasteward.core.util.Nel
 
 class FilterAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -5,13 +5,13 @@ import io.circe.parser.decode
 import java.time.Instant
 import munit.FunSuite
 import org.scalasteward.core.TestInstances.dummyRepoCache
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Resolver.MavenRepository
 import org.scalasteward.core.data.{DependencyInfo, Repo, RepoData, Scope}
 import org.scalasteward.core.mock.MockConfig.config
 import org.scalasteward.core.mock.MockContext.context.pruningAlg
-import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
+import org.scalasteward.core.mock.{MockEffOps, MockState}
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.RepoConfig
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.update
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.util.Nel
 
 class UpdateAlgTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.update.artifact
 
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.{GroupId, Resolver, Scope}
 import org.scalasteward.core.mock.MockContext.context.updateAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.update
 
 import munit.FunSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.util.Nel
 
 class showTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/HttpJsonClientTest.scala
@@ -1,12 +1,12 @@
 package org.scalasteward.core.util
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.CatsEffectSuite
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.{Link, LinkValue}
-import org.http4s.syntax.all._
+import org.http4s.syntax.all.*
 import org.http4s.{HttpApp, HttpVersion, Status}
-import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 
 class HttpJsonClientTest extends CatsEffectSuite with Http4sDsl[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/UnexpectedResponseTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.util
 
 import munit.FunSuite
-import org.http4s._
+import org.http4s.*
 import org.typelevel.ci.CIString
 
 class UnexpectedResponseTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/dateTimeTest.scala
@@ -1,10 +1,10 @@
 package org.scalasteward.core.util
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.ScalaCheckSuite
-import org.scalacheck.Prop._
-import org.scalasteward.core.util.dateTime._
-import scala.concurrent.duration._
+import org.scalacheck.Prop.*
+import org.scalasteward.core.util.dateTime.*
+import scala.concurrent.duration.*
 
 class dateTimeTest extends ScalaCheckSuite {
   def approxEq(x: FiniteDuration, y: FiniteDuration): Unit = {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -1,9 +1,9 @@
 package org.scalasteward.core.util
 
 import munit.CatsEffectSuite
-import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Update
-import org.scalasteward.core.mock.MockContext.context._
+import org.scalasteward.core.mock.MockContext.context.*
 import org.scalasteward.core.mock.MockState.TraceEntry.Log
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.util.logger.{showUpdates, LoggerOps}

--- a/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.util
 
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
-import org.scalacheck.Prop._
+import org.scalacheck.Prop.*
 
 class stringTest extends ScalaCheckSuite {
   test("extractWords") {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/uriTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/uriTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.util
 
 import munit.FunSuite
 import org.http4s.Uri.UserInfo
-import org.http4s.syntax.literals._
+import org.http4s.syntax.literals.*
 import org.scalasteward.core.util
 
 class uriTest extends FunSuite {

--- a/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
-import org.scalacheck.Prop._
+import org.scalacheck.Prop.*
 import scala.collection.mutable.ListBuffer
 
 class utilTest extends ScalaCheckSuite {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
   val bcprovJdk15to18 = "org.bouncycastle" % "bcprov-jdk15to18" % "1.79"


### PR DESCRIPTION
Since #3532 IntelliJ produced "Scala 2 syntax with -Xsource:3" warnings. This fixes them.