### PR TITLE
Use only one variable for `mill-version` files

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -130,7 +130,7 @@ updates.allowPreReleases  = [ { groupId = "com.example", artifactId="foo" } ]
 updates.limit = 5
 
 # The extensions of files that should be updated.
-# Default: [".mill",".mill-version",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".sdkmanrc",".yml","build.properties","mill-version","pom.xml"]
+# Default: [".mill",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".sdkmanrc",".yml","build.properties","mill-version","pom.xml"]
 updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md", ".markdown", ".txt"]
 
 # If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -93,10 +93,8 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
 
   private def getMillVersion(buildRootDir: File): F[Option[Version]] =
     for {
-      millVersionFileContent <- fileAlg.readFile(buildRootDir / millVersionName)
-      millVersionFileInConfigContent <- fileAlg.readFile(
-        buildRootDir / ".config" / millVersionNameInConfig
-      )
+      millVersionFileContent <- fileAlg.readFile(buildRootDir / s".$millVersionName")
+      millVersionFileInConfigContent <- fileAlg.readFile(buildRootDir / ".config" / millVersionName)
       version = millVersionFileContent
         .orElse(millVersionFileInConfigContent)
         .flatMap(parser.parseMillVersion)
@@ -151,6 +149,5 @@ object MillAlg {
     update.groupId === millMainGroupId &&
       update.artifactIds.exists(_.name === millMainArtifactId.name)
 
-  val millVersionName = ".mill-version"
-  val millVersionNameInConfig = "mill-version"
+  val millVersionName = "mill-version"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
@@ -179,10 +179,7 @@ object Selector {
       versionPositions: List[VersionPosition]
   ): List[VersionPosition] =
     if (MillAlg.isMillMainUpdate(update))
-      versionPositions.filter(f =>
-        f.version.path.endsWith(MillAlg.millVersionNameInConfig) ||
-          f.version.path.endsWith(MillAlg.millVersionName)
-      )
+      versionPositions.filter(_.version.path.endsWith(MillAlg.millVersionName))
     else List.empty
 
   private def sbtVersionPositions(

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -107,7 +107,6 @@ object UpdatesConfig {
     Set(
       ".mill",
       MillAlg.millVersionName,
-      MillAlg.millVersionNameInConfig,
       ".sbt",
       ".sbt.shared",
       ".sc",


### PR DESCRIPTION
Using one variable is enough since `millVersionNameInConfig` was a suffix of `millVersionName`. If Scala Steward is allowed to edit files in ending with `mill-version` it is also allowed to edit `.mill-version` files.