### PR TITLE
Run Mill 0.11 with `--disable-ticker` instead of `--ticker false`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -45,20 +45,23 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
           .map(_.nonEmpty)
       )
 
-  private def runMill(buildRootDir: File) = {
-    val options =
-      List("--no-server", "--ticker=false", "--import", cliPluginCoordinate, "show", extractDeps)
-    val command = Nel("mill", options)
-    processAlg.execSandboxed(command, buildRootDir)
-  }
-  private def runMillUnder011(buildRootDir: File, millBuildVersion: Option[Version]) = {
-    val predef = buildRootDir / "scala-steward.sc"
-    val predefContent = content(millBuildVersion)
-    val command = Nel("mill", List("-i", "-p", predef.toString, "show", extractDeps))
-    fileAlg.createTemporarily(predef, predefContent).surround {
-      processAlg.execSandboxed(command, buildRootDir)
+  private def runMill(buildRootDir: File, millBuildVersion: Option[Version]): F[List[String]] =
+    millBuildVersion match {
+      case Some(v) if v >= Version("0.11") =>
+        val noTicker =
+          if (v >= Version("0.12")) List("--ticker", "false") else List("--disable-ticker")
+        val options =
+          "--no-server" :: noTicker ++ List("--import", cliPluginCoordinate, "show", extractDeps)
+        val command = Nel("mill", options)
+        processAlg.execSandboxed(command, buildRootDir)
+      case _ =>
+        val predef = buildRootDir / "scala-steward.sc"
+        val predefContent = content(millBuildVersion)
+        val command = Nel("mill", List("-i", "-p", predef.toString, "show", extractDeps))
+        fileAlg.createTemporarily(predef, predefContent).surround {
+          processAlg.execSandboxed(command, buildRootDir)
+        }
     }
-  }
 
   override def getDependencies(buildRoot: BuildRoot): F[List[Scope.Dependencies]] =
     for {
@@ -79,9 +82,7 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       millBuildVersion: Option[Version]
   ): F[List[Scope.Dependencies]] =
     for {
-      extracted <-
-        if (isMillVersionGreaterOrEqual011(millBuildVersion)) runMill(buildRootDir)
-        else runMillUnder011(buildRootDir, millBuildVersion)
+      extracted <- runMill(buildRootDir, millBuildVersion)
       parsed <- F.fromEither(
         parser.parseModules(extracted.dropWhile(!_.startsWith("{")).mkString("\n"))
       )
@@ -113,9 +114,6 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
 }
 
 object MillAlg {
-  private[mill] def isMillVersionGreaterOrEqual011(millVersion: Option[Version]): Boolean =
-    millMinVersion(millVersion).flatMap(_.toIntOption).exists(_ >= 11)
-
   private[mill] def millMinVersion(millVersion: Option[Version]): Option[String] =
     millVersion.flatMap(_.value.trim.split("[.]", 3).take(2).lastOption)
 


### PR DESCRIPTION
Running Mill 0.11 with `--ticker=false` (which has been added in #3511) produces the following error:
```
Parsing exception Position 1:9, found "=false"
```
The `--ticker <bool>` option has been added to Mill in 0.12.0 if I'm reading [this commit](https://github.com/com-lihaoyi/mill/commit/0c44ffa3e1c197bef13df66baf452b1bf064433d) correctly. We therefore need to use `--disable-ticker` with Mill 0.11 and `--ticker false` with Mill >= 0.12.