### PR TITLE
Short-circuit when reading `mill-version` files

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -92,13 +92,10 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
     Some("https://github.com/scala-steward-org/scala-steward/issues/2838")
 
   private def getMillVersion(buildRootDir: File): F[Option[Version]] =
-    for {
-      millVersionFileContent <- fileAlg.readFile(buildRootDir / s".$millVersionName")
-      millVersionFileInConfigContent <- fileAlg.readFile(buildRootDir / ".config" / millVersionName)
-      version = millVersionFileContent
-        .orElse(millVersionFileInConfigContent)
-        .flatMap(parser.parseMillVersion)
-    } yield version
+    List(
+      buildRootDir / s".$millVersionName",
+      buildRootDir / ".config" / millVersionName
+    ).collectFirstSomeM(fileAlg.readFile).map(_.flatMap(parser.parseMillVersion))
 
   private def getMillPluginDeps(
       millVersion: Version,

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -57,7 +57,6 @@ class MillAlgTest extends FunSuite {
     val expected = initial.copy(
       trace = Vector(
         Cmd("read", s"$repoDir/.mill-version"),
-        Cmd("read", s"$repoDir/.config/mill-version"),
         millCmd,
         Cmd("read", s"$repoDir/build.sc")
       )


### PR DESCRIPTION
If a `.mill-version` exists there is no need to also read `.config/mill-version` and then discard its content.