### PR TITLE
Use `allowOrDefault` in `UpdatesConfig.isAllowed`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -79,7 +79,7 @@ final case class UpdatesConfig(
     val m = UpdatePattern.findMatch(allowOrDefault, update, include = true)
     if (m.filteredVersions.nonEmpty)
       Right(update.copy(newerVersions = Nel.fromListUnsafe(m.filteredVersions)))
-    else if (allow.isEmpty)
+    else if (allowOrDefault.isEmpty)
       Right(update)
     else Left(NotAllowedByConfig(update))
   }


### PR DESCRIPTION
I forgot to update this reference in #3515. This is a subtle change in semantics. If `allow == Some(Nil)`  `allow.isEmpty` is `false` and `allowOrDefault.isEmpty` is `true`.