### PR TITLE
Skip inactive repos

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -201,6 +201,10 @@ reviewers = [ "username1", "username2" ]
 # If true, Scala Steward will sign off all commits (e.g. `git --signoff`).
 # Default: false
 signoffCommits = true
+
+# Repos whose last commit is older than this threshold are considered
+# inactive and are ignored.
+inactivityThreshold = "90 days"
 ```
 
 The version information given in the patterns above can be in two formats:

--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -4,6 +4,9 @@
 //   Changes to this file are therefore immediately visible to all
 //   Scala Steward instances.
 
+// Repos whose last commit is older than this threshold are considered
+// inactive and are ignored. This setting can be overridden with a greater
+// value in your own repo config file.
 inactivityThreshold = "270 days"
 
 postUpdateHooks = [

--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -4,7 +4,7 @@
 //   Changes to this file are therefore immediately visible to all
 //   Scala Steward instances.
 
-lastCommitMaxAge = "540 days"
+inactivityThreshold = "270 days"
 
 postUpdateHooks = [
   {

--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -4,6 +4,8 @@
 //   Changes to this file are therefore immediately visible to all
 //   Scala Steward instances.
 
+lastCommitMaxAge = "540 days"
+
 postUpdateHooks = [
   {
     groupId = "com.github.liancheng",

--- a/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/FileGitAlg.scala
@@ -26,7 +26,6 @@ import org.scalasteward.core.git.FileGitAlg.{dotdot, gitCmd}
 import org.scalasteward.core.io.process.{ProcessFailedException, SlurpOptions}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.{Nel, Timestamp}
-import scala.util.Try
 
 final class FileGitAlg[F[_]](config: Config)(implicit
     fileAlg: FileAlg[F],
@@ -105,7 +104,7 @@ final class FileGitAlg[F[_]](config: Config)(implicit
 
   override def getCommitDate(repo: File, sha1: Sha1): F[Timestamp] =
     git("show", "--no-patch", "--format=%ct", sha1.value.value)(repo)
-      .flatMap(out => F.fromTry(Try(out.mkString.trim.toLong)))
+      .flatMap(out => F.catchNonFatal(out.mkString.trim.toLong))
       .map(Timestamp.fromEpochSecond)
 
   override def hasConflicts(repo: File, branch: Branch, base: Branch): F[Boolean] = {

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GenGitAlg.scala
@@ -22,6 +22,7 @@ import cats.{FlatMap, Monad}
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.util.Timestamp
 
 trait GenGitAlg[F[_], Repo] {
   def add(repo: Repo, file: String): F[Unit]
@@ -56,6 +57,8 @@ trait GenGitAlg[F[_], Repo] {
   def discardChanges(repo: Repo): F[Unit]
 
   def findFilesContaining(repo: Repo, string: String): F[List[String]]
+
+  def getCommitDate(repo: Repo, sha1: Sha1): F[Timestamp]
 
   /** Returns `true` if merging `branch` into `base` results in merge conflicts. */
   def hasConflicts(repo: Repo, branch: Branch, base: Branch): F[Boolean]
@@ -143,6 +146,9 @@ trait GenGitAlg[F[_], Repo] {
 
       override def findFilesContaining(repo: A, string: String): F[List[String]] =
         f(repo).flatMap(self.findFilesContaining(_, string))
+
+      override def getCommitDate(repo: A, sha1: Sha1): F[Timestamp] =
+        f(repo).flatMap(self.getCommitDate(_, sha1))
 
       override def hasConflicts(repo: A, branch: Branch, base: Branch): F[Boolean] =
         f(repo).flatMap(self.hasConflicts(_, branch, base))

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -22,9 +22,11 @@ import io.circe.generic.semiauto.*
 import org.scalasteward.core.data.{ArtifactId, DependencyInfo, GroupId, Scope}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.util.Timestamp
 
 final case class RepoCache(
     sha1: Sha1,
+    commitDate: Timestamp,
     dependencyInfos: List[Scope[List[DependencyInfo]]],
     maybeRepoConfig: Option[RepoConfig],
     maybeRepoConfigParsingError: Option[String]

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -41,7 +41,7 @@ final case class RepoConfig(
     private val reviewers: Option[List[String]] = None,
     private val dependencyOverrides: Option[List[GroupRepoConfig]] = None,
     signoffCommits: Option[Boolean] = None,
-    lastCommitMaxAge: Option[FiniteDuration] = None
+    inactivityThreshold: Option[FiniteDuration] = None
 ) {
   def commitsOrDefault: CommitsConfig =
     commits.getOrElse(CommitsConfig())
@@ -112,7 +112,8 @@ object RepoConfig {
               reviewers = x.reviewers |+| y.reviewers,
               dependencyOverrides = x.dependencyOverrides |+| y.dependencyOverrides,
               signoffCommits = x.signoffCommits.orElse(y.signoffCommits),
-              lastCommitMaxAge = combineOptions(x.lastCommitMaxAge, y.lastCommitMaxAge)(_ max _)
+              inactivityThreshold =
+                combineOptions(x.inactivityThreshold, y.inactivityThreshold)(_ max _)
             )
         }
     )

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -25,6 +25,9 @@ import org.scalasteward.core.buildtool.BuildRoot
 import org.scalasteward.core.data.Repo
 import org.scalasteward.core.edit.hooks.PostUpdateHook
 import org.scalasteward.core.repoconfig.RepoConfig.defaultBuildRoots
+import org.scalasteward.core.util.dateTime.*
+import org.scalasteward.core.util.{combineOptions, intellijThisImportIsUsed}
+import scala.concurrent.duration.FiniteDuration
 
 final case class RepoConfig(
     private val commits: Option[CommitsConfig] = None,
@@ -37,7 +40,8 @@ final case class RepoConfig(
     private val assignees: Option[List[String]] = None,
     private val reviewers: Option[List[String]] = None,
     private val dependencyOverrides: Option[List[GroupRepoConfig]] = None,
-    signoffCommits: Option[Boolean] = None
+    signoffCommits: Option[Boolean] = None,
+    lastCommitMaxAge: Option[FiniteDuration] = None
 ) {
   def commitsOrDefault: CommitsConfig =
     commits.getOrElse(CommitsConfig())
@@ -107,8 +111,11 @@ object RepoConfig {
               assignees = x.assignees |+| y.assignees,
               reviewers = x.reviewers |+| y.reviewers,
               dependencyOverrides = x.dependencyOverrides |+| y.dependencyOverrides,
-              signoffCommits = x.signoffCommits.orElse(y.signoffCommits)
+              signoffCommits = x.signoffCommits.orElse(y.signoffCommits),
+              lastCommitMaxAge = combineOptions(x.lastCommitMaxAge, y.lastCommitMaxAge)(_ max _)
             )
         }
     )
+
+  intellijThisImportIsUsed(finiteDurationEncoder)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -34,6 +34,9 @@ final case class Timestamp(millis: Long) {
 }
 
 object Timestamp {
+  def fromEpochSecond(seconds: Long): Timestamp =
+    Timestamp(seconds * 1000L)
+
   def fromLocalDateTime(ldt: LocalDateTime): Timestamp =
     Timestamp(ldt.toInstant(ZoneOffset.UTC).toEpochMilli)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -17,6 +17,7 @@
 package org.scalasteward.core.util
 
 import cats.syntax.all.*
+import io.circe.{Decoder, Encoder}
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.concurrent.duration.*
@@ -30,6 +31,12 @@ object dateTime {
 
   def renderFiniteDuration(fd: FiniteDuration): String =
     fd.toString.filterNot(_.isSpaceChar)
+
+  implicit val finiteDurationDecoder: Decoder[FiniteDuration] =
+    Decoder[String].emap(parseFiniteDuration(_).leftMap(_.getMessage))
+
+  implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
+    Encoder[String].contramap(renderFiniteDuration)
 
   def showDuration(d: FiniteDuration): String = {
     def symbol(unit: TimeUnit): String =

--- a/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/dateTime.scala
@@ -36,7 +36,7 @@ object dateTime {
     Decoder[String].emap(parseFiniteDuration(_).leftMap(_.getMessage))
 
   implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
-    Encoder[String].contramap(renderFiniteDuration)
+    Encoder[String].contramap(_.toString)
 
   def showDuration(d: FiniteDuration): String = {
     def symbol(unit: TimeUnit): String =

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -10,6 +10,7 @@ import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.repocache.RepoCache
 import org.scalasteward.core.repoconfig.*
 import org.scalasteward.core.repoconfig.PullRequestFrequency.{Asap, Timespan}
+import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration.FiniteDuration
@@ -19,10 +20,13 @@ object TestInstances {
     Sha1.unsafeFrom("da39a3ee5e6b4b0d3255bfef95601890afd80709")
 
   val dummyRepoCache: RepoCache =
-    RepoCache(dummySha1, List.empty, Option.empty, Option.empty)
+    RepoCache(dummySha1, Timestamp(0L), List.empty, Option.empty, Option.empty)
 
   val dummyRepoCacheWithParsingError: RepoCache =
     dummyRepoCache.copy(maybeRepoConfigParsingError = Some("Failed to parse .scala-steward.conf"))
+
+  val ioDateTimeAlg: DateTimeAlg[IO] =
+    DateTimeAlg.create[IO]
 
   implicit val ioLogger: Logger[IO] =
     Slf4jLogger.getLogger[IO]

--- a/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/processTest.scala
@@ -3,8 +3,9 @@ package org.scalasteward.core.io
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import munit.FunSuite
+import org.scalasteward.core.TestInstances.ioDateTimeAlg
 import org.scalasteward.core.io.process.*
-import org.scalasteward.core.util.{DateTimeAlg, Nel}
+import org.scalasteward.core.util.Nel
 import scala.concurrent.duration.*
 
 class processTest extends FunSuite {
@@ -66,7 +67,7 @@ class processTest extends FunSuite {
     val timeout = 500.milliseconds
     val sleep = timeout * 2
     val p = slurp2(Nel.of("sleep", sleep.toSeconds.toInt.toString), timeout).attempt
-    val (Left(t), fd) = DateTimeAlg.create[IO].timed(p).unsafeRunSync(): @unchecked
+    val (Left(t), fd) = ioDateTimeAlg.timed(p).unsafeRunSync(): @unchecked
 
     assert(clue(t).isInstanceOf[ProcessTimedOutException])
     assert(clue(fd) > timeout)

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
@@ -60,32 +60,32 @@ class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     assertIO(obtained, expected)
   }
 
-  test("throwIfAbandoned: no maxAge") {
+  test("throwIfInactive: no maxAge") {
     val repo = Repo("repo-cache-alg", "test-1")
     val cache = RepoCache(dummySha1, Timestamp(0L), Nil, None, None)
     val config = RepoConfig.empty
     val data = RepoData(repo, cache, config)
-    val obtained = repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt
+    val obtained = repoCacheAlg.throwIfInactive(data).runA(MockState.empty).attempt
     assertIO(obtained, Right(()))
   }
 
-  test("throwIfAbandoned: lastCommit < maxAge") {
+  test("throwIfInactive: lastCommit < maxAge") {
     val repo = Repo("repo-cache-alg", "test-2")
     val commitDate = Timestamp.fromLocalDateTime(LocalDateTime.now())
     val cache = RepoCache(dummySha1, commitDate, Nil, None, None)
     val config = RepoConfig(lastCommitMaxAge = Some(1.day))
     val data = RepoData(repo, cache, config)
-    val obtained = repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt
+    val obtained = repoCacheAlg.throwIfInactive(data).runA(MockState.empty).attempt
     assertIO(obtained, Right(()))
   }
 
-  test("throwIfAbandoned: lastCommit > maxAge") {
+  test("throwIfInactive: lastCommit > maxAge") {
     val repo = Repo("repo-cache-alg", "test-3")
     val cache = RepoCache(dummySha1, Timestamp(0L), Nil, None, None)
     val config = RepoConfig(lastCommitMaxAge = Some(1.day))
     val data = RepoData(repo, cache, config)
     val obtained =
-      repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt.map(_.leftMap(_.getMessage))
+      repoCacheAlg.throwIfInactive(data).runA(MockState.empty).attempt.map(_.leftMap(_.getMessage))
     assertIO(obtained, Left("Skipping because last commit is older than 1d"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repocache/RepoCacheAlgTest.scala
@@ -1,7 +1,8 @@
 package org.scalasteward.core.repocache
 
-import cats.implicits.toSemigroupKOps
+import cats.syntax.all.*
 import io.circe.syntax.*
+import java.time.LocalDateTime
 import munit.CatsEffectSuite
 import org.http4s.HttpApp
 import org.http4s.circe.*
@@ -14,7 +15,9 @@ import org.scalasteward.core.forge.github.Repository
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.mock.MockContext.context.{repoCacheAlg, repoConfigAlg, workspaceAlg}
 import org.scalasteward.core.mock.{GitHubAuth, MockEff, MockEffOps, MockState}
-import org.scalasteward.core.util.intellijThisImportIsUsed
+import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.util.{intellijThisImportIsUsed, Timestamp}
+import scala.concurrent.duration.*
 
 class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   intellijThisImportIsUsed(encodeUri)
@@ -36,7 +39,8 @@ class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
       uri"https://github.com/scala-steward/cats-effect.git",
       Branch("main")
     )
-    val repoCache = RepoCache(dummySha1, Nil, None, None)
+    val now = Timestamp.fromLocalDateTime(LocalDateTime.now())
+    val repoCache = RepoCache(dummySha1, now, Nil, None, None)
     val workspace = workspaceAlg.rootDir.unsafeRunSync()
     val httpApp = HttpApp[MockEff] {
       case POST -> Root / "repos" / "typelevel" / "cats-effect" / "forks" =>
@@ -54,5 +58,34 @@ class RepoCacheAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     val obtained = state.flatMap(repoCacheAlg.checkCache(repo).runA)
     val expected = (RepoData(repo, repoCache, repoConfigAlg.mergeWithGlobal(None)), repoOut)
     assertIO(obtained, expected)
+  }
+
+  test("throwIfAbandoned: no maxAge") {
+    val repo = Repo("repo-cache-alg", "test-1")
+    val cache = RepoCache(dummySha1, Timestamp(0L), Nil, None, None)
+    val config = RepoConfig.empty
+    val data = RepoData(repo, cache, config)
+    val obtained = repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt
+    assertIO(obtained, Right(()))
+  }
+
+  test("throwIfAbandoned: lastCommit < maxAge") {
+    val repo = Repo("repo-cache-alg", "test-2")
+    val commitDate = Timestamp.fromLocalDateTime(LocalDateTime.now())
+    val cache = RepoCache(dummySha1, commitDate, Nil, None, None)
+    val config = RepoConfig(lastCommitMaxAge = Some(1.day))
+    val data = RepoData(repo, cache, config)
+    val obtained = repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt
+    assertIO(obtained, Right(()))
+  }
+
+  test("throwIfAbandoned: lastCommit > maxAge") {
+    val repo = Repo("repo-cache-alg", "test-3")
+    val cache = RepoCache(dummySha1, Timestamp(0L), Nil, None, None)
+    val config = RepoConfig(lastCommitMaxAge = Some(1.day))
+    val data = RepoData(repo, cache, config)
+    val obtained =
+      repoCacheAlg.throwIfAbandoned(data).runA(MockState.empty).attempt.map(_.leftMap(_.getMessage))
+    assertIO(obtained, Left("Skipping because last commit is older than 1d"))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -21,6 +21,7 @@ class PruningAlgTest extends FunSuite {
     val Right(repoCache) = decode[RepoCache](
       s"""|{
           |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "commitDate": 0,
           |  "dependencyInfos": [],
           |  "maybeRepoConfig": {
           |    "pullRequests": {
@@ -79,6 +80,7 @@ class PruningAlgTest extends FunSuite {
     val Right(repoCache) = decode[RepoCache](
       s"""|{
           |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "commitDate": 0,
           |  "dependencyInfos" : [
           |    {
           |      "value" : [
@@ -218,6 +220,7 @@ class PruningAlgTest extends FunSuite {
     val Right(repoCache) = decode[RepoCache](
       s"""|{
           |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "commitDate": 0,
           |  "dependencyInfos" : [
           |    {
           |      "value" : [
@@ -330,6 +333,7 @@ class PruningAlgTest extends FunSuite {
     val Right(repoCache) = decode[RepoCache](
       s"""|{
           |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "commitDate": 0,
           |  "dependencyInfos" : [
           |    {
           |      "value" : [
@@ -441,6 +445,7 @@ class PruningAlgTest extends FunSuite {
     val Right(repoCache) = decode[RepoCache](
       s"""|{
           |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "commitDate": 0,
           |  "dependencyInfos" : [
           |    {
           |      "value" : [

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -206,6 +206,10 @@ reviewers = [ "username1", "username2" ]
 # If true, Scala Steward will sign off all commits (e.g. `git --signoff`).
 # Default: false
 signoffCommits = true
+
+# Repos whose last commit is older than this threshold are considered
+# inactive and are ignored.
+inactivityThreshold = "90 days"
 """
 
 DocChecker.verifyParsedEqualsEncoded[RepoConfig](input)


### PR DESCRIPTION
This implements the idea proposed in #3554 to stop creating wasted PRs by skipping repos whose last commit is older than a configured threshold. The PR contains these changes:
* a new `GitAlg.getCommitDate` which returns the commit date as `Timestamp` of a given SHA-1
* a new `RepoCache.commitDate: Timestamp` field that contains the commit date that corresponds to `RepoCache.sha1`
* a new `RepoConfig.lastCommitMaxAge: Option[FiniteDuration]` field that contains the threshold for deciding if a repo should be skipped. A repo is skipped, if the last commit is greater than this `FiniteDuration`.
* a default `lastCommitMaxAge` is added to the default Scala Steward config. Other Scala Steward instances and every repo can override this with a greater value. It is not possible to unset it or override it with a smaller value.
* `RepoCache.checkCache` is modified such that after retrieving a fresh cache, the commit date is compared to `lastCommitMaxAge` and an error is raised eventually

Notes:
* The addition of a non optional field to `RepoCache` means that reading an old cache will log an error like this:
```
2025-01-20 21:16:44,985 ERROR Failed to parse or decode JSON from workspace/store/repo_cache/v1/github/scala-steward-org/test-repo-1/repo_cache.json
io.circe.DecodingFailure$DecodingFailureImpl: DecodingFailure at .commitDate: Missing required field
```
Fortunately this is only a log message so that Scala Steward will recompute the `RepoCache` and proceed as normal then. Adding this field is therefore effectively invalidating all `RepoCache`s out there.

* A skipped repo looks like this in the log:
```
2025-01-21 08:35:25,033 INFO  ──────────── Steward scala-steward-org/test-repo-1:scala-cli-test ────────────
2025-01-21 08:35:25,033 INFO  Check cache of scala-steward-org/test-repo-1:scala-cli-test
2025-01-21 08:35:25,738 ERROR Steward scala-steward-org/test-repo-1:scala-cli-test failed
org.scalasteward.core.repocache.RepoCacheAlg$$anon$1: Skipping because last commit is older than 2d
2025-01-21 08:35:25,738 INFO  ──────────── Total time: Steward scala-steward-org/test-repo-1:scala-cli-test: 705ms ────────────
```
`lastCommitMaxAge` was set to 2 days in this case.

Closes: #3554