### PR TITLE
Rewrite `RepoCacheAlg.checkCache` as for-comprehension

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -35,12 +35,12 @@ final class RefreshErrorAlg[F[_]](
     dateTimeAlg: DateTimeAlg[F],
     F: MonadThrow[F]
 ) {
-  def skipIfFailedRecently[A](repo: Repo)(fa: F[A]): F[A] =
+  def throwIfFailedRecently(repo: Repo): F[Unit] =
     failedRecently(repo).flatMap {
-      case None => fa
+      case None => F.unit
       case Some(fd) =>
         val msg = s"Skipping due to previous error for ${showDuration(fd)}"
-        F.raiseError[A](new Throwable(msg) with NoStackTrace)
+        F.raiseError(new Throwable(msg) with NoStackTrace)
     }
 
   def persistError[A](repo: Repo)(fa: F[A]): F[A] =


### PR DESCRIPTION
This is a small refactoring that rewrites `checkCache` as for-comprehension which I think is a little bit easier to read. It also removes the second parameter from `skipIfFailedRecently` which was a needless complication.