### PR TITLE
Don't exclude `warnUnusedPatVars` compiler option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,6 @@ ThisBuild / evictionErrorLevel := Level.Info
 ThisBuild / tpolecatDefaultOptionsMode := {
   if (insideCI.value) org.typelevel.sbt.tpolecat.CiMode else org.typelevel.sbt.tpolecat.DevMode
 }
-ThisBuild / tpolecatExcludeOptions += ScalacOptions.warnUnusedPatVars // https://github.com/scala/bug/issues/13041
 
 /// projects
 


### PR DESCRIPTION
This is not necessary anymore with Scala 2.13.16.