### PR TITLE
Support multiple default resolvers

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -4,7 +4,7 @@ All command line arguments for the `scala-steward` application.
 
 ```
 Usage:
-    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--signoff] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>] [--refresh-backoff-period <duration>] [--exit-code-success-if-any-repo-succeeds]
+    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--signoff] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>]... [--refresh-backoff-period <duration>] [--exit-code-success-if-any-repo-succeeds]
     scala-steward validate-repo-config
 
 
@@ -87,7 +87,7 @@ Options and flags:
     --url-checker-test-url <uri>
         URL for testing the UrlChecker at start-up (can be used multiple times); default: https://github.com
     --default-maven-repo <string>
-        default: https://repo1.maven.org/maven2/
+        (can be used multiple times); default: https://repo1.maven.org/maven2/
     --refresh-backoff-period <duration>
         Period of time a failed build won't be triggered again; default: 0days
     --exit-code-success-if-any-repo-succeeds

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -316,11 +316,13 @@ object Cli {
     ).withDefault(Nel.one(default))
   }
 
-  private val defaultMavenRepo: Opts[Resolver] = {
+  private val defaultMavenRepos: Opts[List[Resolver]] = {
     val default = Resolver.mavenCentral
-    option[String]("default-maven-repo", s"default: ${default.location}")
-      .map(location => Resolver.MavenRepository("default", location, None, None))
-      .withDefault(default)
+    options[String]("default-maven-repo", s"$multiple; default: ${default.location}")
+      .map(_.toList.zipWithIndex.map { case (location, i) =>
+        Resolver.MavenRepository(s"default-$i", location, None, None)
+      })
+      .withDefault(List(default))
   }
 
   private val exitCodePolicy: Opts[ExitCodePolicy] = flag(
@@ -347,7 +349,7 @@ object Cli {
     azureReposCfg,
     gitHubApp,
     urlCheckerTestUrls,
-    defaultMavenRepo,
+    defaultMavenRepos,
     refreshBackoffPeriod,
     exitCodePolicy
   ).mapN(Config.apply).map(Usage.Regular.apply)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -62,7 +62,7 @@ final case class Config(
     azureReposCfg: AzureReposCfg,
     githubApp: Option[GitHubApp],
     urlCheckerTestUrls: Nel[Uri],
-    defaultResolver: Resolver,
+    defaultResolvers: List[Resolver],
     refreshBackoffPeriod: FiniteDuration,
     exitCodePolicy: ExitCodePolicy
 ) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -172,17 +172,18 @@ object Context {
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](pullRequestsStore)
       implicit val scalafixCli: ScalafixCli[F] = new ScalafixCli[F]
-      implicit val scalafmtAlg: ScalafmtAlg[F] = new ScalafmtAlg[F](config.defaultResolver)
+      implicit val scalafmtAlg: ScalafmtAlg[F] = new ScalafmtAlg[F](config.defaultResolvers)
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F](config)
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create[F]
       implicit val versionsCache: VersionsCache[F] =
         new VersionsCache[F](config.cacheTtl, versionsStore)
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
-      implicit val gradleAlg: GradleAlg[F] = new GradleAlg[F](config.defaultResolver)
+      implicit val gradleAlg: GradleAlg[F] = new GradleAlg[F](config.defaultResolvers)
       implicit val mavenAlg: MavenAlg[F] = new MavenAlg[F](config)
-      implicit val sbtAlg: SbtAlg[F] = new SbtAlg[F](config)
+      implicit val sbtAlg: SbtAlg[F] =
+        new SbtAlg[F](config.defaultResolvers, config.ignoreOptsFiles)
       implicit val scalaCliAlg: ScalaCliAlg[F] = new ScalaCliAlg[F]
-      implicit val millAlg: MillAlg[F] = new MillAlg[F](config.defaultResolver)
+      implicit val millAlg: MillAlg[F] = new MillAlg[F](config.defaultResolvers)
       implicit val buildToolDispatcher: BuildToolDispatcher[F] = new BuildToolDispatcher[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
         new RefreshErrorAlg[F](refreshErrorStore, config.refreshBackoffPeriod)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/gradle/GradleAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/gradle/GradleAlg.scala
@@ -25,7 +25,7 @@ import org.scalasteward.core.data.{Resolver, Scope}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.typelevel.log4cats.Logger
 
-final class GradleAlg[F[_]](defaultResolver: Resolver)(implicit
+final class GradleAlg[F[_]](defaultResolvers: List[Resolver])(implicit
     fileAlg: FileAlg[F],
     override protected val logger: Logger[F],
     workspaceAlg: WorkspaceAlg[F],
@@ -42,7 +42,7 @@ final class GradleAlg[F[_]](defaultResolver: Resolver)(implicit
       .map(_.getOrElse(""))
       .map(gradleParser.parseDependenciesAndPlugins)
       .map { case (dependencies, plugins) =>
-        val ds = Option.when(dependencies.nonEmpty)(Scope(dependencies, List(defaultResolver)))
+        val ds = Option.when(dependencies.nonEmpty)(Scope(dependencies, defaultResolvers))
         val ps = Option.when(plugins.nonEmpty)(Scope(plugins, List(pluginsResolver)))
         ds.toList ++ ps.toList
       }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -26,7 +26,7 @@ import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
+final class MillAlg[F[_]](defaultResolvers: List[Resolver])(implicit
     fileAlg: FileAlg[F],
     override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
@@ -67,7 +67,7 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       millBuildVersion <- getMillVersion(buildRootDir)
       dependencies <- getProjectDependencies(buildRootDir, millBuildVersion)
       millBuildDeps = millBuildVersion.toSeq.map(version =>
-        Scope(List(millMainArtifact(version)), List(defaultResolver))
+        Scope(List(millMainArtifact(version)), defaultResolvers)
       )
       millPluginDeps <- millBuildVersion match {
         case None        => F.pure(Seq.empty[Scope[List[Dependency]]])
@@ -104,7 +104,7 @@ final class MillAlg[F[_]](defaultResolver: Resolver)(implicit
       buildFile <- findBuildFile(buildRootDir)
       buildContent <- buildFile.flatTraverse(fileAlg.readFile)
       deps = buildContent.toList.map(content =>
-        Scope(parser.parseMillPluginDeps(content, millVersion), List(defaultResolver))
+        Scope(parser.parseMillPluginDeps(content, millVersion), defaultResolvers)
       )
     } yield deps
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -20,18 +20,17 @@ import better.files.File
 import cats.data.OptionT
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all.*
-import org.scalasteward.core.application.Config
 import org.scalasteward.core.buildtool.sbt.command.*
 import org.scalasteward.core.buildtool.{BuildRoot, BuildToolAlg}
 import org.scalasteward.core.coursier.VersionsCache
-import org.scalasteward.core.data.{Dependency, Scope, Version}
+import org.scalasteward.core.data.{Dependency, Resolver, Scope, Version}
 import org.scalasteward.core.edit.scalafix.{ScalafixCli, ScalafixMigration}
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class SbtAlg[F[_]](config: Config)(implicit
+final class SbtAlg[F[_]](defaultResolvers: List[Resolver], ignoreOptsFiles: Boolean)(implicit
     fileAlg: FileAlg[F],
     override protected val logger: Logger[F],
     processAlg: ProcessAlg[F],
@@ -100,7 +99,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
   }
 
   private def scopedSbtDependency(sbtVersion: Version): Option[Scope[Dependency]] =
-    sbtDependency(sbtVersion).map(dep => Scope(dep, List(config.defaultResolver)))
+    sbtDependency(sbtVersion).map(dep => Scope(dep, defaultResolvers))
 
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     migration.targetOrDefault match {
@@ -128,7 +127,7 @@ final class SbtAlg[F[_]](config: Config)(implicit
 
   private def latestSbtScalafixVersion: F[Option[Version]] =
     versionsCache
-      .getVersions(Scope(sbtScalafixDependency, List(config.defaultResolver)), None)
+      .getVersions(Scope(sbtScalafixDependency, defaultResolvers), None)
       .map(_.lastOption)
 
   private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
@@ -163,10 +162,10 @@ final class SbtAlg[F[_]](config: Config)(implicit
     }
 
   private def maybeIgnoreOptsFiles(dir: File): Resource[F, Unit] =
-    if (config.ignoreOptsFiles) ignoreOptsFiles(dir) else Resource.unit[F]
-
-  private def ignoreOptsFiles(dir: File): Resource[F, Unit] =
-    List(".jvmopts", ".sbtopts").traverse_(file => fileAlg.removeTemporarily(dir / file))
+    if (ignoreOptsFiles)
+      List(".jvmopts", ".sbtopts").traverse_(file => fileAlg.removeTemporarily(dir / file))
+    else
+      Resource.unit[F]
 
   private val project = "project"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -28,7 +28,7 @@ import org.scalasteward.core.scalafmt.ScalafmtAlg.{opts, parseScalafmtConf}
 import org.scalasteward.core.util.Nel
 import org.typelevel.log4cats.Logger
 
-final class ScalafmtAlg[F[_]](defaultResolver: Resolver)(implicit
+final class ScalafmtAlg[F[_]](defaultResolvers: List[Resolver])(implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
     processAlg: ProcessAlg[F],
@@ -48,7 +48,7 @@ final class ScalafmtAlg[F[_]](defaultResolver: Resolver)(implicit
 
   def getScopedScalafmtDependency(buildRoot: BuildRoot): F[Option[Scope.Dependencies]] =
     OptionT(getScalafmtVersion(buildRoot))
-      .map(version => Scope(List(scalafmtDependency(version)), List(defaultResolver)))
+      .map(version => Scope(List(scalafmtDependency(version)), defaultResolvers))
       .value
 
   def reformatChanged(buildRoot: BuildRoot): F[Unit] =


### PR DESCRIPTION
The default resolver - which is Maven Central if none is provided by the `--default-maven-repo` option - is now used in multiple places where a list of resolvers is expected. It feels like an arbitrary restriction that we only allow one resolver and always wrap that in a list everywhere we use it. Why not allow `--default-maven-repo` to be a repeating option instead so that `Config` has a `List[Resolver]`. This PR does exactly that. It could be useful if a user wants to resolve Scalafmt via resolver A and Gradle dependencies via resolver B for example.