### PR TITLE
Make maximum Pull Request length configurable

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -49,6 +49,8 @@ sealed trait ForgeType extends Product with Serializable {
     */
   def pullRequestHeadFor(@nowarn fork: Repo, updateBranch: Branch): String = updateBranch.name
 
+  val maximumPullRequestLength: Int = 65536
+
   val asString: String = this match {
     case AzureRepos      => "azure-repos"
     case Bitbucket       => "bitbucket"
@@ -66,6 +68,7 @@ object ForgeType {
   case object AzureRepos extends ForgeType {
     override val publicWebHost: Some[String] = Some("dev.azure.com")
     override def supportsForking: Boolean = false
+    override val maximumPullRequestLength: Int = 4000
     val diffs: DiffUriPattern = (from, to) =>
       _ / "branchCompare" +? ("baseVersion", s"GT$from") +? ("targetVersion", s"GT$to")
     val files: FileUriPattern =
@@ -93,6 +96,7 @@ object ForgeType {
     override val publicWebHost: None.type = None
     override def supportsForking: Boolean = false
     override def supportsLabels: Boolean = false
+    override val maximumPullRequestLength: Int = 32768
     val diffs: DiffUriPattern = Bitbucket.diffs
     val files: FileUriPattern = fileName => _ / "browse" / fileName
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -49,7 +49,8 @@ object NewPullRequestData {
       artifactIdToUpdateInfoUrls: Map[String, List[UpdateInfoUrl]],
       filesWithOldVersion: List[String],
       configParsingError: Option[String],
-      labels: List[String]
+      labels: List[String],
+      maximumPullRequestLength: Int
   ): String = {
     val migrations = edits.collect { case scalafixEdit: ScalafixEdit => scalafixEdit }
     val appliedMigrations = migrationNote(migrations)
@@ -129,8 +130,7 @@ object NewPullRequestData {
          |
          |<!-- scala-steward = $metadataJson -->""".stripMargin
 
-    // Github limits PR descriptions to 65536 unicode characters
-    if (bodyWithMetadata.length < 65536)
+    if (bodyWithMetadata.length < maximumPullRequestLength)
       bodyWithMetadata
     else plainBody
   }
@@ -264,7 +264,8 @@ object NewPullRequestData {
       artifactIdToUpdateInfoUrls: Map[String, List[UpdateInfoUrl]] = Map.empty,
       filesWithOldVersion: List[String] = List.empty,
       addLabels: Boolean = false,
-      labels: List[String] = List.empty
+      labels: List[String] = List.empty,
+      maximumPullRequestLength: Int = 65536
   ): NewPullRequestData =
     NewPullRequestData(
       title = CommitMsg
@@ -280,7 +281,8 @@ object NewPullRequestData {
         artifactIdToUpdateInfoUrls,
         filesWithOldVersion,
         data.repoData.cache.maybeRepoConfigParsingError,
-        labels
+        labels,
+        maximumPullRequestLength
       ),
       head = branchName,
       base = data.baseBranch,

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -241,7 +241,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       artifactIdToUpdateInfoUrls = artifactIdToUpdateInfoUrls.toMap,
       filesWithOldVersion = filesWithOldVersion,
       addLabels = config.addLabels,
-      labels = data.repoData.config.pullRequestsOrDefault.customLabelsOrDefault ++ labels
+      labels = data.repoData.config.pullRequestsOrDefault.customLabelsOrDefault ++ labels,
+      maximumPullRequestLength = config.tpe.maximumPullRequestLength
     )
 
   private def createPullRequest(data: UpdateData, edits: List[EditAttempt]): F[ProcessResult] =

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -25,7 +25,8 @@ class NewPullRequestDataTest extends FunSuite {
       artifactIdToUpdateInfoUrls = Map.empty,
       filesWithOldVersion = List.empty,
       configParsingError = None,
-      labels = List("library-update")
+      labels = List("library-update"),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR
@@ -114,7 +115,8 @@ class NewPullRequestDataTest extends FunSuite {
       artifactIdToUpdateInfoUrls = Map.empty,
       filesWithOldVersion = List.empty,
       configParsingError = None,
-      labels = List("library-update")
+      labels = List("library-update"),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR
@@ -200,7 +202,8 @@ class NewPullRequestDataTest extends FunSuite {
       artifactIdToUpdateInfoUrls = Map.empty,
       filesWithOldVersion = List.empty,
       configParsingError = None,
-      labels = List("library-update")
+      labels = List("library-update"),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR
@@ -320,7 +323,8 @@ class NewPullRequestDataTest extends FunSuite {
       artifactIdToUpdateInfoUrls = Map.empty,
       filesWithOldVersion = List.empty,
       configParsingError = Some("parsing error"),
-      labels = List("library-update")
+      labels = List("library-update"),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR
@@ -1004,7 +1008,8 @@ class NewPullRequestDataTest extends FunSuite {
         "early-semver-major",
         "semver-spec-minor",
         "commit-count:1"
-      )
+      ),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR
@@ -1089,7 +1094,8 @@ class NewPullRequestDataTest extends FunSuite {
         "early-semver-major",
         "semver-spec-minor",
         "commit-count:1"
-      )
+      ),
+      maximumPullRequestLength = 65536
     )
     val expected =
       s"""|## About this PR


### PR DESCRIPTION
Depending on the used forge the size of the description of a Pull Request differs. With the additional metadata this limit can be easily exceeded.

This Pull Request sets the allowed length to:
* global default: 65536
* Azure: 4000
* BitbucketServer: 32768

Closes: #3543