### PR TITLE
Use modern syntax for `dependency:` Scalafix rules

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -79,7 +79,7 @@ migrations = [
     groupId: "com.typesafe.akka",
     artifactIds: ["akka-http.*"],
     newVersion: "10.2.0",
-    rewriteRules: ["dependency:MigrateToServerBuilder@com.typesafe.akka:akka-http-scalafix-rules:10.2.0"],
+    rewriteRules: ["dependency:MigrateToServerBuilder@com.typesafe.akka::akka-http-scalafix-rules:10.2.0"],
     doc: "https://doc.akka.io/docs/akka-http/10.2/migration-guide/migration-guide-10.2.x.html#akka-http-10-1-x-10-2-0"
   },
   {
@@ -112,7 +112,7 @@ migrations = [
     groupId: "org.http4s",
     artifactIds: ["http4s-.*"],
     newVersion: "0.21.5",
-    rewriteRules: ["dependency:v0_21@org.http4s:http4s-scalafix:0.21.5"],
+    rewriteRules: ["dependency:v0_21@org.http4s::http4s-scalafix:0.21.5"],
     doc: "https://github.com/http4s/http4s/releases/tag/v0.21.5"
   },
   {
@@ -216,7 +216,7 @@ migrations = [
     groupId: "io.catbird",
     artifactIds: ["catbird-effect", "catbird-effect3", "catbird-finagle", "catbird-util"],
     newVersion: "22.4.0",
-    rewriteRules: ["dependency:RenameIoCatbirdPackage@org.typelevel:catbird-scalafix:22.4.0"]
+    rewriteRules: ["dependency:RenameIoCatbirdPackage@org.typelevel::catbird-scalafix:22.4.0"]
   },
   {
     groupId: "io.janstenpickle",
@@ -230,7 +230,7 @@ migrations = [
     artifactIds: ["scala-library", "scala-compiler", "scala-reflect", "scalap"],
     newVersion: "2.13.0",
     doc: "https://github.com/scala/scala-collection-compat#collection213upgrade",
-    rewriteRules: ["dependency:Collection213Upgrade@org.scala-lang.modules:scala-collection-migrations:2.8.1"], 
+    rewriteRules: ["dependency:Collection213Upgrade@org.scala-lang.modules::scala-collection-migrations:2.8.1"],
     scalacOptions: ["-P:semanticdb:synthetics:on"]
   },
   {
@@ -245,13 +245,13 @@ migrations = [
     groupId: "org.typelevel",
     artifactIds: ["otel4s-.*"],
     newVersion: "0.5.0",
-    rewriteRules: ["dependency:V0_5_0Rewrites@org.typelevel:otel4s-scalafix:0.5.0"]
+    rewriteRules: ["dependency:V0_5_0Rewrites@org.typelevel::otel4s-scalafix:0.5.0"]
   },
   {
     groupId: "org.typelevel",
     artifactIds: ["feral-.*"],
     newVersion: "0.3.0",
-    rewriteRules: ["dependency:V0_3_0Rewrites@org.typelevel:feral-scalafix:0.3.0"]
+    rewriteRules: ["dependency:V0_3_0Rewrites@org.typelevel::feral-scalafix:0.3.0"]
   },
   {
     groupId: "dev.zio",


### PR DESCRIPTION
... which is also compatible with Scala CLI.

See https://github.com/scala-steward-org/scala-steward/issues/3486#issuecomment-2629120439.