### PR TITLE
Disable built-in Scala CLI rules in Scalafix migrations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala
@@ -95,8 +95,13 @@ final class ScalaCliAlg[F[_]](implicit
   override def runMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     for {
       buildRootDir <- workspaceAlg.buildRootDir(buildRoot)
-      cmd = Nel.of("scala-cli", "--power", "fix", "--scalafix-rules") :::
-        migration.rewriteRules.append(buildRootDir.pathAsString)
+      cmd = Nel.of(
+        "scala-cli",
+        "--power",
+        "fix",
+        "--enable-built-in-rules=false",
+        "--scalafix-rules"
+      ) ::: migration.rewriteRules.append(buildRootDir.pathAsString)
       slurpOptions = SlurpOptions.ignoreBufferOverflow
       _ <- processAlg.execSandboxed(cmd, buildRootDir, slurpOptions = slurpOptions)
     } yield ()

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -102,6 +102,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           "scala-cli",
           "--power",
           "fix",
+          "--enable-built-in-rules=false",
           "--scalafix-rules",
           "github:functional-streams-for-scala/fs2/v1?sha=v1.0.5",
           buildRootDir.pathAsString


### PR DESCRIPTION
When running Scalafix migrations in Scala CLI builds, we disable [built-in Scala CLI rules](https://scala-cli.virtuslab.org/docs/commands/fix/#built-in-rules) so that any changes are only coming from the Scalafix migrations.

See https://github.com/scala-steward-org/scala-steward/issues/3486#issuecomment-2629120439.