### PR TITLE
Use `RepoConfig#signoffCommits` for migrations and hooks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -94,11 +94,8 @@ final class EditAlg[F[_]](implicit
       result <- logger.attemptWarn.log("Scalafix migration failed") {
         buildToolDispatcher.runMigration(repo, config, migration)
       }
-      maybeCommit <- gitAlg.commitAllIfDirty(
-        repo,
-        migration.commitMessage(result),
-        migration.signoffCommits
-      )
+      maybeCommit <-
+        gitAlg.commitAllIfDirty(repo, migration.commitMessage(result), config.signoffCommits)
     } yield ScalafixEdit(migration, result, maybeCommit)
 
   private def applyUpdateReplacements(

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/PostUpdateHook.scala
@@ -31,8 +31,7 @@ final case class PostUpdateHook(
     commitMessage: Update.Single => CommitMsg,
     enabledByCache: RepoCache => Boolean,
     enabledByConfig: RepoConfig => Boolean,
-    addToGitBlameIgnoreRevs: Boolean,
-    signoffCommits: Option[Boolean]
+    addToGitBlameIgnoreRevs: Boolean
 ) {
   def showCommand: String = command.mkString_("'", " ", "'")
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/scalafix/ScalafixMigration.scala
@@ -34,8 +34,7 @@ final case class ScalafixMigration(
     scalacOptions: Option[Nel[String]] = None,
     authors: Option[Nel[Author]] = None,
     target: Option[Target] = None,
-    executionOrder: Option[ExecutionOrder] = None,
-    signoffCommits: Option[Boolean]
+    executionOrder: Option[ExecutionOrder] = None
 ) {
   def commitMessage(result: Either[Throwable, Unit]): CommitMsg = {
     val verb = if (result.isRight) "Applied" else "Failed"

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PostUpdateHookConfig.scala
@@ -28,8 +28,7 @@ final case class PostUpdateHookConfig(
     artifactId: Option[String],
     command: Nel[String],
     commitMessage: String,
-    addToGitBlameIgnoreRevs: Option[Boolean] = None,
-    signoffCommits: Option[Boolean]
+    addToGitBlameIgnoreRevs: Option[Boolean] = None
 ) {
   def toHook: PostUpdateHook =
     PostUpdateHook(
@@ -40,8 +39,7 @@ final case class PostUpdateHookConfig(
       commitMessage = CommitMsg.replaceVariables(commitMessage)(_, None),
       enabledByCache = _ => true,
       enabledByConfig = _ => true,
-      addToGitBlameIgnoreRevs = addToGitBlameIgnoreRevs.getOrElse(false),
-      signoffCommits = signoffCommits
+      addToGitBlameIgnoreRevs = addToGitBlameIgnoreRevs.getOrElse(false)
     )
 }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -54,8 +54,7 @@ class SbtAlgTest extends FunSuite {
       GroupId("co.fs2"),
       Nel.of("fs2-core"),
       Version("1.0.0"),
-      Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"),
-      signoffCommits = None
+      Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
     )
     val initialState = MockState.empty
       .addFiles(
@@ -94,8 +93,7 @@ class SbtAlgTest extends FunSuite {
       Nel.of("cats-core"),
       Version("2.2.0"),
       Nel.of("github:cb372/cats/Cats_v2_2_0?sha=235bd7c92e431ab1902db174cf4665b05e08f2f1"),
-      scalacOptions = Some(Nel.of("-P:semanticdb:synthetics:on")),
-      signoffCommits = None
+      scalacOptions = Some(Nel.of("-P:semanticdb:synthetics:on"))
     )
     val initialState = MockState.empty
       .addFiles(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -91,8 +91,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
       GroupId("co.fs2"),
       Nel.of("fs2-core"),
       Version("1.0.0"),
-      Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"),
-      signoffCommits = None
+      Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
     )
     val obtained = scalaCliAlg.runMigration(buildRoot, migration).runS(MockState.empty)
     val expected = MockState.empty.copy(trace =

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -126,8 +126,7 @@ class HookExecutorTest extends CatsEffectSuite {
           groupId = None,
           artifactId = None,
           command = Nel.of("sbt", "mySbtCommand"),
-          commitMessage = "Updated with a hook!",
-          signoffCommits = None
+          commitMessage = "Updated with a hook!"
         )
       ).some
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsFinderTest.scala
@@ -20,8 +20,7 @@ class ScalafixMigrationsFinderTest extends FunSuite {
           Some(
             "https://github.com/typelevel/cats/blob/v2.2.0/scalafix/README.md#migration-to-cats-v220"
           ),
-          Some(Nel.of("-P:semanticdb:synthetics:on")),
-          signoffCommits = None
+          Some(Nel.of("-P:semanticdb:synthetics:on"))
         )
       ),
       List()

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/scalafix/ScalafixMigrationsLoaderTest.scala
@@ -37,8 +37,7 @@ class ScalafixMigrationsLoaderTest extends FunSuite {
     Some("https://scalacenter.github.io/scalafix/"),
     authors = Some(Nel.of(Author("Jane Doe", "jane@example.com"))),
     target = Some(Sources),
-    executionOrder = Some(PreUpdate),
-    signoffCommits = None
+    executionOrder = Some(PreUpdate)
   )
 
   test("loadAll: without extra file, without defaults") {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -101,8 +101,7 @@ class NewPullRequestDataTest extends FunSuite {
         groupId = "com.spotify".g,
         artifactIds = Nel.one("scio-core"),
         newVersion = Version("0.7.0"),
-        rewriteRules = Nel.of("I am a rewrite rule"),
-        signoffCommits = None
+        rewriteRules = Nel.of("I am a rewrite rule")
       ),
       result = Right(()),
       maybeCommit = Some(Commit(dummySha1))
@@ -464,8 +463,7 @@ class NewPullRequestDataTest extends FunSuite {
         "com.spotify".g,
         Nel.one("scio-core"),
         Version("0.7.0"),
-        Nel.of("I am a rewrite rule"),
-        signoffCommits = None
+        Nel.of("I am a rewrite rule")
       ),
       Right(()),
       Some(Commit(dummySha1))
@@ -495,8 +493,7 @@ class NewPullRequestDataTest extends FunSuite {
         Nel.one("scio-core"),
         Version("0.7.0"),
         Nel.of("I am a rewrite rule", "I am a 2nd rewrite rule"),
-        Some("https://scalacenter.github.io/scalafix/"),
-        signoffCommits = None
+        Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
       Some(Commit(dummySha1))
@@ -528,8 +525,7 @@ class NewPullRequestDataTest extends FunSuite {
         Nel.one("scio-core"),
         Version("0.7.0"),
         Nel.of("I am a rewrite rule", "I am a 2nd rewrite rule"),
-        Some("https://scalacenter.github.io/scalafix/"),
-        signoffCommits = None
+        Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
       Some(Commit(dummySha1))
@@ -539,8 +535,7 @@ class NewPullRequestDataTest extends FunSuite {
         "org.typeleve".g,
         Nel.of("cats-effect", "cats-effect-laws"),
         Version("3.0.0"),
-        Nel.of("I am a rule without an effect"),
-        signoffCommits = None
+        Nel.of("I am a rule without an effect")
       ),
       Right(()),
       None
@@ -623,8 +618,7 @@ class NewPullRequestDataTest extends FunSuite {
         Nel.one("scio-core"),
         Version("0.7.0"),
         Nel.of("I am a rewrite rule", "I am a 2nd rewrite rule"),
-        Some("https://scalacenter.github.io/scalafix/"),
-        signoffCommits = None
+        Some("https://scalacenter.github.io/scalafix/")
       ),
       Right(()),
       Some(Commit(dummySha1))

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -393,8 +393,7 @@ class RepoConfigAlgTest extends FunSuite {
           groupId = None,
           artifactId = None,
           command = Nel.of("sbt", "mySbtCommand"),
-          commitMessage = "Updated with a hook!",
-          signoffCommits = None
+          commitMessage = "Updated with a hook!"
         )
       ).some
     )
@@ -418,8 +417,7 @@ class RepoConfigAlgTest extends FunSuite {
           groupId = Some("eu.timepit".g),
           artifactId = Some("refined.1"),
           command = Nel.of("sbt", "mySbtCommand"),
-          commitMessage = "Updated with a hook!",
-          signoffCommits = None
+          commitMessage = "Updated with a hook!"
         )
       ).some
     )


### PR DESCRIPTION
This uses `RepoConfig#signoffCommits` for Scalafix migrations and post-update hooks commits and removes the `signoffCommits` fields from `PostUpdateHook` and `ScalafixMigration` (which were added in #3432). The latter fields concealed that `RepoConfig#signoffCommits` was partially ignored for post-update hooks and completely ignored for Scalafix migrations.