### PR TITLE
Replace http->https in URLs in `DependencyMetadata` for some `Forge`s

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -29,6 +29,7 @@ import scala.annotation.nowarn
 
 sealed trait ForgeType extends Product with Serializable {
   def publicWebHost: Option[String]
+  def publicWebScheme: Option[Uri.Scheme]
 
   /** Defines how to construct 'diff' urls for this forge type - ie a url that will show the
     * difference between two git tags. These can be very useful for understanding the difference
@@ -67,6 +68,7 @@ object ForgeType {
 
   case object AzureRepos extends ForgeType {
     override val publicWebHost: Some[String] = Some("dev.azure.com")
+    override val publicWebScheme: Option[Uri.Scheme] = None
     override def supportsForking: Boolean = false
     override val maximumPullRequestLength: Int = 4000
     val diffs: DiffUriPattern = (from, to) =>
@@ -81,6 +83,7 @@ object ForgeType {
 
   case object Bitbucket extends ForgeType {
     override val publicWebHost: Some[String] = Some("bitbucket.org")
+    override val publicWebScheme: Option[Uri.Scheme] = Some(Uri.Scheme.https)
     override def supportsLabels: Boolean = false
     val publicApiBaseUrl = uri"https://api.bitbucket.org/2.0"
     val diffs: DiffUriPattern = (from, to) => _ / "compare" / s"$to..$from" withFragment "diff"
@@ -94,6 +97,7 @@ object ForgeType {
     */
   case object BitbucketServer extends ForgeType {
     override val publicWebHost: None.type = None
+    override val publicWebScheme: Option[Uri.Scheme] = None
     override def supportsForking: Boolean = false
     override def supportsLabels: Boolean = false
     override val maximumPullRequestLength: Int = 32768
@@ -103,6 +107,7 @@ object ForgeType {
 
   case object GitHub extends ForgeType {
     override val publicWebHost: Some[String] = Some("github.com")
+    override val publicWebScheme: Option[Uri.Scheme] = Some(Uri.Scheme.https)
     val publicApiBaseUrl = uri"https://api.github.com"
     val diffs: DiffUriPattern = (from, to) => _ / "compare" / s"$from...$to"
     val files: FileUriPattern = fileName => _ / "blob" / "master" / fileName
@@ -112,6 +117,7 @@ object ForgeType {
 
   case object GitLab extends ForgeType {
     override val publicWebHost: Some[String] = Some("gitlab.com")
+    override val publicWebScheme: Option[Uri.Scheme] = Some(Uri.Scheme.https)
     val publicApiBaseUrl = uri"https://gitlab.com/api/v4"
     val diffs: DiffUriPattern = GitHub.diffs
     val files: FileUriPattern = GitHub.files
@@ -119,6 +125,7 @@ object ForgeType {
 
   case object Gitea extends ForgeType {
     override val publicWebHost: Option[String] = None
+    override val publicWebScheme: Option[Uri.Scheme] = None
     val diffs: DiffUriPattern = GitHub.diffs
     val files: FileUriPattern = fileName => _ / "src" / "branch" / "master" / fileName
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -49,6 +49,16 @@ class CoursierAlgTest extends CatsEffectSuite {
     assertIO(obtained, expected)
   }
 
+  test("getMetadata: homePage and scmUrl with the https scheme instead of http for github") {
+    val dep = "io.lettuce".g % "lettuce-core".a % "6.5.3.RELEASE"
+    val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)
+    val expected = emptyMetadata.copy(
+      homePage = Some(uri"https://github.com/lettuce-io/lettuce-core"),
+      scmUrl = Some(uri"https://github.com/lettuce-io/lettuce-core")
+    )
+    assertIO(obtained, expected)
+  }
+
   test("getMetadata: homePage from parent") {
     val dep = "net.bytebuddy".g % "byte-buddy".a % "1.10.5"
     val obtained = coursierAlg.getMetadata(dep, resolvers).runA(MockState.empty)


### PR DESCRIPTION
Hey there. Sorry for not starting with some discussion somewhere in Discord, hopefully, this PR is also fine to discuss the idea.

### Motivation

We use `org.scalasteward.core.util.UrlChecker` to validate URLs in several places, such as in `org.scalasteward.core.nurture.UpdateInfoUrlFinder`. In turn, some projects may have `HomePage` and `ScmUrl` for github.com, gitlab.com and bitbucket.org with the `http` scheme. Given how we check for URL existence, the check easily returns false, even though all the mentioned `Forge`s forward to the `https` scheme.

```terminal
❯ curl -I http://github.com/lettuce-io/lettuce-core
HTTP/1.1 301 Moved Permanently
Location: https://github.com/lettuce-io/lettuce-core

❯ curl -I http://bitbucket.org/krake-oss/wurbelizer/
HTTP/1.1 301 Moved Permanently
location: https://bitbucket.org/krake-oss/wurbelizer/

❯ curl -I http://gitlab.com/fdroid/fdroidclient
HTTP/1.1 301 Moved Permanently
Location: https://gitlab.com/fdroid/fdroidclient
```

Ultimately, I think having this strict check might be reasonable (since we have different usage of it across the codebase), as well as automatically substituting `http` with `https` when instantiating `org.scalasteward.core.coursier.DependencyMetadata`.

I’d appreciate your thoughts on this.

