### PR TITLE
Fix the assembly of the Docker image in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -395,16 +395,16 @@ lazy val dockerSettings = Def.settings(
       Cmd("USER", "root"),
       Cmd(
         "RUN",
-        "apk --no-cache add bash git gpg ca-certificates curl maven openssh nodejs npm ncurses"
+        "apk --no-cache add bash git gpg ca-certificates curl maven openssh nodejs npm ncurses sqlite sqlite-dev"
       ),
       Cmd("RUN", installSbt),
       Cmd("RUN", installMill),
       Cmd("RUN", installCoursier),
       Cmd("RUN", installScalaCli),
       Cmd("RUN", s"$csBin install --install-dir $binDir scalafix scalafmt"),
-      Cmd("RUN", "npm install --global yarn"),
       // Ensure binaries are in PATH
       Cmd("RUN", "echo $PATH"),
+      Cmd("RUN", "npm install --global yarn"),
       Cmd("RUN", "which cs mill mvn node npm sbt scala-cli scalafix scalafmt yarn")
     )
   },


### PR DESCRIPTION
Currently, we're experiencing this issue in CI workflows:

```terminal
[info] ERROR: failed to solve: process "/bin/sh -c npm install --global yarn" did not complete successfully: exit code: 127
[error] java.lang.RuntimeException: Nonzero exit value: 1
[error] 	at com.typesafe.sbt.packager.docker.DockerPlugin$.publishLocalDocker(DockerPlugin.scala:745)
```

It turns out, that we run `npm install --global yarn` within the docker settings defined in the SBT build. So, it's an attempt to fix the issue. 