### PR TITLE
Take redirections into account in `UrlChecker`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -81,9 +81,9 @@ final class SelfCheckAlg[F[_]](config: Config)(implicit
 
   private def checkUrlChecker: F[Unit] =
     config.urlCheckerTestUrls.traverse_ { url =>
-      urlChecker.exists(url).flatMap { urlExists =>
+      urlChecker.validate(url).flatMap { res =>
         val msg = s"Self check of UrlChecker failed: checking that $url exists failed"
-        F.whenA(!urlExists)(logger.warn(msg))
+        F.whenA(res.notExists)(logger.warn(msg))
       }
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -206,7 +206,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
         .traverse { case (_, dependency) =>
           coursierAlg
             .getMetadata(dependency, resolvers)
-            .flatMap(_.filterUrls(urlChecker.exists))
+            .flatMap(_.filterUrls(uri => urlChecker.validate(uri).map(_.exists)))
             .tupleLeft(dependency)
         }
         .map(_.toMap)

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrl.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateInfoUrl.scala
@@ -22,13 +22,23 @@ import org.http4s.Uri
 /** A URL of a resource that provides additional information for an update. */
 sealed trait UpdateInfoUrl {
   def url: Uri
+
+  def withUrl(url: Uri): UpdateInfoUrl
 }
 
 object UpdateInfoUrl {
-  final case class CustomChangelog(url: Uri) extends UpdateInfoUrl
-  final case class CustomReleaseNotes(url: Uri) extends UpdateInfoUrl
-  final case class GitHubReleaseNotes(url: Uri) extends UpdateInfoUrl
-  final case class VersionDiff(url: Uri) extends UpdateInfoUrl
+  final case class CustomChangelog(url: Uri) extends UpdateInfoUrl {
+    override def withUrl(url: Uri): UpdateInfoUrl = CustomChangelog(url)
+  }
+  final case class CustomReleaseNotes(url: Uri) extends UpdateInfoUrl {
+    override def withUrl(url: Uri): UpdateInfoUrl = CustomReleaseNotes(url)
+  }
+  final case class GitHubReleaseNotes(url: Uri) extends UpdateInfoUrl {
+    override def withUrl(url: Uri): UpdateInfoUrl = GitHubReleaseNotes(url)
+  }
+  final case class VersionDiff(url: Uri) extends UpdateInfoUrl {
+    override def withUrl(url: Uri): UpdateInfoUrl = VersionDiff(url)
+  }
 
   implicit val updateInfoUrlOrder: Order[UpdateInfoUrl] =
     Order.by {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/UrlChecker.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/UrlChecker.scala
@@ -20,6 +20,7 @@ import cats.effect.Sync
 import cats.syntax.all.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.http4s.client.Client
+import org.http4s.headers.Location
 import org.http4s.{Method, Request, Status, Uri}
 import org.scalasteward.core.application.Config
 import org.typelevel.log4cats.Logger
@@ -27,21 +28,43 @@ import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 
 trait UrlChecker[F[_]] {
-  def exists(url: Uri): F[Boolean]
+  def validate(url: Uri): F[UrlChecker.UrlValidationResult]
 }
 
 final case class UrlCheckerClient[F[_]](client: Client[F]) extends AnyVal
 
 object UrlChecker {
+
+  sealed abstract class UrlValidationResult extends Product with Serializable {
+    def exists: Boolean =
+      fold(exists = true, notExists = false, redirectTo = _ => false)
+
+    def notExists: Boolean =
+      fold(exists = false, notExists = true, redirectTo = _ => false)
+
+    def fold[A](exists: => A, notExists: => A, redirectTo: Uri => A): A =
+      this match {
+        case UrlValidationResult.Exists          => exists
+        case UrlValidationResult.NotExists       => notExists
+        case UrlValidationResult.RedirectTo(url) => redirectTo(url)
+      }
+  }
+
+  object UrlValidationResult {
+    case object Exists extends UrlValidationResult
+    case object NotExists extends UrlValidationResult
+    final case class RedirectTo(url: Uri) extends UrlValidationResult
+  }
+
   private def buildCache[F[_]](config: Config)(implicit
       F: Sync[F]
-  ): F[CaffeineCache[F, String, Status]] =
+  ): F[CaffeineCache[F, String, UrlValidationResult]] =
     F.delay {
       val cache = Caffeine
         .newBuilder()
         .maximumSize(16384L)
         .expireAfterWrite(config.cacheTtl.length, config.cacheTtl.unit)
-        .build[String, Entry[Status]]()
+        .build[String, Entry[UrlValidationResult]]()
       CaffeineCache(cache)
     }
 
@@ -52,15 +75,36 @@ object UrlChecker {
   ): F[UrlChecker[F]] =
     buildCache(config).map { statusCache =>
       new UrlChecker[F] {
-        override def exists(url: Uri): F[Boolean] =
-          status(url).map(_ === Status.Ok).handleErrorWith { throwable =>
-            logger.debug(throwable)(s"Failed to check if $url exists").as(false)
-          }
+        override def validate(url: Uri): F[UrlValidationResult] =
+          check(url).handleErrorWith(th =>
+            logger
+              .debug(th)(s"Failed to check if $url exists")
+              .as(UrlValidationResult.NotExists)
+          )
 
-        private def status(url: Uri): F[Status] =
+        private def check(url: Uri): F[UrlValidationResult] =
           statusCache.cachingF(url.renderString)(None) {
             val req = Request[F](method = Method.HEAD, uri = url)
-            modify(req).flatMap(urlCheckerClient.client.status)
+
+            modify(req).flatMap(r =>
+              urlCheckerClient.client.run(r).use {
+                case resp if resp.status === Status.Ok =>
+                  F.pure(UrlValidationResult.Exists)
+
+                case resp if resp.status === Status.MovedPermanently =>
+                  val uriMaybe =
+                    resp.headers
+                      .get[Location]
+                      .fold[UrlValidationResult](UrlValidationResult.NotExists)(h =>
+                        UrlValidationResult.RedirectTo(h.uri)
+                      )
+
+                  F.pure(uriMaybe)
+
+                case _ =>
+                  F.pure(UrlValidationResult.NotExists)
+              }
+            )
           }
       }
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/UpdateInfoUrlFinderTest.scala
@@ -29,14 +29,14 @@ class UpdateInfoUrlFinderTest extends CatsEffectSuite with Http4sDsl[MockEff] {
         status = Status.MovedPermanently,
         headers = Headers(Location(redirectUrl))
       ).pure[MockEff]
-    case HEAD -> Root / "foo" / "bar3-redirected"                         => Ok()
+    case HEAD -> Root / "foo" / "bar3-redirected"                          => Ok()
     case HEAD -> Root / "foo" / "bar" / "README.md"                        => Ok()
     case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0"      => Ok()
     case HEAD -> Root / "foo" / "bar1" / "blob" / "master" / "RELEASES.md" => Ok()
     case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0"      => PermanentRedirect()
     case HEAD -> Root / "foo" / "bar2" / "releases" / "tag" / "v0.2.0"     => Ok()
     case HEAD -> Root / "foo" / "bar3-redirected" / "releases" / "tag" / "v0.2.0" => Ok()
-    case _                                                                         => NotFound()
+    case _                                                                        => NotFound()
   }
   private val authApp = GitHubAuth.api(List(Repository("foo/bar")))
   private val state = MockState.empty.copy(clientResponses = authApp <+> httpApp)

--- a/modules/core/src/test/scala/org/scalasteward/core/util/UrlCheckerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/UrlCheckerTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.util
 
 import cats.syntax.all.*
 import munit.CatsEffectSuite
-import org.http4s.{Headers, HttpApp, Response, Status}
+import org.http4s.{Headers, HttpApp, Response, Status, Uri}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
 import org.http4s.syntax.all.*
@@ -13,24 +13,29 @@ import org.scalasteward.core.util.UrlChecker.UrlValidationResult
 
 class UrlCheckerTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   private val baseUrl = uri"https://github.com/scala-steward-org"
-  private val redirectUrl = baseUrl / "finished-redirect"
-  private val anotherRedirectUrl = baseUrl / "yet-another-redirect"
+  private val finishedRedirectUrl = baseUrl / "finished-redirect"
+  private val infiniteRedirectUrl = baseUrl / "infinite-redirect"
+  private val secondRedirectUrl = baseUrl / "second-redirect"
+
+  private def movedPermanentlyResponse(uri: Uri): MockEff[Response[MockEff]] =
+    Response[MockEff](
+      status = Status.MovedPermanently,
+      headers = Headers(Location(uri))
+    ).pure[MockEff]
 
   private val state =
     MockState.empty.copy(clientResponses = GitHubAuth.api(List.empty) <+> HttpApp {
       case HEAD -> Root / "scala-steward-org"               => Ok()
       case HEAD -> Root / "scala-steward-org" / "wrong-uri" => NotFound()
       case HEAD -> Root / "scala-steward-org" / "single-redirect" =>
-        Response[MockEff](
-          status = Status.MovedPermanently,
-          headers = Headers(Location(redirectUrl))
-        ).pure[MockEff]
+        movedPermanentlyResponse(finishedRedirectUrl)
+      case HEAD -> Root / "scala-steward-org" / "first-redirect" =>
+        movedPermanentlyResponse(secondRedirectUrl)
+      case HEAD -> Root / "scala-steward-org" / "second-redirect" =>
+        movedPermanentlyResponse(finishedRedirectUrl)
       case HEAD -> Root / "scala-steward-org" / "finished-redirect" => Ok()
-      case HEAD -> Root / "scala-steward-org" / "yet-another-redirect" =>
-        Response[MockEff](
-          status = Status.MovedPermanently,
-          headers = Headers(Location(anotherRedirectUrl))
-        ).pure[MockEff]
+      case HEAD -> Root / "scala-steward-org" / "infinite-redirect" =>
+        movedPermanentlyResponse(infiniteRedirectUrl)
       case _ =>
         ServiceUnavailable()
     })
@@ -52,14 +57,22 @@ class UrlCheckerTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("An URL redirects to another existing URL") {
     val httpUrl = uri"https://github.com/scala-steward-org/single-redirect"
     val check = urlChecker.validate(httpUrl).runA(state)
-    val anticipatedResult = UrlValidationResult.RedirectTo(redirectUrl)
+    val anticipatedResult = UrlValidationResult.RedirectTo(finishedRedirectUrl)
+
+    assertIO(check, anticipatedResult)
+  }
+
+  test("An URL redirects to another redirecting URL (two redirects)") {
+    val httpUrl = uri"https://github.com/scala-steward-org/first-redirect"
+    val check = urlChecker.validate(httpUrl).runA(state)
+    val anticipatedResult = UrlValidationResult.RedirectTo(finishedRedirectUrl)
 
     assertIO(check, anticipatedResult)
   }
 
   // basically, we prohibit the infinite loop of traversing redirect URLs
-  test("An URL redirects to another redirecting URL") {
-    val httpUrl = uri"https://github.com/scala-steward-org/yet-another-redirect"
+  test("An URL redirects to another redirecting URL (more than two redirects)") {
+    val httpUrl = uri"https://github.com/scala-steward-org/infinite-redirect"
     val check = urlChecker.validate(httpUrl).runA(state)
     val anticipatedResult = UrlValidationResult.NotExists
 

--- a/modules/core/src/test/scala/org/scalasteward/core/util/UrlCheckerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/UrlCheckerTest.scala
@@ -1,0 +1,52 @@
+package org.scalasteward.core.util
+
+import cats.syntax.all.*
+import munit.CatsEffectSuite
+import org.http4s.{Headers, HttpApp, Response, Status}
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Location
+import org.http4s.syntax.all.*
+import org.scalasteward.core.mock.*
+import org.scalasteward.core.mock.MockContext.context.*
+import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.util.UrlChecker.UrlValidationResult
+
+class UrlCheckerTest extends CatsEffectSuite with Http4sDsl[MockEff] {
+  private val baseUrl = uri"https://github.com/scala-steward-org"
+  private val redirectUrl = baseUrl / "scala-steward"
+
+  private val state =
+    MockState.empty.copy(clientResponses = GitHubAuth.api(List.empty) <+> HttpApp {
+      case HEAD -> Root / "scala-steward-org"               => Ok()
+      case HEAD -> Root / "scala-steward-org" / "wrong-uri" => NotFound()
+      case HEAD -> Root / "scala-steward-org" / "redirect-uri" =>
+        Response[MockEff](
+          status = Status.MovedPermanently,
+          headers = Headers(Location(redirectUrl))
+        ).pure[MockEff]
+      case _ =>
+        ServiceUnavailable()
+    })
+
+  test("An URL exists") {
+    val url = baseUrl
+    val check = urlChecker.validate(url).runA(state)
+
+    assertIOBoolean(check.map(_.exists))
+  }
+
+  test("An URL does not exist") {
+    val url = baseUrl / "wrong-uri"
+    val check = urlChecker.validate(url).runA(state)
+
+    assertIOBoolean(check.map(_.notExists))
+  }
+
+  test("An URL redirects to another URL") {
+    val httpUrl = uri"https://github.com/scala-steward-org/redirect-uri"
+    val check = urlChecker.validate(httpUrl).runA(state)
+    val anticipatedResult = UrlValidationResult.RedirectTo(redirectUrl)
+
+    assertIO(check, anticipatedResult)
+  }
+}


### PR DESCRIPTION
This PR aims to increase the likelihood of URLs (such as those related to release notes) being propagated into PR descriptions. In #3583, I noticed that we omit URLs in the description of the final PR when facing redirections on GitHub, GitLab, etc. While it may seem that the current PR supersedes the mentioned one, I’m confident it does not — and here’s why.
```terminal
❯ curl -I http://github.com/lettuce-io/lettuce-core/releases/tag/6.5.3.RELEASE
HTTP/1.1 301 Moved Permanently
Content-Length: 0
Location: https://github.com/lettuce-io/lettuce-core/releases/tag/6.5.3.RELEASE

❯ curl -I https://github.com/lettuce-io/lettuce-core/releases/tag/6.5.3.RELEASE
HTTP/2 301
server: GitHub.com
location: https://github.com/redis/lettuce/releases/tag/6.5.3.RELEASE
```
In the first request, we simply received a tweak to the URL’s Scheme (http->https). In the second request, however, we encountered an actual redirection to the existing resource. FWIW, an attentive reader may notice that these two redirections are handled by different middleware (HTTP/1.1 vs HTTP/2).

As always, I'm open to any concerns or suggestions to help drive this to merge.