### PR TITLE
Add artifact migration for scala-uri

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1489,5 +1489,10 @@ changes = [
     groupIdAfter = com.github.sbt
     artifactIdBefore = sbt-bom
     artifactIdAfter = sbt-sbom
+  },
+  {
+    groupIdBefore = io.lemonlabs
+    groupIdAfter = com.indoorvivants
+    artifactIdAfter = scala-uri
   }
 ]


### PR DESCRIPTION
Per original repo [lemonlabsuk/scala-uri](https://github.com/lemonlabsuk/scala-uri?tab=readme-ov-file), it's no longer maintained and the new maintained fork is [indoorvivants/scala-uri](https://github.com/indoorvivants/scala-uri).

