### PR TITLE
Update weaver to `0.9.0`

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1499,5 +1499,35 @@ changes = [
     groupIdBefore = io.lemonlabs
     groupIdAfter = com.indoorvivants
     artifactIdAfter = scala-uri
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-cats
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-cats-core
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-core
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-discipline
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-framework
+  },
+  {
+    groupIdBefore = com.disneystreaming
+    groupIdAfter = org.typelevel
+    artifactIdAfter = weaver-scalacheck
   }
 ]

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -267,7 +267,7 @@ migrations = [
     executionOrder: "post-update"
   },
   {
-    groupId: "org.typelevel",
+    groupId: "com.disneystreaming",
     artifactIds: ["weaver-.*"],
     newVersion: "0.9.0",
     rewriteRules: ["github:typelevel/weaver-test/RenameAssertToExpect?sha=v0.9.0"]

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -265,5 +265,12 @@ migrations = [
       "replace:zio.kafka.serde.Serializer.contramapM/zio.kafka.serde.Serializer.contramapZIO"
     ],
     executionOrder: "post-update"
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["weaver-.*"],
+    newVersion: "0.9.0",
+    rewriteRules: ["github:typelevel/weaver-test/RenameAssertToExpect?sha=v0.9.0"]
   }
+
 ]


### PR DESCRIPTION
weaver has changed stewardship from `com.disneystreaming` to `org.typelevel`.

This PR modifies the group ID and adds a rewrite rule for upgrading to `0.9.0`.