### PR TITLE
Add tests for `pullRequests.grouping` syntax

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilterTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestUpdateFilterTest.scala
@@ -1,0 +1,48 @@
+package org.scalasteward.core.repoconfig
+
+import munit.FunSuite
+import org.scalasteward.core.TestSyntax.*
+
+class PullRequestUpdateFilterTest extends FunSuite {
+
+  object Update {
+    val kinesisClient =
+      ("software.amazon.kinesis".g % "amazon-kinesis-client".a % "3.0.2" %> "3.0.3").single
+    val s3Client = ("software.amazon.awssdk".g % "s3".a % "2.31.60" %> "2.31.61").single
+    val play = ("org.playframework".g % "sbt-plugin".a % "3.0.6" %> "3.0.7").single
+    val contentApiClient = ("com.gu".g % "content-api-client".a % "34.1.1" %> "8.1.5").single
+    val playGoogleAuth = ("com.gu.play-googleauth".g % "play-v30".a % "23.0.0" %> "24.0.0").single
+  }
+
+  test("Allow a wildcard group id") {
+    val groupFilter = PullRequestUpdateFilter(group = Some("*")).toOption.get
+
+    assert(groupFilter.matches(Update.kinesisClient))
+    assert(groupFilter.matches(Update.s3Client))
+    assert(groupFilter.matches(Update.play))
+  }
+
+  test("Allow a wildcard-suffix on group id") {
+    val groupFilter = PullRequestUpdateFilter(group = Some("software.amazon.*")).toOption.get
+
+    assert(groupFilter.matches(Update.kinesisClient))
+    assert(groupFilter.matches(Update.s3Client))
+
+    assert(!groupFilter.matches(Update.play))
+  }
+
+  test("Not match a non-wildcard group id if it is only partially specified") {
+    val groupFilter = PullRequestUpdateFilter(group = Some("software.amazon")).toOption.get
+
+    assert(!groupFilter.matches(Update.kinesisClient))
+    assert(!groupFilter.matches(Update.s3Client))
+    assert(!groupFilter.matches(Update.play))
+  }
+
+  test("Not match a non-wildcard group id if it is only partially specified") {
+    val groupFilter = PullRequestUpdateFilter(group = Some("com.gu.*")).toOption.get
+
+    assert(!groupFilter.matches(Update.contentApiClient))
+    assert(groupFilter.matches(Update.playGoogleAuth))
+  }
+}


### PR DESCRIPTION
A colleague mentioned to me that some of our `pullRequests.grouping` were not pulling in all the artifacts we were expecting - while looking into this, I realised that I wasn't 100% clear on where wildcards could be used in `pullRequests.grouping`, so I wrote this test to exercise all the cases that were relevant to us, and see what worked - this may be tested elsewhere to some extent in the Scala Steward codebase, but I think it's helpful to drill into the specific functionality with these new tests on `PullRequestUpdateFilter`.

Note that the tests only assert the behaviour is what it _is_ (meaning config parsing behaviour is tested to be consistent over time), not what it might 'ideally' be. By that, I mean that for myself, it would be ideal if the matching behaviour automatically included all _sub_-domains - so a filter of `com.gu` would match `com.gu`, `com.gu.play-secret`, `com.gu.foo.bar` etc, but _not_ `com.gumbo` (because it's not a [subdomain](https://central.sonatype.org/publish/requirements/coordinates/#choose-your-coordinates:~:text=sub%2Dgroups) of `com.gu`) - but improving that behaviour would potentially affect how existing `.scala-steward.conf` files are interpreted - see _"Matching group-&-sub-group-ids"_ in https://github.com/scala-steward-org/scala-steward/issues/3655.

