### PR TITLE
Prevent `version.isSnapshot` from incorrectly identifying versions with hashes as snapshots

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -99,10 +99,9 @@ final case class Version(value: String) {
       case _                          => false
     }
 
-  private def isSnapshot: Boolean =
+  def isSnapshot: Boolean =
     components.exists {
       case a: Version.Component.Alpha => a.isSnapshotIdent
-      case _: Version.Component.Hash  => true
       case _                          => false
     }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -267,8 +267,6 @@ class VersionTest extends DisciplineSuite {
         List("0.21.7+81-a0ff7dd-SNAPSHOT", "0.22.0+99-a0087dd-SNAPSHOT"),
         Some("0.22.0+99-a0087dd-SNAPSHOT")
       ),
-      ("0.1.1", List("0.2.1-485fdf3b"), None),
-      ("0.1.1-RC1", List("0.2.1-485fdf3b"), None),
       ("0.1.1-ALPHA", List("0.2.1-SNAPSHOT"), None),
       ("0.21.5", List("0.21.6+75-6ad94f6f-SNAPSHOT"), None),
       ("0.21.6", List("0.21.6+75-6ad94f6f-SNAPSHOT"), None),
@@ -282,14 +280,13 @@ class VersionTest extends DisciplineSuite {
       ("0.1.1", List("0.1.2"), Some("0.1.2")),
       ("0.1.1-RC1", List("0.1.2"), Some("0.1.2")),
       ("0.1.1-ALPHA", List("0.1.2"), Some("0.1.2")),
-      ("0.1.1", List("0.1.2-FEAT"), Some("0.1.2-FEAT")),
-      ("0.1.1", List("0.1.2-FEAT+3dfde9d7"), None)
+      ("0.1.1", List("0.1.2-FEAT"), Some("0.1.2-FEAT"))
     )
 
     val rnd = new Random()
     nextVersions.foreach { case (current, versions, result) =>
       val obtained = Version(current).selectNext(rnd.shuffle(versions).map(Version.apply), true)
-      assertEquals(obtained, result.map(Version.apply))
+      assertEquals(obtained, result.map(Version.apply), s"For current release $current")
     }
   }
 
@@ -304,6 +301,12 @@ class VersionTest extends DisciplineSuite {
   test("Component: round-trip example") {
     val original = "1.0.0-rc.1+build.1"
     assertEquals(Component.render(Component.Empty :: Component.parse(original)), original)
+  }
+
+  test("Stable preview releases should not be identified as snapshots") {
+    val previewVersion =
+      Version("0.0.37-PREVIEW.try-out-verify-artifact-hashes.2024-04-25T1652.c7fa7c2b")
+    assertEquals(previewVersion.isSnapshot, false)
   }
 
   def checkPairwise(versions: List[String]): Unit = {


### PR DESCRIPTION
## What's changed?

At the moment, [we're attempting to create a workflow](https://github.com/guardian/scala-steward-public-repos/pull/90) to raise PRs against consuming projects when we publish prereleases.  

In attempting to [use `updates.allowPrereleases` to do that](https://github.com/scala-steward-org/scala-steward/issues/3612#issuecomment-2743182650), we've encountered an issue where the commit hash in our prerelease version (e.g. `0.0.37-PREVIEW.try-out-verify-artifact-hashes.2024-04-25T1652.c7fa7c2b`) results in scala-steward misidentifying our release as a snapshot. As a result, it won't consider it as a valid next version.

This PR corrects the behaviour of `version.isSnapshot`, which was incorrectly identifying versions with hashes as snapshots.

As far as we're aware, snapshotted versions are usually identified by a `-SNAPSHOT` suffix, which the case below already covers:
https://github.com/scala-steward-org/scala-steward/blob/ef70026241d282af7ee279b2f64af2d2d7abb451/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala#L173
