### PR TITLE
Tighten up http4s-0.19.0 ignores

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -242,7 +242,23 @@ updates.ignore = [
   { groupId = "net.sourceforge.plantuml", artifactId = "plantuml", version = "2017." },
 
   // https://github.com/http4s/http4s/pull/2153
-  { groupId = "org.http4s", version = "0.19.0" },
+  { groupId = "org.http4s", artifactId = "http4s-argonaut", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-async-http-client", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-blaze-core", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-boopickle", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-circe", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-client", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-dropwizard-metrics", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-dsl", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-jawn", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-jetty-client", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-okhttp-client", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-prometheus-metrics", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-scala-xml", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-scalatags", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-server", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-testing", version = { exact = "0.19.0" } },
+  { groupId = "org.http4s", artifactId = "http4s-twirl", version = { exact = "0.19.0" } },
 
   // https://github.com/scala-js/scala-js/issues/3865
   { groupId = "org.scala-js", version = "0.6.30" },


### PR DESCRIPTION
http4s has multiple repos, and some of them have or will have 0.19.0 tags that were not affected by the ill-fated v0.19.0 on http4s/http4s.  This makes the list of artifacts explicit, and switches to exact version numbering.