### PR TITLE
Retract MUnit 1.1.2

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -316,6 +316,9 @@ updates.ignore = [
   { groupId = "org.tpolecat", artifactId="doobie-postgres-circe", version="1.0.0-RC6" },
   { groupId = "com.disneystreaming.smithy4s", version = "0.18.38" },
   { groupId = "com.disneystreaming.smithy4s", version = "0.18.40" },
+
+  // Ignore munit 1.1.2, as it removes some traits required for binary compatibility with munit-scalacheck
+  { groupId = "org.scalameta", artifactId = "munit", version = "1.1.2" }
 ]
 
 updates.retracted = [
@@ -356,6 +359,13 @@ updates.retracted = [
     doc = "https://github.com/disneystreaming/smithy4s/issues/1792",
     artifacts = [
       { groupId = "com.disneystreaming.smithy4s", version = { exact = "0.18.40" } }
+    ]
+  },
+  {
+    reason = "Ignore munit 1.1.2, as it removes some traits required for binary compatibility with munit-scalacheck",
+    doc = "https://github.com/scalameta/munit/releases/tag/v1.2.0",
+    artifacts = [
+      { groupId = "org.scalameta", artifactId = "munit", version = { exact = "1.1.2" } }
     ]
   }
 ]

--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -343,14 +343,14 @@ updates.retracted = [
       { groupId = "org.scala-sbt", artifactId = "sbt",             version = { exact = "1.10.8" } },
       { groupId = "org.scala-sbt", artifactId = "scripted-plugin", version = { exact = "1.10.8" } },
     ]
-  }
+  },
   {
     reason = "Ignore smithy4s 0.18.38, as it refers to a problematic version of Alloy which can cause conflicts",
     doc = "https://github.com/disneystreaming/alloy/pull/237",
     artifacts = [
       { groupId = "com.disneystreaming.smithy4s", version = { exact = "0.18.38" } }
     ]
-  }
+  },
   {
     reason = "Ignore smithy4s 0.18.40, as it accidentally changes the behavior of encoding request paths",
     doc = "https://github.com/disneystreaming/smithy4s/issues/1792",


### PR DESCRIPTION
[MUnit 1.1.2 removed a trait needed for binary compatibility with munit-scalacheck](https://github.com/scalameta/munit/issues/983). This was [fixed in `v1.2.0`](https://github.com/scalameta/munit/releases/tag/v1.2.0).

Since it is common to use MUnit with munit-scalacheck, many Scala Steward PRs are probably failing to build due to the incompatibility. Many will not receive the `v1.2.0` update until `v1.1.2` is merged. Therefore it makes sense to retract `v1.1.2` and let Scala Steward proceed directly to `v1.2.0`.