### PR TITLE
Block updates for Scala 3.7.4

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -42,6 +42,19 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.8.0" } },
   { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.8.0" } },
 
+  // Ignore the next Scala 3 Next version until it is announced (unplanned patch release)
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",                      version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",                       version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1",                  version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "tasty-core",                           version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala2-library-cc-tasty-experimental", version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala2-library-tasty-experimental",    version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-language-server",               version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-presentation-compiler",         version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-staging",                       version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.7.4" } },
+  { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.7.4" } },
+
   // Ignore the Scala 3.6.1 - abandoned hotfix to broken release 3.6.0
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",                      version = { exact = "3.6.1" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",                       version = { exact = "3.6.1" } },


### PR DESCRIPTION
Scala 3.7.4 was not originally planned to be released, however we've decided to have 1 more patch release before 3.8.0