### PR TITLE
Add github ci generate hook for zio-sbt-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Thanks goes to these wonderful people for contributing to Scala Steward:
 * [Eldar Yusupov](https://github.com/eyusupov)
 * [Ender Tunç](https://github.com/endertunc)
 * [Erik Erlandson](https://github.com/erikerlandson)
+* [Erik van Oosten](https://github.com/erikvanoosten)
 * [Erlend Hamnaberg](https://github.com/hamnis)
 * [eugeniyk](https://github.com/eugeniyk)
 * [Fabian Grutsch](https://github.com/fgrutsch)

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -119,13 +119,14 @@ final class HookExecutor[F[_]](implicit
 }
 
 object HookExecutor {
-  // sbt plugins that provide a githubWorkflowGenerate task.
+  // sbt plugins that provide a GitHub workflow generate task.
   private val sbtGitHubWorkflowGenerateModules = List(
     (GroupId("com.codecommit"), ArtifactId("sbt-github-actions")),
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak")),
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-sonatype")),
     (GroupId("com.codecommit"), ArtifactId("sbt-spiewak-bintray")),
     (GroupId("com.github.sbt"), ArtifactId("sbt-github-actions")),
+    (GroupId("dev.zio"), ArtifactId("zio-sbt-ci")),
     (GroupId("io.chrisdavenport"), ArtifactId("sbt-davenverse")),
     (GroupId("io.github.nafg.mergify"), ArtifactId("sbt-mergify-github-actions")),
     (GroupId("org.typelevel"), ArtifactId("sbt-typelevel-ci-release")),
@@ -146,6 +147,15 @@ object HookExecutor {
   private val conditionalSbtGitHubWorkflowGenerateModules =
     (sbtGroupId, sbtArtifactId) :: (sbtScalafixGroupId, sbtScalafixArtifactId) :: scalaLangModules
 
+  private def sbtGithubWorkflowGenerateCommand(
+      groupId: GroupId,
+      artifactId: ArtifactId
+  ): Nel[String] =
+    if ((groupId, artifactId) == (GroupId("dev.zio"), ArtifactId("zio-sbt-ci")))
+      Nel.of("sbt", "ciGenerateGithubWorkflow")
+    else
+      Nel.of("sbt", "githubWorkflowGenerate")
+
   private def sbtGithubWorkflowGenerateHook(
       groupId: GroupId,
       artifactId: ArtifactId,
@@ -154,7 +164,7 @@ object HookExecutor {
     PostUpdateHook(
       groupId = Some(groupId),
       artifactId = Some(artifactId),
-      command = Nel.of("sbt", "githubWorkflowGenerate"),
+      command = sbtGithubWorkflowGenerateCommand(groupId, artifactId),
       useSandbox = true,
       commitMessage = _ => CommitMsg("Regenerate GitHub Actions workflow"),
       enabledByCache = enabledByCache,

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -118,6 +118,23 @@ class HookExecutorTest extends CatsEffectSuite {
     state.map(assertEquals(_, expected))
   }
 
+  test("sbt-zio-ci") {
+    val update = ("dev.zio".g % "zio-sbt-ci".a % "0.4.0-alpha.34" %> "0.4.0-alpha.35").single
+    val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
+
+    val expected = MockState.empty.copy(
+      trace = Vector(
+        Log(
+          "Executing post-update hook for dev.zio:zio-sbt-ci with command 'sbt ciGenerateGithubWorkflow'"
+        ),
+        Cmd.execSandboxed(repoDir, "sbt", "ciGenerateGithubWorkflow"),
+        Cmd.gitStatus(repoDir)
+      )
+    )
+
+    state.map(assertEquals(_, expected))
+  }
+
   test("hook from config") {
     val update = ("com.random".g % "cool-lib".a % "1.0" %> "1.1").single
     val config = RepoConfig(


### PR DESCRIPTION
The [zio-sbt-ci sbt plugin](https://github.com/zio/zio-sbt/tree/main/zio-sbt-ci) regenerates a GitHub workflow just like some of the other supported sbt plugins. Unfortunately, it uses a different sbt command for this so some tweaks are needed.

Note that the zio plugin does not follow name-conventions, its artifact id really is zio-sbt-ci and not ~sbt-zio-ci~.

Thanks for scala-steward. It is a massive time saver!