### PR TITLE
Fix: repo-config for `pullRequests.draft` should not be wiped when combined with _unset_ config

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -63,7 +63,10 @@ object PullRequestsConfig {
           grouping = x.grouping |+| y.grouping,
           includeMatchedLabels = x.includeMatchedLabels.orElse(y.includeMatchedLabels),
           customLabels = x.customLabels |+| y.customLabels,
-          draft = (x.draft, y.draft).mapN(_ || _)
+          draft = {
+            implicit val booleanOrMonoid: Monoid[Boolean] = Monoid.instance(false, _ || _)
+            x.draft |+| y.draft
+          }
         )
     )
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestsConfigTest.scala
@@ -1,9 +1,20 @@
 package org.scalasteward.core.repoconfig
 
+import cats.implicits.*
 import cats.kernel.laws.discipline.MonoidTests
 import munit.DisciplineSuite
 import org.scalasteward.core.TestInstances.*
 
 class PullRequestsConfigTest extends DisciplineSuite {
   checkAll("Monoid[PullRequestsConfig]", MonoidTests[PullRequestsConfig].monoid)
+
+  test("global config to use 'draft' PRs should be retained after merging with local config") {
+    val draftTrue = PullRequestsConfig(draft = Some(true))
+    val draftUnset = PullRequestsConfig()
+    val draftFalse = PullRequestsConfig(draft = Some(false))
+
+    assert((draftTrue |+| draftUnset).draft === Some(true))
+    assert((draftTrue |+| draftFalse).draft === Some(true))
+    assert((draftUnset |+| draftUnset).draft === None)
+  }
 }


### PR DESCRIPTION
This fixes a bug that came in with the initial introduction of the `pullRequests.draft` config setting:

* https://github.com/scala-steward-org/scala-steward/pull/3628

The bug was that when combining global & local repo config, the result of combining `pullRequests.draft = true` with a config with _no_ setting for `pullRequests.draft` would be that `pullRequests.draft` was _unset_ (ie given the value `None`, rather than `Some(true)`.

Here's an example of where this was a problem in the wild:

* https://github.com/guardian/scala-steward-public-repos/pull/102#issuecomment-3356561770

## Cause

This arose because of the behaviour of `.mapN()`, which I hadn't really thought through:

https://github.com/scala-steward-org/scala-steward/blob/373d5a70533a024389bb93f5028d0fee81a6cbd6/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala#L66

...in retrospect, it's not too surprising that `.mapN()` on two `Option`s only produces a populated `Some` if _both_ the inputs are `Some` - which is not the behaviour we want here. For us, if only _one_ of the configs has a value set, we definitely want to use that value.

## Fix

In the end, the neatest way I could find to get the desired behaviour was to remove the thing stopping us from having a `Monoid[Option[Boolean]]` - ie that there is no _general_ `Monoid[Boolean]` (there is no _one_ correct way to combine two `Boolean`s). We can create a specific one for this case, that says `Boolean`s should be combined with logical-`OR` (rather than `AND`, for instance) - and only expose it in the very narrow scope of where we want to use it.
