### PR TITLE
scalafmt-core is not available for Scala 3

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -17,7 +17,6 @@
 package org.scalasteward.core
 
 import cats.syntax.all.*
-import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
 import org.scalasteward.core.data.*
 
 package object scalafmt {
@@ -26,7 +25,7 @@ package object scalafmt {
 
   val scalafmtArtifactId: ArtifactId = {
     val core = "scalafmt-core"
-    ArtifactId(core, s"${core}_$defaultScalaBinaryVersion")
+    ArtifactId(core, s"${core}_2.13")
   }
 
   val scalafmtModule: (GroupId, ArtifactId) =


### PR DESCRIPTION
Scala Steward instance using the Scala-Steward-Github-Action stopped updating scalafmt some time ago. The action launches scala-steward using coursier and that picks the highest available Scala version for its artifacts. As the scalafmt-core artifact isn't available for Scala 3, the `defaultScalaBinaryVersion` can't be used. Instead, I always use the 2.13 artifact to find the available versions.