### PR TITLE
Add scalafix for `weaver-test` `0.11.0`

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -271,6 +271,12 @@ migrations = [
     artifactIds: ["weaver-.*"],
     newVersion: "0.9.0",
     rewriteRules: ["github:typelevel/weaver-test/RenameAssertToExpect?sha=v0.9.0"]
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["weaver-.*"],
+    newVersion: "0.11.0",
+    rewriteRules: ["github:typelevel/weaver-test/v0_11_0?sha=0.11.0"]
   }
 
 ]


### PR DESCRIPTION
Note that version `0.11.0` hasn't been released yet, but the scalafix rules for it are [here](https://github.com/typelevel/weaver-test/blob/main/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule).

I assume we should update the scala steward config _before_ releasing `0.11.0`