### PR TITLE
Correct the weaver-test `v0.11.0` tag.

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -276,7 +276,7 @@ migrations = [
     groupId: "org.typelevel",
     artifactIds: ["weaver-.*"],
     newVersion: "0.11.0",
-    rewriteRules: ["github:typelevel/weaver-test/v0_11_0?sha=0.11.0"]
+    rewriteRules: ["github:typelevel/weaver-test/v0_11_0?sha=v0.11.0"]
   }
 
 ]


### PR DESCRIPTION
Weaver was released under `v0.11.0`, and not `0.11.0`. The tag used by Scala Steward is therefore incorrect.

[Here]( https://raw.githubusercontent.com/typelevel/weaver-test/refs/tags/v0.11.0/scalafix/rules/src/main/scala/fix/v0_11_0.scala) is the correct file (note the `v0.11.0` prefix).

Apologies for the mistake earlier!