### PR TITLE
Add dependency-cooldowns / minimum-artifact-age

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -109,6 +109,15 @@ updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." }
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
+# Scala Steward will ignore dependency update versions while they are newer than
+# the specified minimum age.
+#
+# Scala Steward records the first time it sees any artefact version and calculates
+# the artefact version's age from that time.
+updates.cooldown = {
+  minimumAge: "7 days"
+}
+
 # The dependencies which match the given pattern are retracted. Their existing pull-request will be closed.
 #
 # Each entry must have a `reason`, a `doc` URL and a list of dependency patterns.

--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
 import org.scalasteward.core.data.*
 import org.scalasteward.core.repoconfig.{UpdatePattern, UpdatesConfig, VersionPattern}
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.util.{Nel, Timestamp}
+import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
 
 @BenchmarkMode(Array(Mode.AverageTime))
 class UpdatesConfigBenchmark {
@@ -32,13 +33,14 @@ class UpdatesConfigBenchmark {
     val dependency = CrossDependency(Dependency(groupId, ArtifactId("artifact"), Version("1.0.0")))
     val newerVersions = Nel
       .of("2.0.0", "2.1.0", "2.1.1", "2.2.0", "3.0.0", "3.1.0", "3.2.1", "3.3.3", "4.0", "5.0")
-      .map(Version.apply)
+      .map(v => VersionWithFirstSeen(Version(v), None))
     val update = ArtifactUpdateCandidates(ArtifactForUpdate(dependency), newerVersions)
+    val currentTime = Timestamp(millis = 0)
 
-    UpdatesConfig().keep(update)
-    UpdatesConfig(allow = Some(List(UpdatePattern(groupId, None, None)))).keep(update)
+    UpdatesConfig().keep(update, currentTime)
+    UpdatesConfig(allow = Some(List(UpdatePattern(groupId, None, None)))).keep(update, currentTime)
     UpdatesConfig(allow =
       Some(List(UpdatePattern(groupId, None, Some(VersionPattern(prefix = Some("6.0"))))))
-    ).keep(update)
+    ).keep(update, currentTime)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -129,7 +129,7 @@ final class SbtAlg[F[_]](defaultResolvers: List[Resolver], ignoreOptsFiles: Bool
   private def latestSbtScalafixVersion: F[Option[Version]] =
     versionsCache
       .getVersions(Scope(sbtScalafixDependency, defaultResolvers), None)
-      .map(_.lastOption)
+      .map(_.lastOption.map(_.version))
 
   private def runBuildMigration(buildRoot: BuildRoot, migration: ScalafixMigration): F[Unit] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CooldownConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CooldownConfig.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.implicits.*
+import io.circe.generic.semiauto.deriveCodec
+import io.circe.{Codec, Decoder, Encoder}
+import org.scalasteward.core.data.ArtifactUpdateCandidates
+import org.scalasteward.core.util.Timestamp
+import org.scalasteward.core.util.dateTime.parseFiniteDuration
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class CooldownConfig(
+    minimumAge: FiniteDuration
+) {
+  def filterForAge(
+      updateCandidates: ArtifactUpdateCandidates,
+      currentTime: Timestamp
+  ): Option[ArtifactUpdateCandidates] =
+    updateCandidates.filterVersionsWithFirstSeen(_.isOlderThan(minimumAge, currentTime))
+}
+
+object CooldownConfig {
+  implicit val codec: Codec[CooldownConfig] = deriveCodec
+  implicit val finiteDurationDecoder: Decoder[FiniteDuration] =
+    Decoder[String].emap(s => parseFiniteDuration(s).leftMap(_.toString))
+  implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
+    Encoder[String].contramap(_.toString)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -32,7 +32,7 @@ final case class UpdatePattern(
 object UpdatePattern {
   final case class MatchResult(
       byArtifactId: List[UpdatePattern],
-      filteredVersions: List[Version]
+      filteredVersions: Set[Version]
   )
 
   def findMatch(
@@ -47,7 +47,7 @@ object UpdatePattern {
     val filteredVersions = update.refersToUpdateVersions.filter(newVersion =>
       byArtifactId.exists(_.version.forall(_.matches(newVersion.value))) === include
     )
-    MatchResult(byArtifactId, filteredVersions)
+    MatchResult(byArtifactId, filteredVersions.toSet)
   }
 
   implicit val updatePatternCodec: Codec[UpdatePattern] =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -84,9 +84,9 @@ final class UpdateAlg[F[_]](implicit
   private def findNewerVersions(
       dependency: Scope[Dependency],
       maxAge: Option[FiniteDuration]
-  ): OptionT[F, Nel[Version]] =
+  ): OptionT[F, Nel[VersionsCache.VersionWithFirstSeen]] =
     OptionT(versionsCache.getVersions(dependency, maxAge).map { versions =>
-      Nel.fromList(versions.filter(_ > dependency.value.version))
+      Nel.fromList(versions.filter(v => v.version > dependency.value.version))
     })
 }
 

--- a/modules/core/src/test/resources/versions-cache-value-with-first-seen.json
+++ b/modules/core/src/test/resources/versions-cache-value-with-first-seen.json
@@ -1,0 +1,8 @@
+{
+    "updatedAt": 10002,
+    "versions": [
+        { "version": "1.0.0", "firstSeen": 10000 },
+        { "version": "1.0.1", "firstSeen": 10001 }
+    ],
+    "maybeError": null
+}

--- a/modules/core/src/test/resources/versions-cache-value-without-first-seen.json
+++ b/modules/core/src/test/resources/versions-cache-value-without-first-seen.json
@@ -1,0 +1,5 @@
+{
+    "updatedAt": 1000,
+    "versions": ["1.0.0", "1.0.1"],
+    "maybeError": null
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/VersionsCacheTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/VersionsCacheTest.scala
@@ -1,0 +1,37 @@
+package org.scalasteward.core.coursier
+
+import io.circe.parser
+import munit.FunSuite
+import org.scalasteward.core.coursier.VersionsCache.{Value, VersionWithFirstSeen}
+import org.scalasteward.core.data.Version
+import org.scalasteward.core.util.Timestamp
+
+import scala.io.Source
+
+class VersionsCacheTest extends FunSuite {
+  test("version cache deserialisation without first seen") {
+    val input = Source.fromResource("versions-cache-value-without-first-seen.json").mkString
+    val expected = Value(
+      Timestamp(1000),
+      List(
+        VersionWithFirstSeen(Version("1.0.0"), None),
+        VersionWithFirstSeen(Version("1.0.1"), None)
+      ),
+      None
+    )
+    assertEquals(parser.decode[Value](input), Right(expected))
+  }
+
+  test("version cache deserialisation with first seen") {
+    val input = Source.fromResource("versions-cache-value-with-first-seen.json").mkString
+    val expected = Value(
+      Timestamp(10002),
+      List(
+        VersionWithFirstSeen(Version("1.0.0"), Some(Timestamp(10000))),
+        VersionWithFirstSeen(Version("1.0.1"), Some(Timestamp(10001)))
+      ),
+      None
+    )
+    assertEquals(parser.decode[Value](input), Right(expected))
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CooldownConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CooldownConfigTest.scala
@@ -1,0 +1,27 @@
+package org.scalasteward.core.repoconfig
+
+import munit.FunSuite
+import org.scalasteward.core.TestSyntax.*
+import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
+import org.scalasteward.core.util.Timestamp
+
+import scala.concurrent.duration.*
+
+class CooldownConfigTest extends FunSuite {
+  test("apply first matching cooldown config") {
+    val config = CooldownConfig(
+      minimumAge = 7.millis
+    )
+
+    val update =
+      ("org.bang".g % "example".a % "1.0.0" %> VersionWithFirstSeen(
+        "1.0.1".v,
+        Some(Timestamp(8))
+      )).single
+
+    assertEquals(
+      config.filterForAge(update, Timestamp(10)),
+      None
+    )
+  }
+}

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -114,6 +114,15 @@ updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." }
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
+# Scala Steward will ignore dependency update versions while they are newer than
+# the specified minimum age.
+#
+# Scala Steward records the first time it sees any artefact version and calculates
+# the artefact version's age from that time.
+updates.cooldown = {
+  minimumAge: "7 days"
+}
+
 # The dependencies which match the given pattern are retracted. Their existing pull-request will be closed.
 #
 # Each entry must have a `reason`, a `doc` URL and a list of dependency patterns.


### PR DESCRIPTION
_@emdash-ie & myself (@rtyley) are co-authors of this work._

This PR adds a new `updates.cooldown` config option to allow configuring Scala Steward to defer suggesting an update to a new version of a dependency, until that version has survived a 'cooldown' period (eg 7 days).

This intended to be useful to users who want to reduce the risk of updating to a malicious new version of a dependency before it's been examined by their supply-chain security vendor, addressing:

* https://github.com/scala-steward-org/scala-steward/issues/3757

Note that applying a cooldown does not necessarily mean that you will get _fewer_ updates - just that any update offered will be at least as old as specified.

Artifacts that are _too recent_ will get rejected with a `TooRecentForCooldown` rejection reason.

## Internal changes

* `VersionsCache` now persists `VersionWithFirstSeen` rather than `Version`, allowing us to record when a new version was first seen by this Scala Steward instance (the only simple & reliable way to find out how old a Maven artifact is!). We've added `VersionsCacheTest` to ensure we can still decode both old and new versions of the cache data.
* `ArtifactUpdateCandidates`
  * now stores `newerVersionsWithFirstSeen: Nel[VersionWithFirstSeen]`, so that the candidate versions can be evaluated by age.
  * gains two convenience methods, `filterVersions()` & `filterVersionsWithFirstSeen()`, which filter the versions of the update and return an `Option[ArtifactUpdateCandidates]`, with a value of `None` if no versions are left - this extracts that logic from several places in the Scala Steward codebase (`isAllowed`, `isPinned`, `isIgnored` & `scalaLTSFilter`)

## Config

Right now there's a simple single value that can be configured - this is the cooldown period for all artifacts:

```
updates.cooldown = {
  minimumAge: "7 days"
}
```

### Future config

Later on, in a subsequent PR, we might allow syntax like this, for example stating that we want all Guardian updates promptly, but all other artifacts only once they're 7 days old:

```
updates.cooldown = {
  minimumAge: "7 days",
  overrides: [
    { minimumAge: "1 day", [{groupId = "com.gu"}] }
  ]
}
```

