### PR TITLE
Bump max-buffer-size to 65536

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -53,7 +53,7 @@ Options and flags:
     --disable-sandbox
         Whether to not use the sandbox
     --max-buffer-size <integer>
-        Size of the buffer for the output of an external process in lines; default: 49152
+        Size of the buffer for the output of an external process in lines; default: 65536
     --repo-config <uri>
         Additional repo config file (can be used multiple times)
     --disable-default-repo-config

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -182,7 +182,7 @@ object Cli {
     (whitelist, readOnly, enableSandbox).mapN(SandboxCfg.apply)
 
   private val maxBufferSize: Opts[Int] = {
-    val default = 49152
+    val default = 65536
     val help =
       s"Size of the buffer for the output of an external process in lines; default: $default"
     option[Int](name.maxBufferSize, help).withDefault(default)


### PR DESCRIPTION
Spotify's Scio continues to have issues with smaller buffer sizes; this bumps the default max-buffer-size to 65536

cc @clairemcginty 