### PR TITLE
Refactor: Separate modelling of candidate `newerVersions` from `Update`s

### DIFF
--- a/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
+++ b/modules/benchmark/src/main/scala/org/scalasteward/benchmark/UpdatesConfigBenchmark.scala
@@ -33,7 +33,7 @@ class UpdatesConfigBenchmark {
     val newerVersions = Nel
       .of("2.0.0", "2.1.0", "2.1.1", "2.2.0", "3.0.0", "3.1.0", "3.2.1", "3.3.3", "4.0", "5.0")
       .map(Version.apply)
-    val update = Update.ForArtifactId(dependency, newerVersions)
+    val update = ArtifactUpdateCandidates(ArtifactForUpdate(dependency), newerVersions)
 
     UpdatesConfig().keep(update)
     UpdatesConfig(allow = Some(List(UpdatePattern(groupId, None, None)))).keep(update)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -124,6 +124,12 @@ final case class Version(value: String) {
 object Version {
   case class Update(currentVersion: Version, nextVersion: Version)
 
+  def show(versions: Version*): String = {
+    val vs0 = versions.map(_.value)
+    val vs1: Seq[String] = if (vs0.size > 6) (vs0.take(3) :+ "...") ++ vs0.takeRight(3) else vs0
+    vs1.mkString(" -> ")
+  }
+
   val tagNames: List[Version => String] = List("v" + _, _.value, "release-" + _)
 
   implicit val versionDecoder: Decoder[Version] =
@@ -137,6 +143,9 @@ object Version {
       val (c1, c2) = padToSameLength(v1.alnumComponents, v2.alnumComponents, Component.Empty)
       c1.compare(c2)
     }
+
+  implicit val versionUpdateOrder: Order[Version.Update] =
+    Order.by((vu: Version.Update) => (vu.currentVersion, vu.nextVersion))
 
   private def padToSameLength[A](l1: List[A], l2: List[A], elem: A): (List[A], List[A]) = {
     val maxLength = math.max(l1.length, l2.length)

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
@@ -204,21 +204,19 @@ object Selector {
       update: Update.Single,
       modulePositions: List[ModulePosition]
   ): List[Substring.Replacement] =
-    update.forArtifactIds.toList.flatMap { forArtifactId =>
-      val newerGroupId = forArtifactId.newerGroupId
-      val newerArtifactId = forArtifactId.newerArtifactId
+    update.artifactsForUpdate.toList.flatMap { artifactForUpdate =>
+      val newerGroupId = artifactForUpdate.newerGroupId
+      val newerArtifactId = artifactForUpdate.newerArtifactId
       if (newerGroupId.isEmpty && newerArtifactId.isEmpty) List.empty
       else {
-        val currentGroupId = forArtifactId.groupId
-        val currentArtifactId = forArtifactId.artifactIds.head
         modulePositions
           .filter { p =>
-            p.groupId.value === currentGroupId.value &&
-            currentArtifactId.names.contains_(p.artifactId.value)
+            p.groupId.value === artifactForUpdate.groupId.value &&
+            artifactForUpdate.artifactId.names.contains_(p.artifactId.value)
           }
           .flatMap { p =>
-            newerGroupId.map(g => p.groupId.replaceWith(g.value)).toList ++
-              newerArtifactId.map(a => p.artifactId.replaceWith(a)).toList
+            newerGroupId.map(g => p.groupId.replaceWith(g.value)) ++
+              newerArtifactId.map(a => p.artifactId.replaceWith(a))
           }
       }
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -363,7 +363,7 @@ object NewPullRequestData {
 
     val artifactMigrationsLabel = Option.when {
       update.asSingleUpdates
-        .flatMap(_.forArtifactIds.toList)
+        .flatMap(_.artifactsForUpdate.toList)
         .exists(u => u.newerGroupId.nonEmpty || u.newerArtifactId.nonEmpty)
     }("artifact-migrations")
     val scalafixLabel = edits.collectFirst { case _: ScalafixEdit => "scalafix-migrations" }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -72,7 +72,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
       _.collect {
         case (url, Entry(baseSha1, u: Update.Single, state, _, number, updateBranch))
             if state === PullRequestState.Open &&
-              u.withNewerVersions(update.newerVersions) === update &&
+              u.withNextVersion(update.nextVersion) === update &&
               u.nextVersion < update.nextVersion =>
           for {
             number <- number

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repoconfig
 import cats.syntax.all.*
 import io.circe.Codec
 import io.circe.generic.semiauto.*
-import org.scalasteward.core.data.{GroupId, Update, Version}
+import org.scalasteward.core.data.{ArtifactUpdateVersions, GroupId, Version}
 
 final case class UpdatePattern(
     groupId: GroupId,
@@ -37,12 +37,14 @@ object UpdatePattern {
 
   def findMatch(
       patterns: List[UpdatePattern],
-      update: Update.ForArtifactId,
+      update: ArtifactUpdateVersions,
       include: Boolean
   ): MatchResult = {
-    val byGroupId = patterns.filter(_.groupId === update.groupId)
-    val byArtifactId = byGroupId.filter(_.artifactId.forall(_ === update.artifactId.name))
-    val filteredVersions = update.newerVersions.filter(newVersion =>
+    val artifactForUpdate = update.artifactForUpdate
+    val byGroupId = patterns.filter(_.groupId === artifactForUpdate.groupId)
+    val byArtifactId =
+      byGroupId.filter(_.artifactId.forall(_ === artifactForUpdate.artifactId.name))
+    val filteredVersions = update.refersToUpdateVersions.filter(newVersion =>
       byArtifactId.exists(_.version.forall(_.matches(newVersion.value))) === include
     )
     MatchResult(byArtifactId, filteredVersions)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -68,13 +68,13 @@ object UpdateState {
       case DependencyUpToDate(_) =>
         s"up-to-date: $gav"
       case DependencyOutdated(_, update) =>
-        s"new version: $gav -> ${update.newerVersions.head}"
+        s"new version: $gav -> ${update.nextVersion}"
       case PullRequestUpToDate(_, update, pullRequest) =>
-        s"PR opened: $gav -> ${update.newerVersions.head} ($pullRequest)"
+        s"PR opened: $gav -> ${update.nextVersion} ($pullRequest)"
       case PullRequestOutdated(_, update, pullRequest) =>
-        s"PR outdated: $gav -> ${update.newerVersions.head} ($pullRequest)"
+        s"PR outdated: $gav -> ${update.nextVersion} ($pullRequest)"
       case PullRequestClosed(_, update, pullRequest) =>
-        s"PR closed: $gav -> ${update.newerVersions.head} ($pullRequest)"
+        s"PR closed: $gav -> ${update.nextVersion} ($pullRequest)"
     }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -332,7 +332,7 @@ class RewriteTest extends FunSuite {
 
   test("artifact change with sbt ModuleID") {
     val update = ("org.spire-math".g % "kind-projector".a % "0.9.0" %> "0.10.0").single
-      .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
+      .migration(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
     val original = Map("build.sbt" -> """ "org.spire-math" %% "kind-projector" % "0.9.0" """)
     val expected = Map("build.sbt" -> """ "org.typelevel" %% "kind-projector" % "0.10.0" """)
     runApplyUpdate(update, original, expected)
@@ -340,7 +340,7 @@ class RewriteTest extends FunSuite {
 
   test("artifact change with Mill dependency") {
     val update = ("org.spire-math".g % "kind-projector".a % "0.9.0" %> "0.10.0").single
-      .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
+      .migration(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
     val original = Map("build.sc" -> """ "org.spire-math::kind-projector:0.9.0" """)
     val expected = Map("build.sc" -> """ "org.typelevel::kind-projector:0.10.0" """)
     runApplyUpdate(update, original, expected)
@@ -348,7 +348,7 @@ class RewriteTest extends FunSuite {
 
   test("test updating group id and version") {
     val update = ("com.github.mpilquist".g % "simulacrum".a % "0.19.0" %> "1.0.0").single
-      .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("simulacrum"))
+      .migration(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("simulacrum"))
     val original = Map("build.sbt" -> """val simulacrum = "0.19.0"
                                         |"com.github.mpilquist" %% "simulacrum" % simulacrum
                                         |"""".stripMargin)
@@ -360,7 +360,7 @@ class RewriteTest extends FunSuite {
 
   test("test updating artifact id and version") {
     val update = ("com.test".g % "artifact".a % "1.0.0" %> "2.0.0").single
-      .copy(newerGroupId = Some("com.test".g), newerArtifactId = Some("newer-artifact"))
+      .migration(newerGroupId = Some("com.test".g), newerArtifactId = Some("newer-artifact"))
     val original =
       Map("Dependencies.scala" -> """val testVersion = "1.0.0"
                                     |val test = "com.test" %% "artifact" % testVersion
@@ -375,7 +375,7 @@ class RewriteTest extends FunSuite {
   // https://github.com/scala-steward-org/scala-steward/issues/1977
   test("artifact change: version and groupId/artifactId in different files") {
     val update = ("io.chrisdavenport".g % "log4cats".a % "1.1.1" %> "1.2.0").single
-      .copy(newerGroupId = Some("org.typelevel".g))
+      .migration(newerGroupId = Some("org.typelevel".g))
     val original = Map(
       "Dependencies.scala" -> """val log4catsVersion = "1.1.1" """,
       "build.sbt" -> """ "io.chrisdavenport" %% "log4cats" % log4catsVersion """
@@ -390,9 +390,9 @@ class RewriteTest extends FunSuite {
   // https://github.com/scala-steward-org/scala-steward/issues/1974
   test("artifact change: group update") {
     val update1 = ("io.chrisdavenport".g % "log4cats-core".a % "1.2.1" %> "1.3.0").single
-      .copy(newerGroupId = Some("org.typelevel".g))
+      .migration(newerGroupId = Some("org.typelevel".g))
     val update2 = ("io.chrisdavenport".g % "log4cats-slf4j".a % "1.2.1" %> "1.3.0").single
-      .copy(newerGroupId = Some("org.typelevel".g))
+      .migration(newerGroupId = Some("org.typelevel".g))
     val update = Update.groupByGroupId(List(update1, update2)).head
     val original = Map(
       "Dependencies.scala" -> """val log4catsVersion = "1.2.1" """,
@@ -409,7 +409,7 @@ class RewriteTest extends FunSuite {
 
   test("groupId and version change of Maven dependency") {
     val update = ("io.chrisdavenport".g % "log4cats".a % "1.1.1" %> "1.2.0").single
-      .copy(newerGroupId = Some("org.typelevel".g))
+      .migration(newerGroupId = Some("org.typelevel".g))
     val original = Map("pom.xml" -> """<groupId>io.chrisdavenport</groupId>
                                       |<artifactId>log4cats</artifactId>
                                       |<version>1.1.1</version>""".stripMargin)
@@ -421,7 +421,7 @@ class RewriteTest extends FunSuite {
 
   test("artifactId and version change of Maven dependency with binary suffix") {
     val update = ("org.foo".g % ("log4cats", "log4cats_2.13").a % "1.1.1" %> "1.2.0").single
-      .copy(newerArtifactId = Some("log4dogs"))
+      .migration(newerArtifactId = Some("log4dogs"))
     val original = Map("pom.xml" -> s"""<groupId>org.foo</groupId>
                                        |<artifactId>log4cats_$${scala.binary.version}</artifactId>
                                        |<version>1.1.1</version>""".stripMargin)
@@ -436,7 +436,7 @@ class RewriteTest extends FunSuite {
     val update = ("com.pauldijou".g % Nel.of(
       ("jwt-core", "jwt-core_2.12").a,
       ("jwt-core", "jwt-core_2.13").a
-    ) % "5.0.0" %> "9.2.0").single.copy(newerGroupId = Some("com.github.jwt-scala".g))
+    ) % "5.0.0" %> "9.2.0").single.migration(newerGroupId = Some("com.github.jwt-scala".g))
     val original = Map("build.sbt" -> """ "com.pauldijou" %% "jwt-core" % "5.0.0" """)
     val expected = Map("build.sbt" -> """ "com.github.jwt-scala" %% "jwt-core" % "9.2.0" """)
     runApplyUpdate(update, original, expected)
@@ -941,7 +941,7 @@ class RewriteTest extends FunSuite {
   // https://github.com/scala-steward-org/scala-steward/issues/3206
   test("sbt module where the artifactId is also part of the groupId") {
     val update = ("com.typesafe.play".g % "play".a % "2.9.0" %> "3.0.0").single
-      .copy(newerGroupId = Some("org.playframework".g), newerArtifactId = Some("play"))
+      .migration(newerGroupId = Some("org.playframework".g), newerArtifactId = Some("play"))
     val original = Map("build.sbt" -> """ "com.typesafe.play" %% "play" % "2.9.0" """)
     val expected = Map("build.sbt" -> """ "org.playframework" %% "play" % "3.0.0" """)
     runApplyUpdate(update, original, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -815,7 +815,7 @@ class NewPullRequestDataTest extends FunSuite {
   }
 
   test("artifact-migrations label") {
-    val update = ("a".g % "b".a % "1" -> "2").single.copy(newerGroupId = Some("aa".g))
+    val update = ("a".g % "b".a % "1" -> "2").single.migration(newerGroupId = Some("aa".g))
     val obtained = labelsFor(update)
     val expected = List("library-update", "artifact-migrations", "commit-count:0")
     assertEquals(obtained, expected)

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -15,7 +15,6 @@ import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{RetractedArtifact, UpdatePattern, VersionPattern}
-import org.scalasteward.core.util.Nel
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -81,7 +80,7 @@ class PullRequestRepositoryTest extends FunSuite {
 
   test("getObsoleteOpenPullRequests for single update") {
     val data = openPRFor(portableScala)
-    val nextUpdate = portableScala.copy(newerVersions = Nel.of("1.0.1".v))
+    val nextUpdate = portableScala.copy(nextVersion = "1.0.1".v)
 
     val (emptyResult, result, closedResult) =
       executeOnTestRepo(expectedStoreOps = Seq("read", "write", "write")) { repo =>

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -18,7 +18,7 @@ class FilterAlgTest extends FunSuite {
   test("localFilter: SNAP -> SNAP") {
     val update =
       ("org.scalatest".g % "scalatest".a % "3.0.8-SNAP2" %> Nel.of("3.0.8-SNAP10")).single
-    assertEquals(localFilter(update, config), Right(update))
+    assertEquals(localFilter(update, config), Right(update.asSoleUpdate))
   }
 
   test("localFilter: RC -> SNAP") {
@@ -28,12 +28,12 @@ class FilterAlgTest extends FunSuite {
 
   test("localFilter: update without bad version") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.0" %> Nel.of("1.1.2", "2.0.0")).single
-    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("1.1.2".v))))
+    assertEquals(localFilter(update, config), Right(update.asSpecificUpdate("1.1.2".v)))
   }
 
   test("localFilter: update with bad version") {
     val update = ("com.jsuereth".g % "sbt-pgp".a % "1.1.2-1" %> Nel.of("1.1.2", "2.0.0")).single
-    assertEquals(localFilter(update, config), Right(update.copy(newerVersions = Nel.of("2.0.0".v))))
+    assertEquals(localFilter(update, config), Right(update.asSpecificUpdate("2.0.0".v)))
   }
 
   test("localFilter: update with bad version 2") {
@@ -41,7 +41,7 @@ class FilterAlgTest extends FunSuite {
       Nel.of("7726", "8020", "2017.09", "1.2019.12")).single
     assertEquals(
       localFilter(update, config),
-      Right(update.copy(newerVersions = Nel.of("1.2019.12".v)))
+      Right(update.asSpecificUpdate("1.2019.12".v))
     )
   }
 
@@ -58,7 +58,7 @@ class FilterAlgTest extends FunSuite {
       config.updatesOrDefault.copy(allowPreReleases = allowedPreReleases.some).some
     )
 
-    val expected = Right(update.copy(newerVersions = Nel.of("2.0.1-M3".v)))
+    val expected = Right(update.asSpecificUpdate("2.0.1-M3".v))
     assertEquals(localFilter(update, configWithAllowed), expected)
   }
 
@@ -76,7 +76,7 @@ class FilterAlgTest extends FunSuite {
     )
 
     // ignore update to any version starting with 0.8.*
-    val update1 = ("eu.timepit".g % "refined".a % "0.8.0" %> "0.8.1").single
+    val update1 = ("eu.timepit".g % "refined".a % "0.8.0" %> Nel.of("0.8.1")).single
     val initialState1 = MockState.empty
     val (state1, filtered1) =
       filterAlg.localFilterSingle(config, update1).runSA(initialState1).unsafeRunSync()
@@ -88,12 +88,12 @@ class FilterAlgTest extends FunSuite {
     assertEquals(state1, expected1)
 
     // but at the same time allows update on greater (and smaller) versions
-    val update2 = ("eu.timepit".g % "refined".a % "0.9.0" %> "0.9.1").single
+    val update2 = ("eu.timepit".g % "refined".a % "0.9.0" %> Nel.of("0.9.1")).single
     val initialState2 = MockState.empty
     val (state2, filtered2) =
       filterAlg.localFilterSingle(config, update2).runSA(initialState2).unsafeRunSync()
 
-    assertEquals(filtered2, Some(update2))
+    assertEquals(filtered2, Some(update2.asSpecificUpdate("0.9.1".v)))
     assertEquals(state2, initialState2)
   }
 
@@ -111,21 +111,25 @@ class FilterAlgTest extends FunSuite {
         ).some
       ).some
     )
-    val expected = Right(update.copy(newerVersions = Nel.of("2.13.7".v)))
+    val expected = Right(update.asSpecificUpdate("2.13.7".v))
     assertEquals(localFilter(update, config), expected)
   }
 
   test("ignore update via config updates.pin") {
-    val update1 = ("org.http4s".g % "http4s-dsl".a % "0.17.0" %> "0.18.0").single
-    val update2 = ("eu.timepit".g % "refined".a % "0.8.0" %> "0.8.1").single
-    val update3 = ("eu.timepit".g % "refined".a % "0.9.0" %> "0.9.1").single
+    val update1 = ("org.http4s".g % "http4s-dsl".a % "0.17.0" %> Nel.of("0.18.0")).single
+    val update2 = ("eu.timepit".g % "refined".a % "0.8.0" %> Nel.of("0.8.1")).single
+    val update3 = ("eu.timepit".g % "refined".a % "0.9.0" %> Nel.of("0.9.1")).single
 
     val config = RepoConfig(
       updates = UpdatesConfig(
         pin = List(
-          UpdatePattern(update1.groupId, None, Some(VersionPattern(Some("0.17")))),
           UpdatePattern(
-            update2.groupId,
+            update1.artifactForUpdate.groupId,
+            None,
+            Some(VersionPattern(Some("0.17")))
+          ),
+          UpdatePattern(
+            update2.artifactForUpdate.groupId,
             Some("refined"),
             Some(VersionPattern(Some("0.8")))
           )
@@ -145,7 +149,7 @@ class FilterAlgTest extends FunSuite {
       .runA(MockState.empty)
       .unsafeRunSync()
 
-    assertEquals(filtered2, Some(update2))
+    assertEquals(filtered2, Some(update2.asSpecificUpdate("0.8.1".v)))
 
     // pinning the version to 0.8, prevents updates to greater versions, too.
     // becasue the artifact is "pinned" to version with the "0.8." prefix
@@ -159,14 +163,14 @@ class FilterAlgTest extends FunSuite {
 
   test("ignore update via config updates.allow") {
     val included = List(
-      ("org.my1".g % "artifact".a % "0.8.0" %> "0.8.1").single,
-      ("org.my2".g % "artifact".a % "0.8.0" %> "0.8.1").single,
-      ("org.my2".g % "artifact".a % "0.8.0" %> "0.9.1").single
+      ("org.my1".g % "artifact".a % "0.8.0" %> Nel.of("0.8.1")).single,
+      ("org.my2".g % "artifact".a % "0.8.0" %> Nel.of("0.8.1")).single,
+      ("org.my2".g % "artifact".a % "0.8.0" %> Nel.of("0.9.1")).single
     )
     val notIncluded = List(
-      ("org.http4s".g % "http4s-dsl".a % "0.17.0" %> "0.18.0").single,
-      ("org.my1".g % "artifact".a % "0.8.0" %> "0.9.1").single,
-      ("org.my3".g % "abc".a % "0.8.0" %> "0.8.1").single
+      ("org.http4s".g % "http4s-dsl".a % "0.17.0" %> Nel.of("0.18.0")).single,
+      ("org.my1".g % "artifact".a % "0.8.0" %> Nel.of("0.9.1")).single,
+      ("org.my3".g % "abc".a % "0.8.0" %> Nel.of("0.8.1")).single
     )
 
     val config = RepoConfig(
@@ -185,7 +189,7 @@ class FilterAlgTest extends FunSuite {
         .runA(MockState.empty)
         .unsafeRunSync()
 
-      assertEquals(filtered, Some(update))
+      assertEquals(filtered, Some(update.asSoleUpdate))
     }
     notIncluded.foreach { update =>
       val filtered = filterAlg
@@ -205,8 +209,8 @@ class FilterAlgTest extends FunSuite {
       updates = UpdatesConfig(
         pin = List(
           UpdatePattern(
-            update.groupId,
-            Some(update.artifactId.name),
+            update.artifactForUpdate.groupId,
+            Some(update.artifactForUpdate.artifactId.name),
             Some(VersionPattern(suffix = Some("jre8")))
           )
         ).some
@@ -214,7 +218,7 @@ class FilterAlgTest extends FunSuite {
     )
 
     val filtered = localFilter(update, config)
-    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8".v))))
+    assertEquals(filtered, Right(update.asSpecificUpdate("7.3.0.jre8".v)))
   }
 
   test("ignore update via config updates.ignore using suffix") {
@@ -225,8 +229,8 @@ class FilterAlgTest extends FunSuite {
       updates = UpdatesConfig(
         ignore = List(
           UpdatePattern(
-            update.groupId,
-            Some(update.artifactId.name),
+            update.artifactForUpdate.groupId,
+            Some(update.artifactForUpdate.artifactId.name),
             Some(VersionPattern(suffix = Some("jre11")))
           )
         ).some
@@ -234,19 +238,20 @@ class FilterAlgTest extends FunSuite {
     )
 
     val filtered = localFilter(update, config)
-    assertEquals(filtered, Right(update.copy(newerVersions = Nel.of("7.3.0.jre8".v))))
+    assertEquals(filtered, Right(update.asSpecificUpdate("7.3.0.jre8".v)))
   }
 
   test("ignore update via config updates.pin using prefix and suffix") {
     val update = ("com.microsoft.sqlserver".g % "mssql-jdbc".a % "7.2.2.jre8" %>
       Nel.of("7.2.2.jre11", "7.3.0.jre8", "7.3.0.jre11")).single
+    val artifactForUpdate = update.artifactForUpdate
 
     val config = RepoConfig(
       updates = UpdatesConfig(
         pin = List(
           UpdatePattern(
-            update.groupId,
-            Some(update.artifactId.name),
+            artifactForUpdate.groupId,
+            Some(artifactForUpdate.artifactId.name),
             Some(VersionPattern(Some("7.2."), Some("jre8")))
           )
         ).some
@@ -263,7 +268,7 @@ class FilterAlgTest extends FunSuite {
       """updates.ignore = [ { groupId = "sqlserver", version = { contains = "feature" } } ]"""
     )
     val obtained = repoConfig.flatMap(localFilter(update, _).leftMap(_.show))
-    assertEquals(obtained, Right(update.copy(newerVersions = Nel.of("7.3.0".v))))
+    assertEquals(obtained.map(_.nextVersion), Right("7.3.0".v))
   }
 
   test("isDependencyConfigurationIgnored: false") {
@@ -303,11 +308,11 @@ class FilterAlgTest extends FunSuite {
       ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.3.3" %> Nel.of(
         "3.4.0"
       )).single
-    assert(isScala3Lang(update))
+    assert(isScala3Lang(update.artifactForUpdate))
   }
 
   test("isScala3Lang: false") {
     val update = ("org.scala-lang".g % "scala-compiler".a % "2.13.11" %> Nel.of("2.13.12")).single
-    assert(!isScala3Lang(update))
+    assert(!isScala3Lang(update.artifactForUpdate))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/artifact/ArtifactMigrationsFinderTest.scala
@@ -113,13 +113,13 @@ class ArtifactMigrationsFinderTest extends FunSuite {
   test("findUpdates: newer groupId") {
     val dependency = "org.spire-math".g % ("kind-projector", "kind-projector_2.12").a % "0.9.10"
     val expected = ("org.spire-math".g % ("kind-projector", "kind-projector_2.12").a % "0.9.10" %>
-      Nel.of("0.10.3")).single
+      Nel.of("0.10.3")).single.artifactForUpdate
       .copy(newerGroupId = Some("org.typelevel".g), newerArtifactId = Some("kind-projector"))
     val obtained = updateAlg
       .findUpdates(List(dependency.withMavenCentral), RepoConfig.empty, None)
       .runA(MockState.empty)
       .unsafeRunSync()
-    assertEquals(obtained, List(expected))
+    assertEquals(obtained.map(_.artifactForUpdate), List(expected))
   }
 
   test("migrateDependency: newer groupId") {
@@ -151,7 +151,7 @@ class ArtifactMigrationsFinderTest extends FunSuite {
   test("migrateDependency: sbt-dynver with migration") {
     val dependency = ("com.dwijnand".g % "sbt-dynver".a % "4.1.1")
       .copy(sbtVersion = Some(SbtVersion("1.0")), scalaVersion = Some(ScalaVersion("2.12")))
-    val expected = (dependency %> Nel.of("5.1.1")).single
+    val expected = (dependency %> Nel.of("5.1.1")).single.artifactForUpdate
       .copy(newerGroupId = Some("com.github.sbt".g), newerArtifactId = Some("sbt-dynver"))
     val obtained = updateAlg
       .findUpdates(
@@ -162,6 +162,6 @@ class ArtifactMigrationsFinderTest extends FunSuite {
       .runA(MockState.empty)
       .unsafeRunSync()
 
-    assertEquals(obtained, List(expected))
+    assertEquals(obtained.map(_.artifactForUpdate), List(expected))
   }
 }


### PR DESCRIPTION
_Addresses https://github.com/scala-steward-org/scala-steward/issues/3781 - `Update.Single` doesn't need `newerVersions`, just `nextVersion`_

The Scala Steward codebase deals with the concept of 'updates' in two areas:

* **Multiple `newerVersions`**: Initially, evaluating _candidate_ updates (in `UpdateAlg` & `FilterAlg`), where for any given artifact, there can be many possible versions we might want to upgrade to. The list of versions is reduced down with filtering (based on config & other rules), and eventually a single next version is selected.
* **Single `nextVersion`**: Subsequently, retrieving information on the updates represented by the pull requests Scala Steward created - each artifact being updated to a specific _single_ new version.

...Scala Steward used the `Update` type for _both_ areas (particularly, `Update.ForArtifactId` for the first phase, _requiring_ it to support multiple `newerVersions`).

Looking at a single `Update.ForArtifactId` in code, it's not always clear to the newcomer if the update contains many newer versions or not - ie where we are in the pipeline.

## Changes

* `Update.Single` types (eg `Update.ForArtifactId`) now just have a `nextVersion` field, not `newerVersions`, which better models what they actually signify: the single specific update selected for a particular PR
* Within `UpdateAlg` & `FilterAlg` we change `Update.ForArtifactId` → `ArtifactUpdateCandidates`🆕 (which _does_ have a `newerVersions` field) for the parts where multiple candidate versions _are_ being evaluated
* `Update.ForArtifactId` & `ArtifactUpdateCandidates` both extend `ArtifactUpdateVersions`🆕 to allow `UpdatePattern.findMatch()` to filter lists of either of them:
  * Filtering the candidate versions of `ArtifactUpdateCandidates` in `UpdatesConfig.isAllowed`, etc
  * Filtering the `Update`s of existing PRs in `PruningAlg.newPullRequestsAllowed()` & `RetractedArtifact.isRetracted()`
* The fields from `Update.ForArtifactId` also required by `ArtifactUpdateCandidates` have been placed in the `ArtifactForUpdate`🆕 case class, avoiding possible duplication 

Remaining unchanged:

* `PullRequestRepository` still persists instances of `Update`
* The JSON serialisation format of `Update` remains unchanged for now (the encoder & decoders have been adapted so that they still output the same format, despite the case classes having changed, just with a _single_ 'newerVersion'), so there's currently no need to introduce a new fallback 'legacy' decoder (several of which were recently deleted with #3785). This also means the JSON metadata added to PR descriptions (originally introduced in https://github.com/scala-steward-org/scala-steward/pull/3466) also remains the same for now, though I think it will be reasonable to adjust the format for `Update.ForArtifactId` to something more logical in future.

With this PR, the changes from #3762 will no longer need to change the data stored in `PullRequestRepository`.