### PR TITLE
Refactor check against Coursier version-ordering onto `Version.Update`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -122,7 +122,10 @@ final case class Version(value: String) {
 }
 
 object Version {
-  case class Update(currentVersion: Version, nextVersion: Version)
+  case class Update(currentVersion: Version, nextVersion: Version) {
+    def obeysCoursierOrdering: Boolean =
+      coursier.core.Version(nextVersion.value) >= coursier.core.Version(currentVersion.value)
+  }
 
   def show(versions: Version*): String = {
     val vs0 = versions.map(_.value)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -129,10 +129,7 @@ object FilterAlg {
   }
 
   private def checkVersionOrdering(
-      update: Update.ForArtifactId
-  ): Either[RejectionReason, Update.ForArtifactId] = {
-    val current = coursier.core.Version(update.currentVersion.value)
-    val next = coursier.core.Version(update.nextVersion.value)
-    if (current > next) Left(VersionOrderingConflict(update)) else Right(update)
-  }
+      u: Update.ForArtifactId
+  ): Either[RejectionReason, Update.ForArtifactId] =
+    Either.cond(u.versionUpdate.obeysCoursierOrdering, u, VersionOrderingConflict(u))
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -5,11 +5,20 @@ import cats.kernel.laws.discipline.OrderTests
 import munit.DisciplineSuite
 import org.scalacheck.Prop.*
 import org.scalasteward.core.TestInstances.*
+import org.scalasteward.core.TestSyntax.StringOps
 import org.scalasteward.core.data.Version.Component
+
 import scala.util.Random
 
 class VersionTest extends DisciplineSuite {
   checkAll("Order[Version]", OrderTests[Version].order)
+
+  test("Note that currently, we treat Snapshot vs Milestone differently to Coursier") {
+    val snapshot = "1.0.0-SNAP8"
+    val milestone = "1.0.0-M2"
+    assert(snapshot.v < milestone.v)
+    assert(coursier.core.Version(snapshot) > coursier.core.Version(milestone)) // Surprising to me
+  }
 
   test("issue 1615: broken transitivity") {
     val res = OrderTests[Version].laws.transitivity(Version(""), Version("0"), Version("X"))


### PR DESCRIPTION
This small change just refactors the logic of the version-ordering-agreement check to live on `Version.Update` (introduced with 13380ebd in PR #3145 in August 2023), which feels like a good place for it to belong.

The check for whether our version-updates comply with Coursier version-ordering was added with this PR in January 2020:

* https://github.com/scala-steward-org/scala-steward/pull/1210

...the check was supposed to be temporary, until Scala Steward's own `Order[Version]` was considered battle-tested, but I don't know when we'll decide that's happened!

### Notes

Our Scala Steward check uses `coursier.core.Version`, which is [deprecated since Coursier 2.1.25](https://github.com/coursier/coursier/blame/0f3ceb65e9e46826967d2e4cb6f87cf7fb3e5c9d/modules/core/shared/src/main/scala/coursier/core/Version.scala#L14).

The recommended class is now [`coursier.version.Version`](https://github.com/coursier/versions/blob/main/versions/shared/src/coursier/version/Version.scala), which is in the newer https://github.com/coursier/versions library created in May 2020. In a future PR, we might want to switch to that library.

