### PR TITLE
Refactor: Replace `Update.Single`'s `withNextVersion()` with `supersedes()`

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -108,12 +108,8 @@ object Update {
     final override def show: String =
       s"$groupId:$showArtifacts : ${Version.show(currentVersion, nextVersion)}"
 
-    def withNextVersion(nextVersion: Version): Update.Single = this match {
-      case s: ForArtifactId =>
-        s.copy(nextVersion = nextVersion)
-      case g: ForGroupId =>
-        g.copy(nextVersion = nextVersion)
-    }
+    def supersedes(that: Update.Single): Boolean =
+      groupAndMainArtifactId == that.groupAndMainArtifactId && nextVersion > that.nextVersion
   }
 
   /** Denotes the update of a specific single artifact to some particular chosen next version.

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -71,9 +71,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
     kvStore.getOrElse(repo, Map.empty).map {
       _.collect {
         case (url, Entry(baseSha1, u: Update.Single, state, _, number, updateBranch))
-            if state === PullRequestState.Open &&
-              u.withNextVersion(update.nextVersion) === update &&
-              u.nextVersion < update.nextVersion =>
+            if state === PullRequestState.Open && update.supersedes(u) =>
           for {
             number <- number
             branch = updateBranch.getOrElse(git.branchFor(u, repo.branch))


### PR DESCRIPTION
The needs of the Scala Steward codebase don't require a `withNextVersion()` method on `Update.Single` - just a `supersedes()` method supports the sole use, with `PullRequestRepository.getObsoleteOpenPullRequests()` needing to know if one `Update` can be replaced by another one.

The original `withNewerVersions()` method was added in response to this PR comment: https://github.com/scala-steward-org/scala-steward/pull/1667#discussion_r506648775 ...but we reckon replacing it with a slightly different check makes for clearer, smaller, more explicit code.

This small refactor is extracted from https://github.com/scala-steward-org/scala-steward/pull/3762 (originally commit a11ee91dbcc9bb5af1181299af02a4033cbaafa6), making that PR a little smaller!

Co-authored-by: @emdash-ie
