### PR TITLE
Fix bug #3797: Ensure PR is still open before commenting

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -40,7 +40,12 @@ import org.scalasteward.core.edit.update.ScannerAlg
 import org.scalasteward.core.forge.{ForgeApiAlg, ForgeAuthAlg, ForgeRepoAlg, ForgeSelection}
 import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository, UpdateInfoUrlFinder}
+import org.scalasteward.core.nurture.{
+  NurtureAlg,
+  PullRequestRepository,
+  PullRequestService,
+  UpdateInfoUrlFinder
+}
 import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
 import org.scalasteward.core.repocache.*
 import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader}
@@ -171,6 +176,8 @@ object Context {
       implicit val updateInfoUrlFinder: UpdateInfoUrlFinder[F] = new UpdateInfoUrlFinder[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](pullRequestsStore)
+      implicit val pullRequestService: PullRequestService[F] =
+        new PullRequestService[F](pullRequestRepository, forgeApiAlg)
       implicit val scalafixCli: ScalafixCli[F] = new ScalafixCli[F]
       implicit val scalafmtAlg: ScalafmtAlg[F] = new ScalafmtAlg[F](config.defaultResolvers)
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F](config)

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeApiAlg.scala
@@ -27,6 +27,8 @@ trait ForgeApiAlg[F[_]] {
 
   def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut]
 
+  def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut]
+
   def updatePullRequest(number: PullRequestNumber, repo: Repo, data: NewPullRequestData): F[Unit]
 
   def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut]

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala
@@ -44,8 +44,8 @@ sealed trait ForgeType extends Product with Serializable {
   def supportsForking: Boolean = true
   def supportsLabels: Boolean = true
 
-  /** Determines the `head` (GitHub) / `source_branch` (GitLab, Bitbucket) parameter for searching
-    * for already existing pull requests or creating new pull requests.
+  /** Determines the `head` (GitHub) / `source_branch` (GitLab, Bitbucket) parameter value for
+    * searching for already existing pull requests or creating new pull requests.
     */
   def pullRequestHeadFor(@nowarn fork: Repo, updateBranch: Branch): String = updateBranch.name
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlg.scala
@@ -61,6 +61,10 @@ final class AzureReposApiAlg[F[_]](
   ): F[Unit] =
     logger.warn("Updating PRs is not yet supported for Azure Repos")
 
+  // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/get-pull-request?view=azure-devops-rest-7.1
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    client.get[PullRequestOut](url.pullRequest(repo, number), modify)
+
   // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.1
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
     client.patchWithBody[PullRequestOut, ClosePullRequestPayload](

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/azurerepos/Url.scala
@@ -39,6 +39,9 @@ class Url(apiHost: Uri, organization: String) {
   def pullRequests(repo: Repo): Uri =
     repos(repo) / "pullrequests"
 
+  def pullRequest(repo: Repo, number: PullRequestNumber): Uri =
+    pullRequests(repo) / number.value
+
   def listPullRequests(repo: Repo, source: String, target: Branch): Uri =
     pullRequests(repo).withQueryParams(
       Map("searchCriteria.sourceRefName" -> source, "searchCriteria.targetRefName" -> target.name)

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlg.scala
@@ -104,6 +104,9 @@ class BitbucketApiAlg[F[_]](
   ): F[Unit] =
     logger.warn("Updating PRs is not yet supported for Bitbucket")
 
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    client.get(url.pullRequest(repo, number), modify)
+
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branch(repo, branch), modify)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlg.scala
@@ -39,7 +39,7 @@ final class BitbucketServerApiAlg[F[_]](
   private val url = new Url(bitbucketApiHost)
 
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
-    getPullRequest(repo, number).flatMap { pr =>
+    getBitbucketSpecificPullRequest(repo, number).flatMap { pr =>
       val out = pr.toPullRequestOut.copy(state = PullRequestState.Closed)
       declinePullRequest(repo, number, pr.version).as(out)
     }
@@ -114,8 +114,11 @@ final class BitbucketServerApiAlg[F[_]](
   private def getDefaultBranch(repo: Repo): F[Json.Branch] =
     client.get[Json.Branch](url.defaultBranch(repo), modify)
 
-  private def getPullRequest(repo: Repo, number: PullRequestNumber): F[PR] =
+  private def getBitbucketSpecificPullRequest(repo: Repo, number: PullRequestNumber): F[PR] =
     client.get[Json.PR](url.pullRequest(repo, number), modify)
+
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    getBitbucketSpecificPullRequest(repo, number).map(_.toPullRequestOut)
 
   override def getRepo(repo: Repo): F[RepoOut] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitea/GiteaApiAlg.scala
@@ -193,6 +193,9 @@ final class GiteaApiAlg[F[_]: HttpJsonClient](
   ): F[Unit] =
     logger.warn("Updating PRs is not yet supported for Gitea")
 
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    client.get[PullRequestResp](url.pull(repo, number), modify).map(pullRequestOut)
+
   override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] = {
     val edit = EditPullRequestOption(state = "closed")
     client

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/github/GitHubApiAlg.scala
@@ -89,6 +89,10 @@ final class GitHubApiAlg[F[_]](
     } yield ()
   }
 
+  /** https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request */
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    client.get(url.pull(repo, number), modify)
+
   /** https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#get-a-branch */
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client.get(url.branches(repo, branch), modify)

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlg.scala
@@ -173,6 +173,9 @@ final class GitLabApiAlg[F[_]: Parallel](
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
     client.get(url.listMergeRequests(repo, head, base.name), modify)
 
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    client.get(url.existingMergeRequest(repo, number), modify)
+
   override def createFork(repo: Repo): F[RepoOut] = {
     val userOwnedRepo = repo.copy(owner = forgeCfg.login)
     val data = ForkPayload(url.encodedProjectId(userOwnedRepo), forgeCfg.login)

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -26,7 +26,7 @@ package object git {
 
   val updateBranchPrefix = "update"
 
-  def branchFor(update: Update, baseBranch: Option[Branch]): Branch = {
+  def branchFor(update: Update, baseBranch: Option[Branch] = None): Branch = {
     val base = baseBranch.fold("")(branch => s"${branch.name}/")
     update.on(
       update = u => Branch(s"$updateBranchPrefix/$base${u.name}-${u.nextVersion}"),

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -41,7 +41,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     forgeRepoAlg: ForgeRepoAlg[F],
     gitAlg: GitAlg[F],
     logger: Logger[F],
-    pullRequestRepository: PullRequestRepository[F],
+    pullRequestService: PullRequestService[F],
     updateInfoUrlFinder: UpdateInfoUrlFinder[F],
     urlChecker: UrlChecker[F],
     F: Concurrent[F]
@@ -92,8 +92,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
   private def processUpdate(data: UpdateData): F[ProcessResult] =
     for {
       _ <- logger.info(s"Process update ${data.update.show}")
-      head = config.tpe.pullRequestHeadFor(data.fork, data.updateBranch)
-      pullRequests <- forgeApiAlg.listPullRequests(data.repo, head, data.baseBranch)
+      pullRequests <- pullRequestService.listPullRequestsForUpdate(data, config.tpe)
       result <- pullRequests.headOption match {
         case Some(pr) if pr.state.isClosed && data.update.isInstanceOf[Update.Single] =>
           logger.info(s"PR ${pr.html_url} is closed") >>
@@ -106,22 +105,11 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
             case _                    => F.unit
           }
       }
-      _ <- pullRequests.headOption.traverse_ { pr =>
-        val prData = PullRequestData[Id](
-          pr.html_url,
-          data.baseSha1,
-          data.update,
-          pr.state,
-          pr.number,
-          data.updateBranch
-        )
-        pullRequestRepository.createOrUpdate(data.repo, prData)
-      }
     } yield result
 
   private def closeObsoletePullRequests(data: UpdateData, newNumber: PullRequestNumber): F[Unit] =
     data.update.on(
-      update = pullRequestRepository
+      update = pullRequestService
         .getObsoleteOpenPullRequests(data.repo, _)
         .flatMap(_.traverse_(oldPr => closeObsoletePullRequest(data, newNumber, oldPr))),
       // We don't support closing obsolete PRs for `GroupedUpdate`s
@@ -136,15 +124,14 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     logger.attemptWarn.label_(
       s"Closing obsolete PR ${oldPr.url.renderString} for ${oldPr.update.show} in PR #$newNumber - will not comment due to https://github.com/scala-steward-org/scala-steward/issues/3797"
     ) {
+      val oldRemoteBranch = oldPr.updateBranch.withPrefix("origin/")
       for {
-        _ <- pullRequestRepository.changeState(data.repo, oldPr.url, PullRequestState.Closed)
-        oldRemoteBranch = oldPr.updateBranch.withPrefix("origin/")
         oldBranchExists <- gitAlg.branchExists(data.repo, oldRemoteBranch)
         authors <-
           if (oldBranchExists) gitAlg.branchAuthors(data.repo, oldRemoteBranch, data.baseBranch)
           else List.empty.pure[F]
         _ <- F.whenA(authors.size <= 1) {
-          forgeApiAlg.closePullRequest(data.repo, oldPr.number) >>
+          pullRequestService.closePullRequest(data.repo, oldPr.number) >>
             deleteRemoteBranch(data.repo, oldPr.updateBranch)
         }
       } yield ()
@@ -249,16 +236,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     for {
       _ <- logger.info(s"Create PR ${data.updateBranch.name}")
       requestData <- preparePullRequest(data, edits)
-      pr <- forgeApiAlg.createPullRequest(data.repo, requestData)
-      prData = PullRequestData[Id](
-        pr.html_url,
-        data.baseSha1,
-        data.update,
-        pr.state,
-        pr.number,
-        data.updateBranch
-      )
-      _ <- pullRequestRepository.createOrUpdate(data.repo, prData)
+      pr <- pullRequestService.createPullRequest(data, requestData)
       _ <- logger.info(s"Created PR ${pr.html_url}")
     } yield Created(pr.number)
 
@@ -310,8 +288,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     } yield result
 
   def closeRetractedPullRequests(data: RepoData): F[Unit] =
-    pullRequestRepository
-      .getRetractedPullRequests(data.repo, data.config.updatesOrDefault.retractedOrDefault)
+    pullRequestService
+      .getRetractedOpenPullRequests(data.repo, data.config.updatesOrDefault.retractedOrDefault)
       .flatMap {
         _.traverse_ { case (oldPr, retractedArtifact) =>
           closeRetractedPullRequest(data, oldPr, retractedArtifact)
@@ -321,16 +299,14 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
   private def closeRetractedPullRequest(
       data: RepoData,
       oldPr: PullRequestData[Id],
-      retractedArtifact: RetractedArtifact
+      retraction: RetractedArtifact
   ): F[Unit] =
     logger.attemptWarn.label_(
-      s"Closing retracted PR ${oldPr.url.renderString} for ${oldPr.update.show} because of '${retractedArtifact.reason}'"
+      s"Closing retracted PR ${oldPr.url.renderString} for ${oldPr.update.show} because of '${retraction.reason}'"
     ) {
       for {
-        _ <- pullRequestRepository.changeState(data.repo, oldPr.url, PullRequestState.Closed)
-        comment = retractedArtifact.retractionMsg
-        _ <- forgeApiAlg.commentPullRequest(data.repo, oldPr.number, comment)
-        _ <- forgeApiAlg.closePullRequest(data.repo, oldPr.number)
+        _ <- forgeApiAlg.commentPullRequest(data.repo, oldPr.number, retraction.retractionMsg)
+        _ <- pullRequestService.closePullRequest(data.repo, oldPr.number)
         _ <- deleteRemoteBranch(data.repo, oldPr.updateBranch)
       } yield F.unit
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestData.scala
@@ -16,9 +16,10 @@
 
 package org.scalasteward.core.nurture
 
+import cats.Id
 import org.http4s.Uri
-import org.scalasteward.core.data.Update
-import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestState}
+import org.scalasteward.core.data.{Update, UpdateData}
+import org.scalasteward.core.forge.data.{PullRequestNumber, PullRequestOut, PullRequestState}
 import org.scalasteward.core.git.{Branch, Sha1}
 
 final case class PullRequestData[F[_]](
@@ -29,3 +30,14 @@ final case class PullRequestData[F[_]](
     number: F[PullRequestNumber],
     updateBranch: F[Branch]
 )
+
+object PullRequestData {
+  def apply(pr: PullRequestOut, updateData: UpdateData): PullRequestData[Id] = PullRequestData[Id](
+    pr.html_url,
+    updateData.baseSha1,
+    updateData.update,
+    pr.state,
+    pr.number,
+    updateData.updateBranch
+  )
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -79,7 +79,7 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
       }.flatten.toList.sortBy(_.number.value)
     }
 
-  def getRetractedPullRequests(
+  def getRetractedOpenPullRequests(
       repo: Repo,
       allRetractedArtifacts: List[RetractedArtifact]
   ): F[List[(PullRequestData[Id], RetractedArtifact)]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestService.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.nurture
+
+import cats.*
+import cats.syntax.all.*
+import org.scalasteward.core.data.*
+import org.scalasteward.core.forge.data.{
+  NewPullRequestData,
+  PullRequestNumber,
+  PullRequestOut,
+  PullRequestState
+}
+import org.scalasteward.core.forge.{ForgeApiAlg, ForgeType}
+import org.scalasteward.core.repoconfig.RetractedArtifact
+
+final class PullRequestService[F[_]](
+    pullRequestRepository: PullRequestRepository[F],
+    forgeApiAlg: ForgeApiAlg[F]
+)(implicit
+    F: Monad[F]
+) {
+
+  def createPullRequest(
+      updateData: UpdateData,
+      requestData: NewPullRequestData
+  ): F[PullRequestOut] = forgeApiAlg
+    .createPullRequest(updateData.repo, requestData)
+    .flatTap(pr =>
+      pullRequestRepository.createOrUpdate(updateData.repo, PullRequestData(pr, updateData))
+    )
+
+  def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] = forgeApiAlg
+    .closePullRequest(repo, number)
+    .flatTap { pr =>
+      pullRequestRepository.changeState(repo, pr.html_url, PullRequestState.Closed)
+    }
+
+  def listPullRequestsForUpdate(data: UpdateData, forgeType: ForgeType): F[List[PullRequestOut]] = {
+    val head = forgeType.pullRequestHeadFor(data.fork, data.updateBranch)
+    forgeApiAlg.listPullRequests(data.repo, head, data.baseBranch).flatTap { pullRequests =>
+      pullRequests.headOption.traverse_ { pr =>
+        pullRequestRepository.createOrUpdate(data.repo, PullRequestData(pr, data))
+      }
+    }
+  }
+
+  def getObsoleteOpenPullRequests(repo: Repo, update: Update.Single): F[List[PullRequestData[Id]]] =
+    flatTraverseOpts(pullRequestRepository.getObsoleteOpenPullRequests(repo, update))(
+      refreshAndEnsureStillOpen(repo)
+    )
+
+  def getRetractedOpenPullRequests(
+      repo: Repo,
+      allRetractedArtifacts: List[RetractedArtifact]
+  ): F[List[(PullRequestData[Id], RetractedArtifact)]] =
+    flatTraverseOpts(
+      pullRequestRepository.getRetractedOpenPullRequests(repo, allRetractedArtifacts)
+    ) { case (stalePr, retractedArtifact) =>
+      refreshAndEnsureStillOpen(repo)(stalePr).map(_.map(_ -> retractedArtifact))
+    }
+
+  private def flatTraverseOpts[T](items: F[List[T]])(f: T => F[Option[T]]): F[List[T]] =
+    items.flatMap(_.traverseFilter(f))
+
+  private def refreshAndEnsureStillOpen(
+      repo: Repo
+  ): PullRequestData[Id] => F[Option[PullRequestData[Id]]] = { stalePrData =>
+    forgeApiAlg
+      .getPullRequest(repo, stalePrData.number)
+      .flatTap(freshPr => pullRequestRepository.changeState(repo, stalePrData.url, freshPr.state))
+      .map(freshPr =>
+        Option.when(freshPr.state == PullRequestState.Open)(stalePrData.copy(state = freshPr.state))
+      )
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/azurerepos/AzureReposApiAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.forge.azurerepos
 
-import io.circe.literal.JsonStringContext
+import io.circe.literal.*
 import munit.CatsEffectSuite
 import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucket/BitbucketApiAlgTest.scala
@@ -171,6 +171,19 @@ class BitbucketApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
           ]
       }"""
       )
+    case GET -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" / IntVar(2) =>
+      Ok(
+        json"""{
+            "id": 2,
+            "title": "scala-steward-pr",
+            "state": "OPEN",
+            "links": {
+                "html": {
+                    "href": "https://bitbucket.org/fthomas/base.g8/pullrequests/2"
+                }
+            }
+        }"""
+      )
     case POST -> Root / "repositories" / "fthomas" / "base.g8" / "pullrequests" / IntVar(
           _
         ) / "decline" =>
@@ -326,6 +339,11 @@ class BitbucketApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
   test("listPullRequests") {
     val prs = bitbucketApiAlg.listPullRequests(repo, "master", master).runA(state)
     assertIO(prs, List(pullRequest))
+  }
+
+  test("getPullRequest") {
+    val prOut = bitbucketApiAlg.getPullRequest(repo, PullRequestNumber(2)).runA(state)
+    assertIO(prOut, pullRequest)
   }
 
   test("closePullRequest") {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/bitbucketserver/BitbucketServerApiAlgTest.scala
@@ -186,6 +186,18 @@ class BitbucketServerApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] 
     assertIO(obtained, expected)
   }
 
+  test("getPullRequest") {
+    val obtained =
+      bitbucketServerApiAlg.getPullRequest(repo, PullRequestNumber(4711)).runA(state)
+    val expected = PullRequestOut(
+      Uri.unsafeFromString("http://example.org"),
+      PullRequestState.Open,
+      PullRequestNumber(4711),
+      "Update sbt to 1.4.6"
+    )
+    assertIO(obtained, expected)
+  }
+
   test("commentPullRequest") {
     val comment = bitbucketServerApiAlg
       .commentPullRequest(repo, PullRequestNumber(1347), "Superseded by #1234")

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/gitlab/GitLabApiAlgTest.scala
@@ -413,6 +413,19 @@ class GitLabApiAlgTest extends CatsEffectSuite with Http4sDsl[MockEff] {
     )
   }
 
+  test("getPullRequest") {
+    val prOut = gitlabApiAlgNoFork
+      .getPullRequest(Repo("foo", "bar"), PullRequestNumber(150))
+      .runA(state)
+    val expected = PullRequestOut(
+      uri"https://gitlab.com/foo/bar/merge_requests/150",
+      PullRequestState.Open,
+      PullRequestNumber(150),
+      "title"
+    )
+    assertIO(prOut, expected)
+  }
+
   private val getMr = json"""
     {
       "id": 26328,

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockForgeApiAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockForgeApiAlg.scala
@@ -1,0 +1,108 @@
+package org.scalasteward.core.mock
+
+import cats.Endo
+import cats.data.Kleisli
+import org.http4s.Uri
+import org.scalasteward.core.data.Repo
+import org.scalasteward.core.forge.ForgeApiAlg
+import org.scalasteward.core.forge.data.*
+import org.scalasteward.core.forge.data.PullRequestState.{Closed, Open}
+import org.scalasteward.core.git.Branch
+
+object MockForgeApiAlg {
+
+  case class PRState(initialData: NewPullRequestData, current: PullRequestOut) {
+    def close: PRState = copy(current = current.copy(state = Closed))
+
+    def update(newData: NewPullRequestData): PRState =
+      PRState(newData, current.copy(title = newData.title))
+  }
+  case class RepoState(highestPrNumber: Int = 0, prs: Map[PullRequestNumber, PRState] = Map.empty) {
+    def createPullRequest(data: NewPullRequestData): (RepoState, PullRequestOut) = {
+      val number = PullRequestNumber(highestPrNumber + 1)
+      val pr = PullRequestOut(
+        html_url = Uri.unsafeFromString(s"https://example.com/${number.value}"),
+        state = Open,
+        number,
+        title = data.title
+      )
+      (copy(highestPrNumber = pr.number.value, prs = prs + (pr.number -> PRState(data, pr))), pr)
+    }
+
+    def getPullRequest(num: PullRequestNumber): PullRequestOut = prs(num).current
+
+    def listPullRequests(head: String, base: Branch): List[PullRequestOut] = prs.values
+      .filter(state => state.initialData.head == head && state.initialData.base == base)
+      .map(_.current)
+      .toList
+
+    private def update(number: PullRequestNumber, f: Endo[PRState]): (RepoState, PullRequestOut) = {
+      val state = copy(prs = prs.updatedWith(number)(_.map(f)))
+      (state, state.getPullRequest(number))
+    }
+
+    def closePullRequest(number: PullRequestNumber): (RepoState, PullRequestOut) =
+      update(number, _.close)
+
+    def updatePullRequest(
+        number: PullRequestNumber,
+        data: NewPullRequestData
+    ): (RepoState, PullRequestOut) =
+      update(number, _.update(data))
+
+  }
+
+  case class MockForgeState(repos: Map[Repo, RepoState])
+
+  object MockForgeState {
+    val empty = MockForgeState(Map.empty)
+  }
+
+  implicit val mockApiAlg: ForgeApiAlg[MockEff] = new ForgeApiAlg[MockEff] {
+
+    private def modifyRepo[A](repo: Repo, f: RepoState => (RepoState, A)): MockEff[A] = Kleisli {
+      _.modify { state =>
+        val (repoState, output) = f(state.forgeState.repos(repo))
+        state.copy(forgeState =
+          state.forgeState.copy(repos = state.forgeState.repos + (repo -> repoState))
+        ) -> output
+      }
+    }
+
+    private def readRepo[A](repo: Repo, f: RepoState => A): MockEff[A] =
+      Kleisli(_.get.map(state => f(state.forgeState.repos(repo))))
+
+    override def createPullRequest(repo: Repo, data: NewPullRequestData): MockEff[PullRequestOut] =
+      modifyRepo(repo, _.createPullRequest(data))
+
+    override def closePullRequest(repo: Repo, number: PullRequestNumber): MockEff[PullRequestOut] =
+      modifyRepo(repo, _.closePullRequest(number))
+
+    override def listPullRequests(
+        repo: Repo,
+        head: String,
+        base: Branch
+    ): MockEff[List[PullRequestOut]] = readRepo(repo, _.listPullRequests(head, base))
+
+    override def getPullRequest(repo: Repo, number: PullRequestNumber): MockEff[PullRequestOut] =
+      readRepo(repo, _.getPullRequest(number))
+
+    override def createFork(repo: Repo): MockEff[RepoOut] = ???
+
+    override def updatePullRequest(
+        number: PullRequestNumber,
+        repo: Repo,
+        data: NewPullRequestData
+    ): MockEff[Unit] = ???
+
+    override def getBranch(repo: Repo, branch: Branch): MockEff[BranchOut] = ???
+
+    override def getRepo(repo: Repo): MockEff[RepoOut] = ???
+
+    override def commentPullRequest(
+        repo: Repo,
+        number: PullRequestNumber,
+        comment: String
+    ): MockEff[Comment] = ???
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -7,6 +7,7 @@ import org.http4s.{HttpApp, Uri}
 import org.scalasteward.core.git.FileGitAlg
 import org.scalasteward.core.git.FileGitAlgTest.ioAuxGitAlg
 import org.scalasteward.core.io.FileAlgTest.ioFileAlg
+import org.scalasteward.core.mock.MockForgeApiAlg.MockForgeState
 import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 
@@ -16,7 +17,8 @@ final case class MockState(
     execCommands: Boolean,
     files: Map[File, String],
     uris: Map[Uri, String],
-    clientResponses: HttpApp[MockEff]
+    clientResponses: HttpApp[MockEff],
+    forgeState: MockForgeState
 ) {
   def addFiles(newFiles: (File, String)*): IO[MockState] =
     newFiles.toList
@@ -45,19 +47,21 @@ final case class MockState(
   def appendTraceEntry(entry: TraceEntry): MockState =
     copy(trace = trace :+ entry)
 
-  def toRef: IO[Ref[IO, MockState]] =
+  def toRef: IO[MockCtx] =
     Ref[IO].of(this)
 }
 
 object MockState {
-  def empty: MockState =
+
+  val empty: MockState =
     MockState(
       trace = Vector.empty,
       commandOutputs = Map.empty,
       execCommands = false,
       files = Map.empty,
       uris = Map.empty,
-      clientResponses = HttpApp.notFound
+      clientResponses = HttpApp.notFound,
+      forgeState = MockForgeState.empty
     )
 
   sealed trait TraceEntry extends Product with Serializable

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -124,7 +124,7 @@ class PullRequestRepositoryTest extends FunSuite {
 
   test("getRetractedPullRequests with no retractions defined") {
     val (_, obtained) = beforeAndAfterPRCreation(portableScala) { repo =>
-      pullRequestRepository.getRetractedPullRequests(repo, List.empty)
+      pullRequestRepository.getRetractedOpenPullRequests(repo, List.empty)
     }
     assertEquals(obtained, List.empty[(PullRequestData[Id], RetractedArtifact)])
   }
@@ -142,7 +142,7 @@ class PullRequestRepositoryTest extends FunSuite {
       )
     )
     val (_, obtained) = beforeAndAfterPRCreation(portableScala) { repo =>
-      pullRequestRepository.getRetractedPullRequests(repo, List(retractedPortableScala))
+      pullRequestRepository.getRetractedOpenPullRequests(repo, List(retractedPortableScala))
     }
     assertEquals(obtained.size, 1)
     assertEquals(obtained.head._1.update, portableScala)
@@ -162,7 +162,7 @@ class PullRequestRepositoryTest extends FunSuite {
       )
     )
     val (_, obtained) = beforeAndAfterPRCreation(portableScala) { repo =>
-      pullRequestRepository.getRetractedPullRequests(repo, List(retractedPortableScala))
+      pullRequestRepository.getRetractedOpenPullRequests(repo, List(retractedPortableScala))
     }
     assertEquals(obtained, List.empty[(PullRequestData[Id], RetractedArtifact)])
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestServiceTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestServiceTest.scala
@@ -1,0 +1,176 @@
+package org.scalasteward.core.nurture
+
+import cats.effect.unsafe.implicits.global
+import munit.FunSuite
+import org.scalasteward.core.TestSyntax.*
+import org.scalasteward.core.data.*
+import org.scalasteward.core.forge.ForgeType.Bitbucket
+import org.scalasteward.core.forge.data.{NewPullRequestData, PullRequestOut, PullRequestState}
+import org.scalasteward.core.git.{branchFor, Branch, Sha1}
+import org.scalasteward.core.mock.MockContext.context
+import org.scalasteward.core.mock.MockForgeApiAlg.{MockForgeState, RepoState}
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockForgeApiAlg, MockState}
+import org.scalasteward.core.nurture.TestRepo.{baseSha, withTestRepo}
+import org.scalasteward.core.repocache.RepoCache
+import org.scalasteward.core.repoconfig.{RepoConfig, RetractedArtifact, UpdatePattern}
+
+import java.util.concurrent.atomic.AtomicInteger
+
+object TestRepo {
+  val baseSha: Sha1 = Sha1.unsafeFrom("07eb2a203e297c8340273950e98b2cab68b560c1")
+
+  val repoCount = new AtomicInteger()
+
+  def withTestRepo[A](f: TestRepo => MockEff[A]): A = {
+    val testRepo: TestRepo = TestRepo(
+      Repo("example-org", s"example-repo-${repoCount.incrementAndGet()}")
+    )
+    f(testRepo)
+      .runA(
+        MockState.empty.copy(forgeState = MockForgeState(repos = Map(testRepo.repo -> RepoState())))
+      )
+      .unsafeRunSync()
+  }
+}
+
+case class TestRepo(repo: Repo) {
+  val mockStateWithExampleRepo: MockState =
+    MockState.empty.copy(forgeState = MockForgeState(repos = Map(repo -> RepoState())))
+
+  def updateDataFor(update: Update.Single) = UpdateData(
+    repoData = RepoData(
+      repo,
+      cache = RepoCache(
+        baseSha,
+        dependencyInfos = List.empty,
+        maybeRepoConfig = None,
+        maybeRepoConfigParsingError = None
+      ),
+      config = RepoConfig()
+    ),
+    fork = repo,
+    update,
+    baseBranch = Branch("main"),
+    baseSha1 = baseSha,
+    updateBranch = branchFor(update)
+  )
+}
+
+class PullRequestServiceTest extends FunSuite {
+
+  // val exampleRepo: Repo = Repo("example-org", "example-repo")
+
+  val forgeApiAlg = MockForgeApiAlg.mockApiAlg
+  val prRepository = context.pullRequestRepository
+  val service: PullRequestService[MockEff] =
+    new PullRequestService[MockEff](prRepository, forgeApiAlg)
+  val exampleGroupId: GroupId = "com.example".g
+  val dependencyA: Dependency = exampleGroupId % "thing-A".a % "1.0.0"
+  val dependencyB: Dependency = exampleGroupId % "thing-B".a % "1.0.0"
+  def createPrFor(update: UpdateData): MockEff[PullRequestOut] =
+    service.createPullRequest(update, newPullRequestDataFor(update))
+
+  private def newPullRequestDataFor(update: UpdateData) =
+    NewPullRequestData.from(update, branchName = update.updateBranch.name)
+
+  test("createPullRequest() stores info in our local repository on the created PR") {
+    val singleUpdate = (dependencyA %> "2.0.0").single
+    val (createdPr, prFromRepository) = withTestRepo { testRepo =>
+      for {
+        createdPr <- createPrFor(testRepo.updateDataFor(singleUpdate))
+        prFromRepository <- prRepository.findLatestPullRequest(
+          testRepo.repo,
+          singleUpdate.crossDependency,
+          singleUpdate.nextVersion
+        )
+      } yield (createdPr, prFromRepository)
+    }
+
+    assert(prFromRepository.flatMap(_.number).contains(createdPr.number))
+    assert(prFromRepository.map(_.update).contains(singleUpdate))
+  }
+
+  test("listPullRequestsForUpdate() stores info on the PRs it finds in our local repository") {
+    val singleUpdate = (dependencyA %> "2.0.0").single
+
+    val (before, after) = withTestRepo { testRepo =>
+      val updateData = testRepo.updateDataFor(singleUpdate)
+      val checkRepositoryForUpdatePR =
+        prRepository.findLatestPullRequest(
+          testRepo.repo,
+          singleUpdate.crossDependency,
+          singleUpdate.nextVersion
+        )
+
+      for {
+        _ <- forgeApiAlg.createPullRequest(testRepo.repo, newPullRequestDataFor(updateData))
+        before <- checkRepositoryForUpdatePR
+        _ <- service.listPullRequestsForUpdate(updateData, Bitbucket)
+        after <- checkRepositoryForUpdatePR
+      } yield (before, after)
+    }
+
+    assertEquals(before.map(_.update), None)
+    assertEquals(after.map(_.update), Some(singleUpdate))
+  }
+
+  test("getObsoleteOpenPullRequests() does not return externally-closed PRs") {
+    val (obsoleteOpenPrsA, obsoleteOpenPrsB) = withTestRepo { testRepo =>
+      def getObsoleteOpenPrsForUpdating(dependency: Dependency) =
+        service.getObsoleteOpenPullRequests(testRepo.repo, (dependency %> "3.0.0").single)
+
+      for {
+        initialPrA <- createPrFor(testRepo.updateDataFor((dependencyA %> "2.0.0").single))
+        _ <- createPrFor(testRepo.updateDataFor((dependencyB %> "2.0.0").single))
+        _ <- forgeApiAlg.closePullRequest(testRepo.repo, initialPrA.number)
+        obsoleteOpenPrsA <- getObsoleteOpenPrsForUpdating(dependencyA)
+        obsoleteOpenPrsB <- getObsoleteOpenPrsForUpdating(dependencyB)
+      } yield (obsoleteOpenPrsA, obsoleteOpenPrsB)
+    }
+
+    assertEquals(obsoleteOpenPrsA, List.empty)
+    assertEquals(obsoleteOpenPrsB.size, 1)
+  }
+
+  test("getRetractedOpenPullRequests() does not return externally-closed PRs") {
+    val allRetractedArtifacts = List(
+      RetractedArtifact(
+        "example-reason",
+        "example-doc",
+        List(UpdatePattern(exampleGroupId, None, None))
+      )
+    )
+    val updateA = (dependencyA %> "2.0.0").single
+    val updateB = (dependencyB %> "2.0.0").single
+    val retractedOpenPrs = withTestRepo { testRepo =>
+      for {
+        prA <- createPrFor(testRepo.updateDataFor(updateA))
+        _ <- createPrFor(testRepo.updateDataFor(updateB))
+        _ <- forgeApiAlg.closePullRequest(testRepo.repo, prA.number)
+        retractedOpenPrs <-
+          service.getRetractedOpenPullRequests(testRepo.repo, allRetractedArtifacts)
+      } yield retractedOpenPrs
+    }
+
+    assertEquals(retractedOpenPrs.map(_._1.update), List(updateB))
+  }
+
+  test("closePullRequest() updates state for the closed PR in our local repository") {
+    val update = (dependencyA %> "2.0.0").single
+
+    val foundPr = withTestRepo { testRepo =>
+      for {
+        createdPr <- createPrFor(testRepo.updateDataFor(update))
+        _ <- service.closePullRequest(testRepo.repo, createdPr.number)
+        foundPr <-
+          prRepository.findLatestPullRequest(
+            testRepo.repo,
+            update.crossDependency,
+            update.nextVersion
+          )
+      } yield foundPr
+    }
+
+    assertEquals(foundPr.map(_.state), Some(PullRequestState.Closed))
+  }
+}


### PR DESCRIPTION
Fixes this issue:

* https://github.com/scala-steward-org/scala-steward/issues/3797

This PR is made of two commits:

1. fa14c29306de9eb364a53d9cfe61149122027ed4 : Add `ForgeApiAlg.getPullRequest()` (implementing this for the 6 Forge types, GitHub, GitLab, BitBucket, etc) - this new capability, of getting _current_ information for the state of an existing PR, is required for this fix.
1. 4322da82138a3eb68708f5c3da8ed1da78420c7f : Introduce `PullRequestService`, encapsulating `PullRequestRepository` & `ForgeApiAlg`

...when reviewing them, it's probably helpful to review each commit separately.

### `PullRequestService`: combining calls to `PullRequestRepository` & `ForgeApiAlg`

Although the key fix here was to additionally hit the Forge API to see if the PRs returned by `pullRequestRepository.getObsoleteOpenPullRequests()` actually _are_ still open, this leads to the creation of a `PullRequestService` that provides a combined interface to calls of the Forge API & the flat-file Repository.

It turns out there are several places within `NurtureAlg` where complementary pairs of calls to the Forge API and the flat-file Repository were occurring, and it simplifies `NurtureAlg` to make sure that `PullRequestService` takes over all of them:

* `createPullRequest` replaces `forgeApiAlg.createPullRequest` & `pullRequestRepository.createOrUpdate`
* `closePullRequest` replaces `pullRequestRepository.changeState` & `forgeApiAlg.closePullRequest`
* `listPullRequestsForUpdate` replaces `forgeApiAlg.listPullRequests` & `pullRequestRepository.createOrUpdate`

Additionally, these two `PullRequestService` methods enhance existing `PullRequestRepository` methods with `forgeApiAlg.getPullRequest` where it previously should have been used, but wasn't:

* `getObsoleteOpenPullRequests` enhances `pullRequestRepository.getObsoleteOpenPullRequests` 
* `getRetractedOpenPullRequests` enhances `pullRequestRepository.getRetractedPullRequests`

## Testing

### Testing `ForgeApiAlg.getPullRequest()`

Scala Steward supports *six* different Forge types (GitHub, GitLab, Gitea, etc) and so adding even one method to the `ForgeApiAlg` involves multiple implementations. I've included tests for all 6 implementations, but do not have user accounts on many of the forge types, and so have included best-guess stub test data that's based on what we already had:

#### Reusing existing test data without modification

 * `GitLab`
 * `BitbucketServer`

#### Reusing existing test data, single item extracted from the 'list PRs' case

 * `GitHub`
 * `Bitbucket`
 * `AzureRepos`
 * `Gitea`

### Testing `PullRequestService`: requires new `MockForgeApiAlg`

In order to test the substantial new `PullRequestService` class, it was necessary to mock its two encapsulated components; `PullRequestRepository` (already supported in `MockContext`) and `ForgeApiAlg` - which did not have any existing test implementation. Mocking it requires a minimal in-memory implementation of the Forge API (eg, like the GitHub or BitBucket API) - something that can remember a PR has been created, what its state is, what the next PR number should be, etc.

This has been done with `MockForgeApiAlg`, implementing all the methods required for testing `PullRequestRepository`, and leaving other methods unimplemented with `???`. The state for all this (`MockForgeState`) has been added as a field to the existing `org.scalasteward.core.mock.MockState` class, so it can used with existing `MockEff` testing.

### Coverage

Coverage of the project as a whole slightly increases this this PR, but the codecov also points out that of the lines touched in the diff, 8 lines (all in `NurtureAlg`) are currently not covered by tests at all:

* [codecov/project](https://github.com/scala-steward-org/scala-steward/pull/3804/checks?check_run_id=65727127397) 90.51% (+0.48%) compared to e6ce04e
* [codecov/patch](https://github.com/scala-steward-org/scala-steward/pull/3804/checks?check_run_id=65727130213) 87.69% of diff hit (target 90.03%)

Having reviewed the fairly straightforward changes to `NurtureAlg`, and given the effort already expended getting testing working on `PullRequestService`, I feel that it's acceptable to allow the diff coverage to be lower than the target of 90%.

## Next steps

After this has bedded in, we can re-enable the commenting temporarily disabled by:

* https://github.com/scala-steward-org/scala-steward/pull/3802

cc @danicheg
