### PR TITLE
Support for non-aggregated projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ lazy val core = myCrossProject("core")
       Dependencies.logbackClassic % Runtime,
       Dependencies.catsLaws % Test,
       Dependencies.circeLiteral % Test,
+      Dependencies.circeTesting % Test,
       Dependencies.disciplineMunit % Test,
       Dependencies.http4sDsl % Test,
       Dependencies.http4sEmberServer % Test,

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -167,9 +167,12 @@ commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersio
 scalafmt.runAfterUpgrading = false
 
 # It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
-# are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
+# are specified using the buildRoots property. Also, an inner subproject for every build root can be specified after `:` (colon).
+# It can be useful when there are subprojects in the build that are not aggregated into the root project. The subproject part cannot be empty.
+# If there's no subproject part (the default) then the root project is assumed.
+# Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
 # Default: ["."]
-buildRoots = [ ".", "subfolder/projectA" ]
+buildRoots=[ ".", "subfolder/projectA", ".:subprojectX", "subfolder/projectB:subprojectY" ]
 
 # Define commands that are executed after an update via a hook.
 # A groupId and/or artifactId can be defined to only execute after certain dependencies are updated. If neither is defined, the hook runs for every update.

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildRoot.scala
@@ -18,4 +18,4 @@ package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.data.Repo
 
-final case class BuildRoot(repo: Repo, relativePath: String)
+final case class BuildRoot(repo: Repo, relativePath: String, subProject: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolDispatcher.scala
@@ -43,7 +43,10 @@ final class BuildToolDispatcher[F[_]](implicit
     getBuildRootsAndTools(repo, repoConfig).flatMap(_.flatTraverse { case (buildRoot, buildTools) =>
       for {
         dependencies <- buildTools.flatTraverse { buildTool =>
-          logger.info(s"Get dependencies in ${buildRoot.relativePath} from ${buildTool.name}") >>
+          logger.info {
+            val subProjStr = if (buildRoot.subProject.isEmpty) "" else "/" + buildRoot.subProject
+            s"Get dependencies in ${buildRoot.relativePath}$subProjStr from ${buildTool.name}"
+          } >>
             buildTool.getDependencies(buildRoot)
         }
         maybeScalafmtDependency <- scalafmtAlg.getScopedScalafmtDependency(buildRoot)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -68,8 +68,8 @@ final class SbtAlg[F[_]](defaultResolvers: List[Resolver], ignoreOptsFiles: Bool
       maybeSbtVersion <- getSbtVersion(buildRootDir)
       metaBuilds <- metaBuildsCount(buildRootDir)
       lines <- addStewardPluginTemporarily(buildRootDir, maybeSbtVersion, metaBuilds).surround {
-        val commands = Nel.of(crossStewardDependencies) ++
-          List.fill(metaBuilds)(List(reloadPlugins, stewardDependencies)).flatten
+        val commands = Nel.of(crossStewardDependencies(buildRoot.subProject)) ++
+          List.fill(metaBuilds)(List(reloadPlugins, stewardDependencies(""))).flatten
         sbt(commands, buildRootDir)
       }
       dependencies = parser.parseDependencies(lines)

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
@@ -17,8 +17,16 @@
 package org.scalasteward.core.buildtool.sbt
 
 object command {
-  val stewardDependencies = "stewardDependencies"
-  val crossStewardDependencies = s"+ $stewardDependencies"
+  // NOTE: if `subProj` contains blank chars in the middle, then an incorrect command will be produced.
+  // TODO: consider `subProj` validation.
+  def stewardDependencies(subProj: String): String =
+    (if (subProj.isBlank) "" else s"${subProj.strip}/") + "stewardDependencies"
+
+  // NOTE: if `subProj` contains blank chars in the middle, then an incorrect command will be produced.
+  // TODO: consider `subProj` validation.
+  def crossStewardDependencies(subProj: String): String =
+    s"+ ${stewardDependencies(subProj)}"
+
   val reloadPlugins = "reload plugins"
   val scalafixAll = "scalafixAll"
   val scalafixEnable = "scalafixEnable"

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
@@ -20,7 +20,7 @@ import cats.Eq
 import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 
-final case class BuildRootConfig(relativePath: String, subProject: String = "")
+final case class BuildRootConfig(relativePath: String, subProject: String)
 
 object BuildRootConfig {
   val repoRoot: BuildRootConfig = BuildRootConfig(".", "")

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/BuildRootConfig.scala
@@ -17,18 +17,34 @@
 package org.scalasteward.core.repoconfig
 
 import cats.Eq
+import cats.syntax.all.*
 import io.circe.{Decoder, Encoder}
 
-final case class BuildRootConfig(relativePath: String)
+final case class BuildRootConfig(relativePath: String, subProject: String = "")
 
 object BuildRootConfig {
-  val repoRoot: BuildRootConfig = BuildRootConfig(".")
+  val repoRoot: BuildRootConfig = BuildRootConfig(".", "")
 
   implicit val buildRootConfigDecoder: Decoder[BuildRootConfig] =
-    Decoder[String].map(BuildRootConfig.apply)
+    Decoder[String].emap { str =>
+      str.indexOf(':') match {
+        case -1  => BuildRootConfig(str, "").asRight
+        case cln =>
+          val relPath = str.substring(0, cln)
+          val subProj = str.substring(cln + 1, str.length)
+          Either.cond(
+            subProj.nonEmpty,
+            BuildRootConfig(relPath, subProj),
+            s"$str\nThe subproject part cannot be empty after ':'"
+          )
+      }
+    }
 
   implicit val buildRootConfigEncoder: Encoder[BuildRootConfig] =
-    Encoder[String].contramap(_.relativePath)
+    Encoder[String].contramap {
+      case brc if brc.subProject.isEmpty => brc.relativePath
+      case brc                           => s"${brc.relativePath}:${brc.subProject}"
+    }
 
   implicit val buildRootConfigEq: Eq[BuildRootConfig] =
     Eq.fromUniversalEquals

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -55,7 +55,7 @@ final case class RepoConfig(
     buildRoots
       .map(_.filterNot(_.relativePath.contains("..")))
       .getOrElse(defaultBuildRoots)
-      .map(cfg => BuildRoot(repo, cfg.relativePath))
+      .map(cfg => BuildRoot(repo, cfg.relativePath, cfg.subProject))
 
   def assigneesOrDefault: List[String] =
     assignees.getOrElse(Nil)

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -16,7 +16,7 @@ class BuildToolDispatcherTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("build-tool-dispatcher", "test-1")
     val repoConfig = RepoConfig.empty.copy(buildRoots =
-      Some(List(BuildRootConfig("."), BuildRootConfig("mvn-build")))
+      Some(List(BuildRootConfig(".", ""), BuildRootConfig("mvn-build", "")))
     )
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val initial = MockState.empty
@@ -69,7 +69,7 @@ class BuildToolDispatcherTest extends FunSuite {
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
           "-Dsbt.server.forcestart=true",
-          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";${crossStewardDependencies("")};$reloadPlugins;${stewardDependencies("")}"
         ) +:
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_0_0.scala") +:
         Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin_1_0_0.scala") +:

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/gradle/GradleAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/gradle/GradleAlgTest.scala
@@ -10,7 +10,7 @@ import org.scalasteward.core.mock.{MockEffOps, MockState}
 class GradleAlgTest extends CatsEffectSuite {
   test("getDependencies") {
     val repo = Repo("gradle-alg", "test-getDependencies")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
 
     val initial = MockState.empty.addFiles(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -11,7 +11,7 @@ import org.scalasteward.core.mock.{MockEffOps, MockState}
 class MavenAlgTest extends FunSuite {
   test("getDependencies") {
     val repo = Repo("namespace", "repo-name")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
 
     val state = mavenAlg.getDependencies(buildRoot).runS(MockState.empty).unsafeRunSync()

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/mill/MillAlgTest.scala
@@ -13,7 +13,7 @@ import org.scalasteward.core.mock.{MockEffOps, MockState}
 class MillAlgTest extends FunSuite {
   test("getDependencies, version < 0.11") {
     val repo = Repo("lihaoyi", "fastparse")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
     val predef = s"$buildRootDir/scala-steward.sc"
     val millCmd = Cmd.execSandboxed(buildRootDir, "mill", "-i", "-p", predef, "show", extractDeps)
@@ -37,7 +37,7 @@ class MillAlgTest extends FunSuite {
 
   test("getDependencies, 0.11 <= version < 0.12") {
     val repo = Repo("lihaoyi", "fastparse")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
     val millCmd = Cmd.execSandboxed(
       buildRootDir,
@@ -72,7 +72,7 @@ class MillAlgTest extends FunSuite {
 
   test("getDependencies, 0.12 <= version") {
     val repo = Repo("mill-alg", "test-3")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
     val millCmd = Cmd.execSandboxed(
       buildRootDir,
@@ -108,7 +108,7 @@ class MillAlgTest extends FunSuite {
 
   test("getDependencies, 1 <= version") {
     val repo = Repo("mill-alg", "test-3")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
     val millCmd = Cmd.execSandboxed(
       buildRootDir,

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -16,7 +16,7 @@ class SbtAlgTest extends FunSuite {
 
   test("getDependencies") {
     val repo = Repo("sbt-alg", "test-1")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val initial = MockState.empty
       .addFiles(repoDir / "project" / "build.properties" -> "sbt.version=1.3.11")
@@ -37,7 +37,7 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
           "-Dsbt.server.forcestart=true",
-          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";${crossStewardDependencies("")};$reloadPlugins;${stewardDependencies("")}"
         ),
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin_1_3_11.scala")
@@ -48,7 +48,7 @@ class SbtAlgTest extends FunSuite {
 
   test("sbt 2") {
     val repo = Repo("sbt-alg", "test-2")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val initial = MockState.empty
       .addFiles(repoDir / "project" / "build.properties" -> "sbt.version=2.0.0-RC3")
@@ -69,7 +69,7 @@ class SbtAlgTest extends FunSuite {
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
           "-Dsbt.server.forcestart=true",
-          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";${crossStewardDependencies("")};$reloadPlugins;${stewardDependencies("")}"
         ),
         Cmd("rm", "-rf", s"$repoDir/project/project/scala-steward-StewardPlugin_2_0_0.scala"),
         Cmd("rm", "-rf", s"$repoDir/project/scala-steward-StewardPlugin_2_0_0.scala")
@@ -80,7 +80,7 @@ class SbtAlgTest extends FunSuite {
 
   test("runMigrations") {
     val repo = Repo("fthomas", "scala-steward")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val migration = ScalafixMigration(
       GroupId("co.fs2"),
@@ -118,7 +118,7 @@ class SbtAlgTest extends FunSuite {
 
   test("runMigrations: migration with scalacOptions") {
     val repo = Repo("fthomas", "scala-steward")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val migration = ScalafixMigration(
       GroupId("org.typelevel"),

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/commandTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/commandTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.buildtool.sbt
+
+import munit.ScalaCheckSuite
+import org.scalacheck.{Arbitrary, Gen, Prop}
+
+class commandTest extends ScalaCheckSuite {
+  private val genWsChar = Gen.oneOf(' ', '\f', '\n', '\r', '\t')
+  private val genWsStr = Gen.stringOf(genWsChar)
+  private val genNonBlankChar = Arbitrary.arbitrary[Char].retryUntil(!_.isWhitespace)
+  private val genNoBlanksStr = Gen.nonEmptyStringOf(genNonBlankChar)
+
+  property("stewardDependencies/crossStewardDependencies with blank subproject") {
+    Prop.forAllNoShrink(genWsStr) { wsStr =>
+      assertEquals(command.stewardDependencies(wsStr), "stewardDependencies")
+      assertEquals(command.crossStewardDependencies(wsStr), "+ stewardDependencies")
+    }
+  }
+  property("stewardDependencies/crossStewardDependencies with non-blank subproject") {
+    val gen = for {
+      subProj <-
+        Gen.zipWith(
+          // This will insert whitespace in the middle of `subProj`, which is currently allowed
+          // but incorrect. It should be removed once `subProj` validation is added.
+          Gen.nonEmptyListOf(Gen.zipWith(genNoBlanksStr, genWsStr)(_ + _)),
+          genNoBlanksStr
+        )(_.mkString + _)
+      leadWss <- genWsStr
+      trailWss <- genWsStr
+    } yield (leadWss, subProj, trailWss)
+
+    Prop.forAllNoShrink(gen) { case (leadWss, subProj, trailWss) =>
+      val input = leadWss + subProj + trailWss
+      assertEquals(command.stewardDependencies(input), s"$subProj/stewardDependencies")
+      assertEquals(command.crossStewardDependencies(input), s"+ $subProj/stewardDependencies")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlgTest.scala
@@ -14,7 +14,7 @@ import org.scalasteward.core.util.Nel
 class ScalaCliAlgTest extends CatsEffectSuite {
   test("containsBuild: directive in non-source file") {
     val repo = Repo("user", "repo")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val fileWithUsingLib = "test.md" // this test fails if the extension is .scala or .sc
     val grepCmd = Cmd.gitGrep(repoDir, "//> using lib ")
@@ -26,7 +26,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
 
   test("containsBuild: directive with test.dep, dep, and lib") {
     val repo = Repo("user", "repo")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val fileWithUsingDirective = "project.scala"
 
@@ -45,7 +45,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
 
   test("getDependencies") {
     val repo = Repo("user", "repo")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val sbtBuildDir = repoDir / "tmp-sbt-build-for-scala-steward"
 
@@ -73,7 +73,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
           "-Dsbt.log.noformat=true",
           "-Dsbt.supershell=false",
           "-Dsbt.server.forcestart=true",
-          s";$crossStewardDependencies"
+          s";${crossStewardDependencies("")}"
         ),
         Cmd("rm", "-rf", s"$sbtBuildDir/project/scala-steward-StewardPlugin_1_3_11.scala"),
         Cmd("rm", "-rf", s"$sbtBuildDir")
@@ -85,7 +85,7 @@ class ScalaCliAlgTest extends CatsEffectSuite {
 
   test("runMigration") {
     val repo = Repo("scala-cli-alg", "test-runMigration")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val buildRootDir = workspaceAlg.buildRootDir(buildRoot).unsafeRunSync()
     val migration = ScalafixMigration(
       GroupId("co.fs2"),

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/BuildRootConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/BuildRootConfigTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.syntax.all.*
+import io.circe.testing.CodecTests
+import io.circe.testing.instances.*
+import io.circe.{DecodingFailure, Json}
+import munit.{DisciplineSuite, FunSuite}
+import org.scalacheck.{Arbitrary, Gen, Prop}
+
+class BuildRootConfigTest extends FunSuite with DisciplineSuite {
+  private val genRelPathStr: Gen[String] =
+    Gen.nonEmptyStringOf(Arbitrary.arbitrary[Char]).filterNot(_.contains(':'))
+  private val genSubProjStr: Gen[String] =
+    Gen.nonEmptyStringOf(Arbitrary.arbitrary[Char])
+
+  private val genBuildRootConfig: Gen[BuildRootConfig] =
+    Gen.zipWith(
+      genRelPathStr,
+      Gen.frequency(1 -> Gen.const(""), 4 -> genSubProjStr)
+    )(BuildRootConfig.apply)
+
+  implicit private val arbBuildRootConfig: Arbitrary[BuildRootConfig] = Arbitrary(
+    genBuildRootConfig
+  )
+
+  test("Decode empty string") {
+    val expected = Right(BuildRootConfig("", ""))
+    val obtained = Json.fromString("").as[BuildRootConfig]
+    assertEquals(obtained, expected)
+  }
+  property("Decode `relativePath` only") {
+    Prop.forAllNoShrink(genRelPathStr) { (relPathStr: String) =>
+      val expected = Right(BuildRootConfig(relPathStr, ""))
+      val obtained = Json.fromString(relPathStr).as[BuildRootConfig]
+      assertEquals(obtained, expected)
+    }
+  }
+  property("Decode `relativePath` with separator and empty `subProject` part") {
+    Prop.forAllNoShrink(genRelPathStr) { (relPathStr: String) =>
+      val input = s"$relPathStr:"
+      val expected =
+        DecodingFailure(s"$input\nThe subproject part cannot be empty after ':'", Nil)
+          .asLeft[BuildRootConfig]
+      val obtained = Json.fromString(input).as[BuildRootConfig]
+      assertEquals(obtained, expected)
+    }
+  }
+  property("Decode `relativePath` with separator and non-empty `subProject` part") {
+    Prop.forAllNoShrink(genRelPathStr, genSubProjStr) { (relPathStr: String, subProjStr) =>
+      val input = s"$relPathStr:$subProjStr"
+      val expected = Right(BuildRootConfig(relPathStr, subProjStr))
+      val obtained = Json.fromString(input).as[BuildRootConfig]
+      assertEquals(obtained, expected)
+    }
+  }
+
+  checkAll("CodecTests", CodecTests[BuildRootConfig].codec)
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -136,7 +136,7 @@ class RepoConfigAlgTest extends FunSuite {
       commits = CommitsConfig(
         message = Some("Update ${artifactName} from ${currentVersion} to ${nextVersion}")
       ).some,
-      buildRoots = Some(List(BuildRootConfig.repoRoot, BuildRootConfig("subfolder/subfolder"))),
+      buildRoots = Some(List(BuildRootConfig.repoRoot, BuildRootConfig("subfolder/subfolder", ""))),
       dependencyOverrides = List(
         GroupRepoConfig(
           dependency = UpdatePattern(GroupId("eu.timepit"), None, None),

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/ScalafmtAlgTest.scala
@@ -11,7 +11,7 @@ import org.scalasteward.core.mock.{MockEffOps, MockState}
 class ScalafmtAlgTest extends FunSuite {
   test("getScalafmtVersion on unquoted version") {
     val repo = Repo("fthomas", "scala-steward")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val scalafmtConf = repoDir / scalafmtConfName
     val initialState = MockState.empty
@@ -32,7 +32,7 @@ class ScalafmtAlgTest extends FunSuite {
 
   test("getScalafmtVersion on quoted version") {
     val repo = Repo("fthomas", "scala-steward")
-    val buildRoot = BuildRoot(repo, ".")
+    val buildRoot = BuildRoot(repo, ".", "")
     val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
     val scalafmtConf = repoDir / scalafmtConfName
     val initialState = MockState.empty

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val circeGeneric = "io.circe" %% "circe-generic" % "0.14.15"
   val circeLiteral = "io.circe" %% "circe-literal" % circeGeneric.revision
   val circeParser = "io.circe" %% "circe-parser" % circeGeneric.revision
+  val circeTesting = "io.circe" %% "circe-testing" % circeGeneric.revision
   val circeRefined = "io.circe" %% "circe-refined" % "0.15.1"
   val commonsIo = "commons-io" % "commons-io" % "2.22.0"
   val coursierCore = "io.get-coursier" %% "coursier" % "2.1.24"


### PR DESCRIPTION
One more step towards #1481 resolution.
Although it probably does not resolve it completely – this PR only tackles on SBT builds.

Introduces a "sub-project" part for the `buildRoots` configuration option:
```
# It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
# are specified using the buildRoots property. Also, an inner subproject for every build root can be specified after `:` (colon).
# It can be useful when there are subprojects in the build that are not aggregated into the root project. The subproject part cannot be empty.
# If there's no subproject part (the default) then the root project is assumed.
# Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
# Default: ["."]
buildRoots=[ ".", "subfolder/projectA", ".:subProjectX", "subfolder/projectB:subprojectY" ]
```

The `:` (colon) symbol is used as a separator between the `relativePath` and `subProject` parts in the configuration.
