### PR TITLE
Update dockerBaseImage to eclipse-temurin:17-alpine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,7 +362,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val dockerSettings = Def.settings(
   dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE"))
-    .getOrElse("eclipse-temurin:11-alpine"),
+    .getOrElse("eclipse-temurin:17-alpine"),
   dockerCommands ++= {
     val curl = "curl -fL --output"
     val binDir = "/usr/local/bin"


### PR DESCRIPTION
Fixes https://github.com/scala-steward-org/scala-steward/issues/3835. I'm aware of https://github.com/scala-steward-org/scala-steward/pull/3471, but at the moment scalafix doesn't run because of this error:
```
2026-03-05 13:24:49,876 WARN  Failed to execute scalafix  -- make sure it is on the PATH; following the detailed exception:
[org.scalasteward.core.io](http://org.scalasteward.core.io/).process$ProcessFailedException: 'scalafix --version' exited with code 1.
Exception in thread "main" java.lang.UnsupportedClassVersionError: scalafix/cli/Cli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

If java 21 is a step too far, maybe we can go to java 17?