### PR TITLE
Avoid long GitHub errors causing excessively-long run-summaries

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -20,12 +20,14 @@ import cats.effect.Concurrent
 import cats.syntax.all.*
 import fs2.Stream
 import io.circe.{Decoder, Encoder}
+import org.apache.commons.lang3.StringUtils.abbreviate
 import org.http4s.*
 import org.http4s.Method.{GET, PATCH, POST, PUT}
 import org.http4s.Status.Successful
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.Client
 import org.http4s.headers.{Accept, Link, MediaRangeAndQValue}
+
 import scala.util.control.NoStackTrace
 
 final class HttpJsonClient[F[_]](implicit
@@ -140,5 +142,5 @@ final case class UnexpectedResponse(
         |status: $status
         |headers:
         |${headers.headers.map(h => s"  ${h.show}").mkString("\n")}
-        |body: $body""".stripMargin
+        |body: ${abbreviate(body, 1000)}""".stripMargin
 }


### PR DESCRIPTION
With the sadly declining reliability of the GitHub API, I've started to see [Scala Steward run summaries](https://github.com/scala-steward-org/scala-steward/pull/3071) become so large that they exceed GitHub Actions' 1024k limit:

```
call-reusable-workflow / scala-steward
$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1194k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary
```

In that example, the run summary for just 37 repos is 1194KB because many of them failed with a `502 Bad Gateway` response from GitHub - and when GitHub fails like that, it returns a large [HTML error page](https://github.com/502.html) - about 55KB of HTML:

```
2026-03-10 10:43:51,750 ERROR Steward guardian/ophan failed
  org.scalasteward.core.util.UnexpectedResponse: uri: https://api.github.com/installation/repositories?per_page=100
  method: GET
  status: 502 Bad Gateway
  headers:
    cache-control: no-cache
    connection: close
    content-security-policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:;
    content-type: text/html; charset=utf-8
    strict-transport-security: max-age=31536000; includeSubDomains; preload
    x-content-type-options: nosniff
    x-frame-options: deny
    x-github-request-id: 9C00:23F69F:90EE0B:2713574:69AFF5E7
    x-xss-protection: 0
  body: <!DOCTYPE html>
  <!--

  Hello future GitHubber! I bet you're here to remove those nasty inline styles,
  DRY up these templates and make 'em nice and re-usable, right?

  Please, don't. https://github.com/styleguide/templates/2.0

  -->
  <html>
    <head>
      <title>Unicorn! &middot; GitHub</title>
...
```

<img width="1129" height="463" alt="image" src="https://github.com/user-attachments/assets/cb149b1c-16e8-4a8f-acbf-c3afe2461965" />

## Fix

This change truncates the body of the response written to logs and the summary. The truncation is only for the `UnexpectedResponse` exception, which occurs for HTTP status codes of 5xx and above, where the full response body is less likely to be useful, and not others like `DecodeFailure` (where the full response body might be diagnostically useful).
