### PR TITLE
WIP: Group updates by Edit

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -19,10 +19,11 @@ package org.scalasteward.core.data
 import cats.Order
 import cats.implicits.*
 import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
+import org.scalasteward.core.nurture.UpdatesForGivenEdit
 import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
-import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
 
 case class ArtifactForUpdate(
     crossDependency: CrossDependency,
@@ -243,12 +244,32 @@ object Update {
     groups1.toList.distinct.sortBy(u => u: Update.Single)
   }
 
-  def groupByGroupId(updates: List[ForArtifactId]): List[Single] = {
+  /** If a set of ApplicableUpdateSet all have the same GroupId, then they could be an
+    * Update.ForGroupId()
+    *
+    * If there is only one artifact within a ApplicableUpdateSet for a given group id, just create a
+    * Update.ForArtifactId
+    *
+    * Otherwise, create a Grouped()?
+    */
+  def groupByGroupId(updates: List[UpdatesForGivenEdit]): List[Update] = {
     val groups0 =
-      updates.groupByNel(s => (s.groupId, s.versionUpdate))
-    val groups1 = groups0.map { case ((_, versionUpdate), group) =>
-      if (group.tail.isEmpty) group.head
-      else ForGroupId(group.map(_.artifactForUpdate), versionUpdate.nextVersion)
+      updates.groupByNel(s => (s.commonGroupId, s.commonVersionUpdate))
+    val groups1: Iterable[Update] = groups0.map {
+      case ((Some(_), Some(versionUpdate)), updatesWithCommonMavenGroupId) =>
+        val affectedArtifacts = updatesWithCommonMavenGroupId.flatMap(_.artifactsForUpdate)
+        if (affectedArtifacts.size == 1)
+          Update.ForArtifactId(
+            affectedArtifacts.head,
+            updatesWithCommonMavenGroupId.head.nextVersion
+          )
+        else
+          ForGroupId(
+            updatesWithCommonMavenGroupId.flatMap(_.artifactsForUpdate),
+            versionUpdate.nextVersion
+          )
+      case (_, group) =>
+        Update.Grouped("some random name", None, group.flatMap(_.asUpdatesForArtifactId).toList)
     }
     groups1.toList.distinct.sorted
   }
@@ -260,17 +281,33 @@ object Update {
     */
   def groupByPullRequestGroup(
       groups: List[PullRequestGroup],
-      updates: List[Update.ForArtifactId]
-  ): (List[Grouped], List[Update.ForArtifactId]) =
+      updates: List[UpdatesForGivenEdit]
+  ): (List[Grouped], List[UpdatesForGivenEdit]) =
     groups.foldLeft((List.empty[Grouped], updates)) { case ((grouped, notGrouped), group) =>
       notGrouped.partition(group.matches) match {
         case (Nil, rest)     => (grouped, rest)
-        case (matched, rest) => (grouped :+ Grouped(group.name, group.title, matched), rest)
+        case (matched, rest) =>
+          (
+            grouped :+ Grouped(
+              group.name,
+              group.title,
+              matched.flatMap(_.asUpdatesForArtifactId.toList)
+            ),
+            rest
+          )
       }
     }
 
   implicit val SingleOrder: Order[Single] =
     Order.by((u: Single) => (u.crossDependencies, u.nextVersion))
+
+  implicit val GroupedOrder: Order[Grouped] =
+    Order.by((u: Grouped) => (u.name, u.asSingleUpdates))
+
+  implicit val UpdateOrder: Order[Update] = Order.by {
+    case g: Grouped => Left(g)
+    case s: Single  => Right(s)
+  }
 
   // Encoder and Decoder instances
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -274,6 +274,14 @@ object Update {
     groups1.toList.distinct.sorted
   }
 
+  def performAllGrouping(
+      updatesByEdit: Seq[UpdatesForGivenEdit],
+      groups: List[PullRequestGroup]
+  ): List[Update] = {
+    val (grouped, notGrouped) = groupByPullRequestGroup(groups, updatesByEdit.toList)
+    groupByGroupId(notGrouped) ++ grouped
+  }
+
   /** Processes the provided updates using the group configuration. Each update will only be present
     * in the first group it falls into.
     *

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -17,13 +17,16 @@
 package org.scalasteward.core.data
 
 import cats.Order
+import cats.data.NonEmptyList
 import cats.implicits.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
-import org.scalasteward.core.nurture.UpdatesForGivenEdit
+import org.scalasteward.core.edit.update.data.Substring.Replacement
+import org.scalasteward.core.nurture.InseparableUpdateSet
 import org.scalasteward.core.repoconfig.PullRequestGroup
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
+import cats.syntax.*
 
 case class ArtifactForUpdate(
     crossDependency: CrossDependency,
@@ -83,7 +86,7 @@ sealed trait Update {
 
   def show: String
 
-  val asSingleUpdates: List[Update.Single]
+  val asSingleUpdates: Nel[Update.Single]
 }
 
 object Update {
@@ -96,15 +99,15 @@ object Update {
   final case class Grouped(
       name: String,
       title: Option[String],
-      updates: List[Update.ForArtifactId]
+      updates: Nel[Update.ForArtifactId]
   ) extends Update {
 
     override def show: String = name
-    override val asSingleUpdates: List[Update.Single] = updates
+    override val asSingleUpdates: Nel[Update.Single] = updates
   }
 
   sealed trait Single extends Product with Serializable with Update {
-    override val asSingleUpdates: List[Update.Single] = List(this)
+    override val asSingleUpdates: Nel[Update.Single] = Nel.one(this)
     def artifactsForUpdate: Nel[ArtifactForUpdate]
     def forArtifactIds: Nel[ForArtifactId]
     def crossDependencies: Nel[CrossDependency]
@@ -252,9 +255,8 @@ object Update {
     *
     * Otherwise, create a Grouped()?
     */
-  def groupByGroupId(updates: List[UpdatesForGivenEdit]): List[Update] = {
-    val groups0 =
-      updates.groupByNel(s => (s.commonGroupId, s.commonVersionUpdate))
+  def groupByGroupId(updates: Map[Set[Replacement], InseparableUpdateSet]): List[Update] = {
+    val groups0 = updates.values.toList.groupByNel(s => (s.commonGroupId, s.commonVersionUpdate))
     val groups1: Iterable[Update] = groups0.map {
       case ((Some(_), Some(versionUpdate)), updatesWithCommonMavenGroupId) =>
         val affectedArtifacts = updatesWithCommonMavenGroupId.flatMap(_.artifactsForUpdate)
@@ -269,16 +271,16 @@ object Update {
             versionUpdate.nextVersion
           )
       case (_, group) =>
-        Update.Grouped("some random name", None, group.flatMap(_.asUpdatesForArtifactId).toList)
+        Update.Grouped("some random name", None, group.flatMap(_.asUpdatesForArtifactId))
     }
     groups1.toList.distinct.sorted
   }
 
   def performAllGrouping(
-      updatesByEdit: Seq[UpdatesForGivenEdit],
+      updatesByEdit: Map[Set[Replacement], InseparableUpdateSet],
       groups: List[PullRequestGroup]
   ): List[Update] = {
-    val (grouped, notGrouped) = groupByPullRequestGroup(groups, updatesByEdit.toList)
+    val (grouped, notGrouped) = groupByPullRequestGroup(groups, updatesByEdit)
     groupByGroupId(notGrouped) ++ grouped
   }
 
@@ -289,19 +291,14 @@ object Update {
     */
   def groupByPullRequestGroup(
       groups: List[PullRequestGroup],
-      updates: List[UpdatesForGivenEdit]
-  ): (List[Grouped], List[UpdatesForGivenEdit]) =
-    groups.foldLeft((List.empty[Grouped], updates)) { case ((grouped, notGrouped), group) =>
-      notGrouped.partition(group.matches) match {
-        case (Nil, rest)     => (grouped, rest)
-        case (matched, rest) =>
-          (
-            grouped :+ Grouped(
-              group.name,
-              group.title,
-              matched.flatMap(_.asUpdatesForArtifactId.toList)
-            ),
-            rest
+      updatesByEdit: Map[Set[Replacement], InseparableUpdateSet]
+  ): (List[Grouped], Map[Set[Replacement], InseparableUpdateSet]) =
+    groups.foldLeft((List.empty[Grouped], updatesByEdit)) { case ((grouped, notGrouped), group) =>
+      notGrouped.partition(x => group.matches(x._2)).leftMap { matched =>
+        grouped ++ NonEmptyList
+          .fromList(matched.toList)
+          .map(updateSets =>
+            group.asGroupedUpdateOf(updateSets.flatMap(_._2.asUpdatesForArtifactId))
           )
       }
     }
@@ -382,7 +379,7 @@ object Update {
     Decoder.forProduct1("Grouped")(identity[Grouped]) {
       Decoder.forProduct3("name", "title", "updates") {
         (name: String, title: Option[String], updates: List[ForArtifactId]) =>
-          Grouped(name, title, updates)
+          Grouped(name, title, Nel.fromListUnsafe(updates))
       }
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -44,7 +44,17 @@ final class EditAlg[F[_]](implicit
     workspaceAlg: WorkspaceAlg[F],
     F: MonadThrow[F]
 ) {
+
   def applyUpdate(
+      data: RepoData,
+      update: Update,
+      preCommit: F[Unit] = F.unit
+  ): F[List[EditAttempt]] = update.on(
+    update = applySingleUpdate(data, _, preCommit),
+    grouped = preCommit >> _.updates.flatTraverse(applySingleUpdate(data, _))
+  )
+
+  private def applySingleUpdate(
       data: RepoData,
       update: Update.Single,
       preCommit: F[Unit] = F.unit
@@ -67,7 +77,7 @@ final class EditAlg[F[_]](implicit
         } yield preScalafixEdits ++ updateEdit ++ postScalafixEdits ++ hooksEdits
     }
 
-  private def findUpdateReplacements(
+  def findUpdateReplacements(
       repo: Repo,
       config: RepoConfig,
       update: Update.Single

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -51,7 +51,7 @@ final class EditAlg[F[_]](implicit
       preCommit: F[Unit] = F.unit
   ): F[List[EditAttempt]] = update.on(
     update = applySingleUpdate(data, _, preCommit),
-    grouped = preCommit >> _.updates.flatTraverse(applySingleUpdate(data, _))
+    grouped = preCommit >> _.updates.toList.flatTraverse(applySingleUpdate(data, _))
   )
 
   private def applySingleUpdate(

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/data/Substring.scala
@@ -16,7 +16,8 @@
 
 package org.scalasteward.core.edit.update.data
 
-import cats.ApplicativeThrow
+import cats.{ApplicativeThrow, Order}
+
 import scala.util.matching.Regex.Match
 
 object Substring {
@@ -28,6 +29,8 @@ object Substring {
   }
 
   object Position {
+    implicit val orderPosition: Order[Position] = Order.by(p => (p.path, p.start, p.value))
+
     def fromMatch(path: String, m: Match, value: String): Position = {
       val start = m.start + m.matched.indexOf(value)
       Position(path, start, value)
@@ -42,6 +45,8 @@ object Substring {
   final case class Replacement(position: Position, replacement: String)
 
   object Replacement {
+    implicit val orderReplacement: Order[Replacement] = Order.by(r => (r.position, r.replacement))
+
     def applyAll[F[_]](replacements: List[Replacement])(source: String)(implicit
         F: ApplicativeThrow[F]
     ): F[String] =

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/data/NewPullRequestData.scala
@@ -148,15 +148,11 @@ object NewPullRequestData {
     update match {
       case single: Update.Single   => single
       case grouped: Update.Grouped =>
-        grouped.copy(updates = grouped.updates.filter { update =>
+        grouped.copy(updates = Nel.fromListUnsafe(grouped.updates.filter { update =>
           edits
-            .collect { case EditAttempt.UpdateEdit(update, _) =>
-              update.groupAndMainArtifactId
-            }
-            .exists { case (groupId, artifactId) =>
-              update.groupId == groupId && update.mainArtifactId == artifactId
-            }
-        })
+            .collect { case EditAttempt.UpdateEdit(u, _) => u.groupAndMainArtifactId }
+            .exists { case (groupId, artifactId) => update.groupId == groupId && update.mainArtifactId == artifactId }
+        }))
     }
 
   def renderUpdateInfoUrls(updateInfoUrls: List[UpdateInfoUrl]): Option[String] =
@@ -318,7 +314,7 @@ object NewPullRequestData {
     )
 
   def updateTypeLabels(anUpdate: Update): List[String] = {
-    def forUpdate(update: Update.Single) = {
+    def forUpdate(update: Update.Single): String = {
       val dependencies = update.dependencies
       if (dependencies.forall(_.configurations.contains("test")))
         "test-library-update"
@@ -330,7 +326,7 @@ object NewPullRequestData {
         "library-update"
     }
 
-    anUpdate.on(u => List(forUpdate(u)), _.updates.map(forUpdate).distinct)
+    anUpdate.on(u => List(forUpdate(u)), _.updates.map(forUpdate).distinct.toList)
   }
 
   def labelsFor(
@@ -359,11 +355,11 @@ object NewPullRequestData {
       List(earlySemVerLabel, semVerSpecLabel, versionSchemeLabel).flatten
     }
     val semverLabels =
-      update.on(u => semverForUpdate(u), _.updates.flatMap(semverForUpdate(_)).distinct)
+      update.on(u => semverForUpdate(u), _.updates.toList.flatMap(semverForUpdate(_)).distinct)
 
     val artifactMigrationsLabel = Option.when {
       update.asSingleUpdates
-        .flatMap(_.artifactsForUpdate.toList)
+        .flatMap(_.artifactsForUpdate)
         .exists(u => u.newerGroupId.nonEmpty || u.newerArtifactId.nonEmpty)
     }("artifact-migrations")
     val scalafixLabel = edits.collectFirst { case _: ScalafixEdit => "scalafix-migrations" }

--- a/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala
@@ -58,17 +58,12 @@ object CommitMsg {
   def groupMessage(group: Update.Grouped, baseBranch: Option[Branch]): String = {
     def innerGroupMessage(shortNotation: Boolean) = {
       val artifactsWithVersions = group.updates
-        .groupBy(_.nextVersion)
-        .map {
-          case (version, List(update)) =>
-            s"${update.artifactId.name} to ${version.value}"
-
-          case (version, updates) if shortNotation =>
-            val firstArtifactName = updates.headOption.map(_.artifactId.name).getOrElse("")
-            s"$firstArtifactName and ${updates.size - 1} more to ${version.value}"
-
-          case (version, updates) =>
-            s"${updates.map(_.artifactId.name).mkString(", ")} to ${version.value}"
+        .groupMap(_.nextVersion)(_.artifactId.name)
+        .map { case (version, updates) =>
+          updates.head + Nel.fromList(updates.tail).map { tails =>
+            if (shortNotation) s" and ${tails.size} more"
+            else tails.map(", " + _).toList.mkString
+          } + s" to ${version.value}"
         }
         .mkString(" - ")
 

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -23,6 +23,7 @@ import org.scalasteward.core.application.Config.ForgeCfg
 import org.scalasteward.core.coursier.CoursierAlg
 import org.scalasteward.core.data.*
 import org.scalasteward.core.data.ProcessResult.{Created, Ignored, Updated}
+import org.scalasteward.core.edit.update.data.Substring
 import org.scalasteward.core.edit.{EditAlg, EditAttempt}
 import org.scalasteward.core.forge.ForgeType.GitHub
 import org.scalasteward.core.forge.data.*
@@ -34,6 +35,29 @@ import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.util.{Nel, UrlChecker}
 import org.scalasteward.core.{git, util}
 import org.typelevel.log4cats.Logger
+
+case class UpdatesForGivenEdit(
+    edits: List[Substring.Replacement],
+    artifactsForUpdate: Nel[ArtifactForUpdate],
+    nextVersion: Version
+) {
+  val commonGroupId: Option[GroupId] = {
+    val updatesByGroupId = artifactsForUpdate.groupBy(_.groupId)
+    Option.when(updatesByGroupId.size == 1)(updatesByGroupId.keys.head)
+  }
+
+  val commonCurrentVersion: Option[Version] = {
+    val updatesByVersionUpdate = artifactsForUpdate.groupBy(_.currentVersion)
+    Option.when(updatesByVersionUpdate.size == 1)(updatesByVersionUpdate.keys.head)
+  }
+
+  val commonVersionUpdate: Option[Version.Update] =
+    commonCurrentVersion.map(Version.Update(_, nextVersion))
+
+  lazy val asUpdatesForArtifactId: Nel[Update.ForArtifactId] = for {
+    artifactForUpdate <- artifactsForUpdate
+  } yield Update.ForArtifactId(artifactForUpdate, nextVersion)
+}
 
 final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     coursierAlg: CoursierAlg[F],
@@ -48,12 +72,25 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     F: Concurrent[F]
 ) {
   def nurture(data: RepoData, fork: RepoOut, updates: Nel[Update.ForArtifactId]): F[Unit] =
+
     for {
       _ <- logger.info(s"Nurture ${data.repo.show}")
       baseBranch <- cloneAndSync(data.repo, fork)
+      applicableUpdateSets <- updates
+        .traverse(update =>
+          editAlg
+            .findUpdateReplacements(fork.repo, data.config, update)
+            .map(update -> (_, update.nextVersion))
+        )
+        .map {
+          _.toList.groupMap(_._2)(_._1).flatMap { case ((r, nextVersion), a) =>
+            Nel.fromList(a.map(_.artifactForUpdate)).map(UpdatesForGivenEdit(r, _, nextVersion))
+          }
+        }
+
       (grouped, notGrouped) = Update.groupByPullRequestGroup(
         data.config.pullRequestsOrDefault.groupingOrDefault,
-        updates.toList
+        applicableUpdateSets.toList
       )
       finalUpdates = Update.groupByGroupId(notGrouped) ++ grouped
       _ <- updateDependencies(data, fork.repo, baseBranch, finalUpdates)
@@ -158,11 +195,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     gitAlg.returnToCurrentBranch(data.repo) {
       val createBranch = logger.info(s"Create branch ${data.updateBranch.name}") >>
         gitAlg.createBranch(data.repo, data.updateBranch)
-      data.update
-        .on(
-          update = editAlg.applyUpdate(data.repoData, _, createBranch),
-          grouped = createBranch >> _.updates.flatTraverse(editAlg.applyUpdate(data.repoData, _))
-        )
+      editAlg
+        .applyUpdate(data.repoData, data.update, createBranch)
         .flatMap { edits =>
           val editCommits = edits.flatMap(_.commits)
           if (editCommits.isEmpty) logger.warn("No commits created").as(Ignored)
@@ -288,10 +322,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
         s"Reset ${data.updateBranch.name} to ${data.baseBranch.name} and apply again"
       )
       _ <- gitAlg.resetHard(data.repo, data.baseBranch)
-      edits <- data.update.on(
-        update = editAlg.applyUpdate(data.repoData, _),
-        grouped = _.updates.flatTraverse(editAlg.applyUpdate(data.repoData, _))
-      )
+      edits <- editAlg.applyUpdate(data.repoData, data.update)
       editCommits = edits.flatMap(_.commits)
       result <- pushCommits(data, editCommits)
       requestData <- preparePullRequest(data, edits)

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -30,7 +30,7 @@ import org.scalasteward.core.forge.data.*
 import org.scalasteward.core.forge.data.NewPullRequestData.{filterLabels, labelsFor}
 import org.scalasteward.core.forge.{ForgeApiAlg, ForgeRepoAlg}
 import org.scalasteward.core.git.{Branch, Commit, GitAlg}
-import org.scalasteward.core.repoconfig.{PullRequestUpdateStrategy, RetractedArtifact}
+import org.scalasteward.core.repoconfig.{PullRequestUpdateStrategy, RepoConfig, RetractedArtifact}
 import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.util.{Nel, UrlChecker}
 import org.scalasteward.core.{git, util}
@@ -71,28 +71,38 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     urlChecker: UrlChecker[F],
     F: Concurrent[F]
 ) {
-  def nurture(data: RepoData, fork: RepoOut, updates: Nel[Update.ForArtifactId]): F[Unit] =
+  def updateEditsFor(
+      repoConfig: RepoConfig,
+      repo: Repo,
+      updates: Nel[Update.ForArtifactId]
+  ): F[Iterable[UpdatesForGivenEdit]] = updates
+    .traverse(update =>
+      editAlg
+        .findUpdateReplacements(repo, repoConfig, update)
+        .map(reps => (reps, update.nextVersion) -> update.artifactForUpdate)
+    )
+    .map {
+      _.groupMap(_._1)(_._2).map { case ((reps, nextVersion), artifacts) =>
+        UpdatesForGivenEdit(reps, artifacts, nextVersion)
+      }
+    }
 
+  def finalUpdatesFor(
+      repoConfig: RepoConfig,
+      repo: Repo,
+      updates: Nel[Update.ForArtifactId]
+  ): F[List[Update]] = for {
+    updatesByEdit <- updateEditsFor(repoConfig, repo, updates)
+  } yield Update.performAllGrouping(
+    updatesByEdit.toSeq,
+    repoConfig.pullRequestsOrDefault.groupingOrDefault
+  )
+
+  def nurture(data: RepoData, fork: RepoOut, updates: Nel[Update.ForArtifactId]): F[Unit] =
     for {
       _ <- logger.info(s"Nurture ${data.repo.show}")
       baseBranch <- cloneAndSync(data.repo, fork)
-      applicableUpdateSets <- updates
-        .traverse(update =>
-          editAlg
-            .findUpdateReplacements(fork.repo, data.config, update)
-            .map(update -> (_, update.nextVersion))
-        )
-        .map {
-          _.toList.groupMap(_._2)(_._1).flatMap { case ((r, nextVersion), a) =>
-            Nel.fromList(a.map(_.artifactForUpdate)).map(UpdatesForGivenEdit(r, _, nextVersion))
-          }
-        }
-
-      (grouped, notGrouped) = Update.groupByPullRequestGroup(
-        data.config.pullRequestsOrDefault.groupingOrDefault,
-        applicableUpdateSets.toList
-      )
-      finalUpdates = Update.groupByGroupId(notGrouped) ++ grouped
+      finalUpdates <- finalUpdatesFor(data.config, fork.repo, updates)
       _ <- updateDependencies(data, fork.repo, baseBranch, finalUpdates)
     } yield ()
 

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -98,13 +98,12 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     repoConfig.pullRequestsOrDefault.groupingOrDefault
   )
 
-  def nurture(data: RepoData, fork: RepoOut, updates: Nel[Update.ForArtifactId]): F[Unit] =
-    for {
-      _ <- logger.info(s"Nurture ${data.repo.show}")
-      baseBranch <- cloneAndSync(data.repo, fork)
-      finalUpdates <- finalUpdatesFor(data.config, fork.repo, updates)
-      _ <- updateDependencies(data, fork.repo, baseBranch, finalUpdates)
-    } yield ()
+  def nurture(data: RepoData, fork: RepoOut, updates: Nel[Update.ForArtifactId]): F[Unit] = for {
+    _ <- logger.info(s"Nurture ${data.repo.show}")
+    baseBranch <- cloneAndSync(data.repo, fork)
+    finalUpdates <- finalUpdatesFor(data.config, fork.repo, updates)
+    _ <- updateDependencies(data, fork.repo, baseBranch, finalUpdates)
+  } yield ()
 
   private def cloneAndSync(repo: Repo, fork: RepoOut): F[Branch] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -66,7 +66,9 @@ case class InseparableUpdateSet(
 case class UpdatesForGivenEdit(
   edits: List[Substring.Replacement],
   inseparableUpdateSet: InseparableUpdateSet
-)
+) {
+  lazy val asUpdatesForArtifactId: Nel[Update.ForArtifactId] = inseparableUpdateSet.asUpdatesForArtifactId
+}
 
 final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     coursierAlg: CoursierAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -24,6 +24,7 @@ import org.scalasteward.core.coursier.CoursierAlg
 import org.scalasteward.core.data.*
 import org.scalasteward.core.data.ProcessResult.{Created, Ignored, Updated}
 import org.scalasteward.core.edit.update.data.Substring
+import org.scalasteward.core.edit.update.data.Substring.Replacement
 import org.scalasteward.core.edit.{EditAlg, EditAttempt}
 import org.scalasteward.core.forge.ForgeType.GitHub
 import org.scalasteward.core.forge.data.*
@@ -36,10 +37,9 @@ import org.scalasteward.core.util.{Nel, UrlChecker}
 import org.scalasteward.core.{git, util}
 import org.typelevel.log4cats.Logger
 
-case class UpdatesForGivenEdit(
-    edits: List[Substring.Replacement],
-    artifactsForUpdate: Nel[ArtifactForUpdate],
-    nextVersion: Version
+case class InseparableUpdateSet(
+  artifactsForUpdate: Nel[ArtifactForUpdate],
+  nextVersion: Version
 ) {
   val commonGroupId: Option[GroupId] = {
     val updatesByGroupId = artifactsForUpdate.groupBy(_.groupId)
@@ -59,6 +59,11 @@ case class UpdatesForGivenEdit(
   } yield Update.ForArtifactId(artifactForUpdate, nextVersion)
 }
 
+case class UpdatesForGivenEdit(
+  edits: List[Substring.Replacement],
+  inseparableUpdateSet: InseparableUpdateSet
+)
+
 final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
     coursierAlg: CoursierAlg[F],
     editAlg: EditAlg[F],
@@ -75,15 +80,15 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       repoConfig: RepoConfig,
       repo: Repo,
       updates: Nel[Update.ForArtifactId]
-  ): F[Iterable[UpdatesForGivenEdit]] = updates
+  ): F[Map[Set[Replacement], InseparableUpdateSet]] = updates
     .traverse(update =>
       editAlg
         .findUpdateReplacements(repo, repoConfig, update)
         .map(reps => (reps, update.nextVersion) -> update.artifactForUpdate)
     )
     .map {
-      _.groupMap(_._1)(_._2).map { case ((reps, nextVersion), artifacts) =>
-        UpdatesForGivenEdit(reps, artifacts, nextVersion)
+      _.groupMap(_._1)(_._2).toMap.map { case ((reps, nextVersion), artifacts) =>
+        reps.toSet -> InseparableUpdateSet(artifacts, nextVersion)
       }
     }
 
@@ -94,7 +99,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
   ): F[List[Update]] = for {
     updatesByEdit <- updateEditsFor(repoConfig, repo, updates)
   } yield Update.performAllGrouping(
-    updatesByEdit.toSeq,
+    updatesByEdit,
     repoConfig.pullRequestsOrDefault.groupingOrDefault
   )
 
@@ -227,9 +232,9 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
 
   private def dependenciesUpdatedWithNextAndCurrentVersion(
       update: Update
-  ): List[(Version, Dependency)] =
+  ): Nel[(Version, Dependency)] =
     update.on(
-      u => u.dependencies.map(_.copy(version = u.nextVersion)).tupleLeft(u.currentVersion).toList,
+      u => u.dependencies.map(_.copy(version = u.nextVersion)).tupleLeft(u.currentVersion),
       _.updates.flatMap(dependenciesUpdatedWithNextAndCurrentVersion(_))
     )
 
@@ -248,11 +253,11 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
             .flatMap(_.filterUrls(urlChecker.exists))
             .tupleLeft(dependency)
         }
-        .map(_.toMap)
+        .map(_.toList.toMap)
       artifactIdToUrl = dependencyToMetadata.toList.mapFilter { case (dependency, metadata) =>
         metadata.repoUrl.tupleLeft(dependency.artifactId.name)
       }.toMap
-      artifactIdToUpdateInfoUrls <- dependenciesWithNextVersion.flatTraverse {
+      artifactIdToUpdateInfoUrls <- dependenciesWithNextVersion.toList.flatTraverse {
         case (currentVersion, dependency) =>
           dependencyToMetadata.get(dependency).toList.traverse { metadata =>
             updateInfoUrlFinder
@@ -266,7 +271,7 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
       }.toMap
       filesWithOldVersion <-
         data.update
-          .on(u => List(u.currentVersion.value), _.updates.map(_.currentVersion.value))
+          .on(u => List(u.currentVersion.value), _.updates.map(_.currentVersion.value).toList)
           .flatTraverse(gitAlg.findFilesContaining(data.repo, _))
           .map(_.distinct)
       allLabels = labelsFor(data.update, edits, filesWithOldVersion, artifactIdToVersionScheme)

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -37,6 +37,10 @@ import org.scalasteward.core.util.{Nel, UrlChecker}
 import org.scalasteward.core.{git, util}
 import org.typelevel.log4cats.Logger
 
+/**
+ * Updates that can not be separated from each other - usually because of a version
+ * number for several artifacts being defined in a single place in the build definition.
+ */
 case class InseparableUpdateSet(
   artifactsForUpdate: Nel[ArtifactForUpdate],
   nextVersion: Version

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -91,8 +91,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
         .map(reps => (reps, update.nextVersion) -> update.artifactForUpdate)
     )
     .map {
-      _.groupMap(_._1)(_._2).toMap.map { case ((reps, nextVersion), artifacts) =>
-        reps.toSet -> InseparableUpdateSet(artifacts, nextVersion)
+      _.groupMap(_._1)(_._2).toMap.map { case ((replacements, nextVersion), artifacts) =>
+        replacements.toSet -> InseparableUpdateSet(artifacts, nextVersion)
       }
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -135,7 +135,9 @@ final class PullRequestRepository[F[_]](kvStore: KeyValueStore[F, Repo, Map[Uri,
       case Some(pullRequests) =>
         pullRequests.values
           .flatMap { entry =>
-            entry.update.asSingleUpdates.map(_.groupAndMainArtifactId -> entry.entryCreatedAt)
+            entry.update.asSingleUpdates
+              .map(_.groupAndMainArtifactId -> entry.entryCreatedAt)
+              .toList
           }
           .groupMapReduce(_._1)(_._2)(_ max _)
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/GroupRepoConfig.scala
@@ -51,6 +51,7 @@ object GroupRepoConfig {
         .map(forUpdate(_))
         .map(_.linesIterator.toList)
         .map(indentLines(_))
+        .toList
         .mkString("dependencyOverrides = [\n", ",\n", "\n]")
     )
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -21,6 +21,7 @@ import cats.data.NonEmptyList
 import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Update
+import org.scalasteward.core.nurture.UpdatesForGivenEdit
 
 case class PullRequestGroup(
     name: String,
@@ -32,6 +33,8 @@ case class PullRequestGroup(
     */
   def matches(update: Update.ForArtifactId): Boolean = filter.exists(_.matches(update))
 
+  def matches(updates: UpdatesForGivenEdit): Boolean =
+    filter.exists(f => updates.asUpdatesForArtifactId.exists(update => f.matches(update)))
 }
 
 object PullRequestGroup {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestGroup.scala
@@ -21,7 +21,8 @@ import cats.data.NonEmptyList
 import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Update
-import org.scalasteward.core.nurture.UpdatesForGivenEdit
+import org.scalasteward.core.data.Update.Grouped
+import org.scalasteward.core.nurture.{InseparableUpdateSet, UpdatesForGivenEdit}
 
 case class PullRequestGroup(
     name: String,
@@ -33,8 +34,10 @@ case class PullRequestGroup(
     */
   def matches(update: Update.ForArtifactId): Boolean = filter.exists(_.matches(update))
 
-  def matches(updates: UpdatesForGivenEdit): Boolean =
+  def matches(updates: InseparableUpdateSet): Boolean =
     filter.exists(f => updates.asUpdatesForArtifactId.exists(update => f.matches(update)))
+
+  def asGroupedUpdateOf(updates: NonEmptyList[Update.ForArtifactId]) = Grouped(name, title, updates)
 }
 
 object PullRequestGroup {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -129,6 +129,7 @@ object RepoConfigAlg {
       grouped = g =>
         g.updates
           .map("  " + forUpdate(_))
+          .toList
           .mkString("updates.ignore = [\n", ",\n", "\n]")
     )
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -70,7 +70,7 @@ object logger {
   def showUpdates(allUpdates: List[Update]): String = {
     val updates = allUpdates.map {
       case g: Update.Grouped =>
-        g.updates.map(_.show).mkString(s"${g.name} (group) {\n    ", "\n    ", "\n  }")
+        g.updates.map(_.show).toList.mkString(s"${g.name} (group) {\n    ", "\n    ", "\n  }")
       case u: Update.Single => u.show
     }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -4,12 +4,23 @@ import org.scalasteward.core.data.*
 import org.scalasteward.core.data.Resolver.IvyRepository
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
+import org.scalasteward.core.edit.update.data.Substring
+import org.scalasteward.core.edit.update.data.Substring.Position
+import org.scalasteward.core.nurture.UpdatesForGivenEdit
 
 object TestSyntax {
   val sbtPluginReleases: IvyRepository = {
     val pattern = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/[defaultPattern]"
     IvyRepository("sbt-plugin-releases", pattern, None, None)
   }
+
+  def stubReplacementFor(u: Update.ForArtifactId): Substring.Replacement = Substring.Replacement(
+    Position("build.sbt", u.artifactForUpdate.hashCode(), u.currentVersion.value),
+    u.nextVersion.value
+  )
+
+  def artifactUpdatesOf(updates: UpdatesForGivenEdit*): List[Update.ForArtifactId] =
+    updates.flatMap(_.asUpdatesForArtifactId.toList).toList
 
   implicit class GenericOps[A](val self: A) extends AnyVal {
     def withMavenCentral: Scope[A] =
@@ -143,6 +154,12 @@ object TestSyntax {
         artifactForUpdate = self.artifactForUpdate
           .copy(newerGroupId = newerGroupId, newerArtifactId = newerArtifactId)
       )
+
+    def stubEdit = UpdatesForGivenEdit(
+      List(stubReplacementFor(self)),
+      self.artifactsForUpdate,
+      self.nextVersion
+    )
   }
 
   implicit class ArtifactUpdateCandidatesOps(

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -7,6 +7,7 @@ import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
 import org.scalasteward.core.edit.update.data.Substring
 import org.scalasteward.core.edit.update.data.Substring.{Position, Replacement}
 import org.scalasteward.core.nurture.UpdatesForGivenEdit
+import org.scalasteward.core.nurture.InseparableUpdateSet
 
 object TestSyntax {
   val sbtPluginReleases: IvyRepository = {
@@ -26,7 +27,7 @@ object TestSyntax {
   )
 
   def artifactUpdatesOf(updates: UpdatesForGivenEdit*): Nel[Update.ForArtifactId] =
-    updates.flatMap(_.asUpdatesForArtifactId.toList)
+    Nel.fromListUnsafe(updates.flatMap(_.inseparableUpdateSet.asUpdatesForArtifactId.toList).toList)
 
   implicit class GenericOps[A](val self: A) extends AnyVal {
     def withMavenCentral: Scope[A] =
@@ -170,8 +171,7 @@ object TestSyntax {
 
     def withEdit(replacement: Replacement) = UpdatesForGivenEdit(
       List(replacement),
-      self.artifactsForUpdate,
-      self.nextVersion
+      InseparableUpdateSet(self.artifactsForUpdate, self.nextVersion)
     )
 
     def stubEdit = withEdit(stubReplacementFor(self))

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -25,9 +25,24 @@ object TestSyntax {
     positionIndex = u.artifactForUpdate.hashCode(),
     versionUpdate = u.versionUpdate
   )
+//
+//  def replace(diff: String): Set[Replacement] = {
+//    val strings = diff.split('→')
+//    val before = (strings.head +: strings.tail.map(_.tail)).mkString
+//    val after = strings.dropRight(1).map(_.dropRight(1)) :+ strings.last
+//
+//    diff.zipWithIndex.filter(_._1 == '→').map(_._2).zipWithIndex.map {
+//      case (arrowIndexInStr, arrowIndex) =>
+//        Replacement(
+//          Position("build.sbt", arrowIndexInStr - arrowIndex - 1, "" + diff(arrowIndexInStr - 1)),
+//          "" + diff(arrowIndexInStr + 1)
+//        )
+//    }
+//
+//  }
 
   def artifactUpdatesOf(updates: UpdatesForGivenEdit*): Nel[Update.ForArtifactId] =
-    Nel.fromListUnsafe(updates.flatMap(_.inseparableUpdateSet.asUpdatesForArtifactId.toList).toList)
+    Nel.fromListUnsafe(updates.toList).flatMap(_.asUpdatesForArtifactId)
 
   implicit class GenericOps[A](val self: A) extends AnyVal {
     def withMavenCentral: Scope[A] =
@@ -81,6 +96,8 @@ object TestSyntax {
       (self, nextVersion)
     def %>(newerVersions: Nel[String]): (Dependency, Nel[String]) = (self, newerVersions)
     def cross: CrossDependency = CrossDependency(self)
+
+    def asArtifactForUpdate: ArtifactForUpdate = ArtifactForUpdate(cross)
   }
 
   implicit class DependenciesOps(private val self: Nel[Dependency]) extends AnyVal {

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -5,7 +5,7 @@ import org.scalasteward.core.data.Resolver.IvyRepository
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.coursier.VersionsCache.VersionWithFirstSeen
 import org.scalasteward.core.edit.update.data.Substring
-import org.scalasteward.core.edit.update.data.Substring.Position
+import org.scalasteward.core.edit.update.data.Substring.{Position, Replacement}
 import org.scalasteward.core.nurture.UpdatesForGivenEdit
 
 object TestSyntax {
@@ -14,9 +14,14 @@ object TestSyntax {
     IvyRepository("sbt-plugin-releases", pattern, None, None)
   }
 
-  def stubReplacementFor(u: Update.ForArtifactId): Substring.Replacement = Substring.Replacement(
-    Position("build.sbt", u.artifactForUpdate.hashCode(), u.currentVersion.value),
-    u.nextVersion.value
+  def stubReplacement(positionIndex: Int, versionUpdate: Version.Update): Substring.Replacement = Substring.Replacement(
+    Position("build.sbt", positionIndex, versionUpdate.currentVersion.value),
+    versionUpdate.nextVersion.value
+  )
+
+  def stubReplacementFor(u: Update.ForArtifactId): Substring.Replacement = stubReplacement(
+    positionIndex = u.artifactForUpdate.hashCode(),
+    versionUpdate = u.versionUpdate
   )
 
   def artifactUpdatesOf(updates: UpdatesForGivenEdit*): List[Update.ForArtifactId] =
@@ -46,6 +51,10 @@ object TestSyntax {
 
   implicit class GroupIdAndArtifactIdOps(private val self: (GroupId, ArtifactId)) extends AnyVal {
     def %(version: String): Dependency = Dependency(self._1, self._2, version.v)
+
+    def %(versionUpdate: Version.Update): Update.ForArtifactId = Update.ForArtifactId(
+      ArtifactForUpdate(CrossDependency(Dependency(self._1, self._2, versionUpdate.currentVersion))), versionUpdate.nextVersion
+    )
   }
 
   implicit class GroupIdAndArtifactIdsOps(
@@ -155,11 +164,13 @@ object TestSyntax {
           .copy(newerGroupId = newerGroupId, newerArtifactId = newerArtifactId)
       )
 
-    def stubEdit = UpdatesForGivenEdit(
-      List(stubReplacementFor(self)),
+    def withEdit(replacement: Replacement) = UpdatesForGivenEdit(
+      List(replacement),
       self.artifactsForUpdate,
       self.nextVersion
     )
+
+    def stubEdit = withEdit(stubReplacementFor(self))
   }
 
   implicit class ArtifactUpdateCandidatesOps(

--- a/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestSyntax.scala
@@ -14,18 +14,19 @@ object TestSyntax {
     IvyRepository("sbt-plugin-releases", pattern, None, None)
   }
 
-  def stubReplacement(positionIndex: Int, versionUpdate: Version.Update): Substring.Replacement = Substring.Replacement(
-    Position("build.sbt", positionIndex, versionUpdate.currentVersion.value),
-    versionUpdate.nextVersion.value
-  )
+  def stubReplacement(positionIndex: Int, versionUpdate: Version.Update): Substring.Replacement =
+    Substring.Replacement(
+      Position("build.sbt", positionIndex, versionUpdate.currentVersion.value),
+      versionUpdate.nextVersion.value
+    )
 
   def stubReplacementFor(u: Update.ForArtifactId): Substring.Replacement = stubReplacement(
     positionIndex = u.artifactForUpdate.hashCode(),
     versionUpdate = u.versionUpdate
   )
 
-  def artifactUpdatesOf(updates: UpdatesForGivenEdit*): List[Update.ForArtifactId] =
-    updates.flatMap(_.asUpdatesForArtifactId.toList).toList
+  def artifactUpdatesOf(updates: UpdatesForGivenEdit*): Nel[Update.ForArtifactId] =
+    updates.flatMap(_.asUpdatesForArtifactId.toList)
 
   implicit class GenericOps[A](val self: A) extends AnyVal {
     def withMavenCentral: Scope[A] =
@@ -53,7 +54,10 @@ object TestSyntax {
     def %(version: String): Dependency = Dependency(self._1, self._2, version.v)
 
     def %(versionUpdate: Version.Update): Update.ForArtifactId = Update.ForArtifactId(
-      ArtifactForUpdate(CrossDependency(Dependency(self._1, self._2, versionUpdate.currentVersion))), versionUpdate.nextVersion
+      ArtifactForUpdate(
+        CrossDependency(Dependency(self._1, self._2, versionUpdate.currentVersion))
+      ),
+      versionUpdate.nextVersion
     )
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -14,7 +14,7 @@ class GroupedUpdateTest extends FunSuite {
     ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single
 
   val updateSingleTypelevelAlgebra: Update.ForArtifactId =
-    ("org.typelevel".g % "algebra".a % "3.9.4" %> "3.9.5").single
+    ("org.typelevel".g % "algebra".a % "2.1.1" %> "2.2.0").single
 
   val updateSingleCirceCore: Update.ForArtifactId =
     ("circe".g % "core".a % "1.4.2" %> "1.5.0").single

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -4,20 +4,22 @@ import cats.data.NonEmptyList
 import cats.implicits.catsSyntaxOptionId
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax.*
+import org.scalasteward.core.nurture.UpdatesForGivenEdit
 import org.scalasteward.core.repoconfig.{PullRequestGroup, PullRequestUpdateFilter}
 
 class GroupedUpdateTest extends FunSuite {
-  val updateSingleSpecs2Core: Update.ForArtifactId =
-    ("org.specs2".g % "specs2-core".a % "3.9.3" %> "3.9.5").single
 
-  val updateSingleSpecs2Scalacheck: Update.ForArtifactId =
-    ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single
+  val updateSingleSpecs2Core =
+    ("org.specs2".g % "specs2-core".a % "3.9.3" %> "3.9.5").single.stubEdit
 
-  val updateSingleTypelevelAlgebra: Update.ForArtifactId =
-    ("org.typelevel".g % "algebra".a % "2.1.1" %> "2.2.0").single
+  val updateSingleSpecs2Scalacheck =
+    ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single.stubEdit
 
-  val updateSingleCirceCore: Update.ForArtifactId =
-    ("circe".g % "core".a % "1.4.2" %> "1.5.0").single
+  val updateSingleTypelevelAlgebra =
+    ("org.typelevel".g % "algebra".a % "2.1.1" %> "2.2.0").single.stubEdit
+
+  val updateSingleCirceCore =
+    ("circe".g % "core".a % "1.4.2" %> "1.5.0").single.stubEdit
 
   test(
     "GroupedUpdate.from: Do not group a Update.Single if the groupId does not match the filter"
@@ -76,7 +78,11 @@ class GroupedUpdateTest extends FunSuite {
     assertEquals(
       grouped,
       List(
-        Update.Grouped("typelevel", Some("update typelevel"), List(updateSingleTypelevelAlgebra))
+        Update.Grouped(
+          "typelevel",
+          Some("update typelevel"),
+          artifactUpdatesOf(updateSingleTypelevelAlgebra)
+        )
       )
     )
     assertEquals(notGrouped, List.empty)
@@ -103,7 +109,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2",
           Some("update specs2"),
-          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
         )
       )
     )
@@ -143,9 +149,13 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2",
           Some("update specs2"),
-          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
         ),
-        Update.Grouped("typelevel", Some("update typelevel"), List(updateSingleTypelevelAlgebra))
+        Update.Grouped(
+          "typelevel",
+          Some("update typelevel"),
+          artifactUpdatesOf(updateSingleTypelevelAlgebra)
+        )
       )
     )
     assertEquals(notGrouped, List(updateSingleCirceCore))
@@ -174,7 +184,11 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "org",
           Some("update org"),
-          List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck, updateSingleTypelevelAlgebra)
+          artifactUpdatesOf(
+            updateSingleSpecs2Core,
+            updateSingleSpecs2Scalacheck,
+            updateSingleTypelevelAlgebra
+          )
         )
       )
     )
@@ -203,7 +217,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "all wildcard",
           Some("update all wildcard"),
-          List(
+          artifactUpdatesOf(
             updateSingleTypelevelAlgebra,
             updateSingleSpecs2Core,
             updateSingleSpecs2Scalacheck
@@ -233,7 +247,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2 core",
           Some("update specs2 core"),
-          List(updateSingleSpecs2Core)
+          artifactUpdatesOf(updateSingleSpecs2Core)
         )
       )
     )
@@ -262,7 +276,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2 core",
           Some("update specs2 core"),
-          List(updateSingleSpecs2Core)
+          artifactUpdatesOf(updateSingleSpecs2Core)
         )
       )
     )
@@ -315,7 +329,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2",
           Some("update specs2"),
-          List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
         )
       )
     )
@@ -345,7 +359,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "specs2",
           Some("update specs2"),
-          List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
         )
       )
     )
@@ -378,9 +392,12 @@ class GroupedUpdateTest extends FunSuite {
     )
   }
 
-  val majorUpdate: Update.ForArtifactId = ("org.major".g % "major".a % "3.1.2" %> "4.0.0").single
-  val minorUpdate: Update.ForArtifactId = ("org.minor".g % "minor".a % "3.1.2" %> "3.2.0").single
-  val patchUpdate: Update.ForArtifactId = ("org.patch".g % "patch".a % "3.1.2" %> "3.1.3").single
+  val majorUpdate: UpdatesForGivenEdit =
+    ("org.major".g % "major".a % "3.1.2" %> "4.0.0").single.stubEdit
+  val minorUpdate: UpdatesForGivenEdit =
+    ("org.minor".g % "minor".a % "3.1.2" %> "3.2.0").single.stubEdit
+  val patchUpdate: UpdatesForGivenEdit =
+    ("org.patch".g % "patch".a % "3.1.2" %> "3.1.3").single.stubEdit
 
   test(
     "GroupedUpdate.from: Group major updates"
@@ -403,7 +420,7 @@ class GroupedUpdateTest extends FunSuite {
     assertEquals(
       grouped,
       List(
-        Update.Grouped("major", Some("update major"), List(majorUpdate))
+        Update.Grouped("major", Some("update major"), artifactUpdatesOf(majorUpdate))
       )
     )
 
@@ -431,7 +448,7 @@ class GroupedUpdateTest extends FunSuite {
     assertEquals(
       grouped,
       List(
-        Update.Grouped("minor", Some("update minor"), List(minorUpdate))
+        Update.Grouped("minor", Some("update minor"), artifactUpdatesOf(minorUpdate))
       )
     )
 
@@ -459,7 +476,7 @@ class GroupedUpdateTest extends FunSuite {
     assertEquals(
       grouped,
       List(
-        Update.Grouped("patch", Some("update patch"), List(patchUpdate))
+        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
       )
     )
 
@@ -492,7 +509,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "patch & minor",
           Some("update patch & minor"),
-          List(minorUpdate, patchUpdate)
+          artifactUpdatesOf(minorUpdate, patchUpdate)
         )
       )
     )
@@ -503,12 +520,14 @@ class GroupedUpdateTest extends FunSuite {
   test(
     "GroupedUpdate.from: Group major & minor updates with version numbers containing a date and commit hash"
   ) {
-    val majorUpdate: Update.ForArtifactId =
-      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single
-    val minorUpdate: Update.ForArtifactId =
-      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single
-    val patchUpdate: Update.ForArtifactId =
-      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220922-180024-dd318047").single
+    val majorUpdate: UpdatesForGivenEdit =
+      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
+
+    val minorUpdate: UpdatesForGivenEdit =
+      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
+
+    val patchUpdate: UpdatesForGivenEdit =
+      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220922-180024-dd318047").single.stubEdit
 
     val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
       "major & minor",
@@ -533,7 +552,7 @@ class GroupedUpdateTest extends FunSuite {
         Update.Grouped(
           "major & minor",
           Some("update major & minor"),
-          List(majorUpdate, minorUpdate)
+          artifactUpdatesOf(majorUpdate, minorUpdate)
         )
       )
     )
@@ -544,12 +563,14 @@ class GroupedUpdateTest extends FunSuite {
   test(
     "GroupedUpdate.from: Group patch updates with version numbers containing a date and commit hash"
   ) {
-    val majorUpdate: Update.ForArtifactId =
-      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single
-    val minorUpdate: Update.ForArtifactId =
-      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single
-    val patchUpdate: Update.ForArtifactId =
-      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220920-180024-dd318047").single
+    val majorUpdate: UpdatesForGivenEdit =
+      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
+
+    val minorUpdate: UpdatesForGivenEdit =
+      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
+
+    val patchUpdate: UpdatesForGivenEdit =
+      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220920-180024-dd318047").single.stubEdit
 
     val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
       "patch",
@@ -569,7 +590,7 @@ class GroupedUpdateTest extends FunSuite {
     assertEquals(
       grouped,
       List(
-        Update.Grouped("patch", Some("update patch"), List(patchUpdate))
+        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/GroupedUpdateTest.scala
@@ -4,22 +4,31 @@ import cats.data.NonEmptyList
 import cats.implicits.catsSyntaxOptionId
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax.*
-import org.scalasteward.core.nurture.UpdatesForGivenEdit
+import org.scalasteward.core.edit.update.data.Substring.{Position, Replacement}
+import org.scalasteward.core.nurture.{InseparableUpdateSet, UpdatesForGivenEdit}
 import org.scalasteward.core.repoconfig.{PullRequestGroup, PullRequestUpdateFilter}
+import org.scalasteward.core.util.Nel
 
 class GroupedUpdateTest extends FunSuite {
 
+  def edit(start: Int): Set[Replacement] = Set(
+    Replacement(Position("build.sbt", start, "Old"), "New")
+  )
+
+  val Edit1 = edit(1)
+  val Edit2 = edit(2)
+
   val updateSingleSpecs2Core =
-    ("org.specs2".g % "specs2-core".a % "3.9.3" %> "3.9.5").single.stubEdit
+    ("org.specs2".g % "specs2-core".a % "3.9.3" %> "3.9.5").single
 
   val updateSingleSpecs2Scalacheck =
-    ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single.stubEdit
+    ("org.specs2".g % "specs2-scalacheck".a % "3.9.3" %> "3.9.5").single
 
   val updateSingleTypelevelAlgebra =
-    ("org.typelevel".g % "algebra".a % "2.1.1" %> "2.2.0").single.stubEdit
+    ("org.typelevel".g % "algebra".a % "2.1.1").asArtifactForUpdate // %> "2.2.0").single
 
   val updateSingleCirceCore =
-    ("circe".g % "core".a % "1.4.2" %> "1.5.0").single.stubEdit
+    ("circe".g % "core".a % "1.4.2" %> "1.5.0").single
 
   test(
     "GroupedUpdate.from: Do not group a Update.Single if the groupId does not match the filter"
@@ -32,568 +41,572 @@ class GroupedUpdateTest extends FunSuite {
       )
     )
 
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestGroupSpecs2),
-        List(updateSingleTypelevelAlgebra)
-      )
-    assertEquals(grouped, List.empty)
-    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
-  }
-
-  test(
-    "GroupedUpdate.from: Do not group multiple Update.Single if the groupId does not match the filter"
-  ) {
-    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
-      "typelevel",
-      Some("update typelevel"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
-      )
-    )
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestGroupTypeLevel),
-        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
-      )
-    assertEquals(grouped, List.empty)
-    assertEquals(notGrouped, List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck))
-  }
-
-  test("GroupedUpdate.from: Group a Update.Single for a single GroupId filter") {
-    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
-      "typelevel",
-      Some("update typelevel"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestGroupTypeLevel),
-        List(updateSingleTypelevelAlgebra)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "typelevel",
-          Some("update typelevel"),
-          artifactUpdatesOf(updateSingleTypelevelAlgebra)
-        )
-      )
-    )
-    assertEquals(notGrouped, List.empty)
-  }
-
-  test("GroupedUpdate.from: Group multiple Update.Single for a single GroupId filter") {
-    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
-      "specs2",
-      Some("update specs2"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
-      )
+    val availableUpdateEdits: Map[Set[Replacement], InseparableUpdateSet] = Map(
+      Edit1 -> InseparableUpdateSet(Nel.one(updateSingleTypelevelAlgebra), "3.0.1".v)
     )
 
     val (grouped, notGrouped) =
       Update.groupByPullRequestGroup(
         List(pullRequestGroupSpecs2),
-        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+        availableUpdateEdits
       )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2",
-          Some("update specs2"),
-          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
-        )
-      )
-    )
-    assertEquals(notGrouped, List.empty)
-  }
-
-  test("GroupedUpdate.from: Group multiple Updates for multiple GroupId filters") {
-    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
-      "specs2",
-      Some("update specs2"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
-      "typelevel",
-      Some("update typelevel"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val updates = List(
-      updateSingleSpecs2Core,
-      updateSingleSpecs2Scalacheck,
-      updateSingleTypelevelAlgebra,
-      updateSingleCirceCore
-    )
-    val pullRequestGroups = List(pullRequestGroupSpecs2, pullRequestGroupTypeLevel)
-
-    val (grouped, notGrouped) = Update.groupByPullRequestGroup(pullRequestGroups, updates)
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2",
-          Some("update specs2"),
-          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
-        ),
-        Update.Grouped(
-          "typelevel",
-          Some("update typelevel"),
-          artifactUpdatesOf(updateSingleTypelevelAlgebra)
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleCirceCore))
-  }
-
-  val pullRequestGroupOrgWildcard: PullRequestGroup = PullRequestGroup(
-    "org",
-    Some("update org"),
-    NonEmptyList.one(PullRequestUpdateFilter("org.*".some).getOrElse(fail("Should not be called")))
-  )
-
-  test("GroupedUpdate.from: Group multiple Updates for a GroupId filter with a wildcard") {
-    val updates = List(
-      updateSingleSpecs2Core,
-      updateSingleSpecs2Scalacheck,
-      updateSingleTypelevelAlgebra,
-      updateSingleCirceCore
-    )
-    val pullRequestGroups = List(pullRequestGroupOrgWildcard)
-
-    val (grouped, notGrouped) = Update.groupByPullRequestGroup(pullRequestGroups, updates)
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "org",
-          Some("update org"),
-          artifactUpdatesOf(
-            updateSingleSpecs2Core,
-            updateSingleSpecs2Scalacheck,
-            updateSingleTypelevelAlgebra
-          )
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleCirceCore))
-  }
-
-  test("GroupedUpdate.from: Group everything when using * for OrganisationId") {
-    val pullRequestGroupWildcardAll: PullRequestGroup = PullRequestGroup(
-      "all wildcard",
-      Some("update all wildcard"),
-      NonEmptyList.one(PullRequestUpdateFilter("*".some).getOrElse(fail("Should not be called")))
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestGroupWildcardAll),
-        List(
-          updateSingleTypelevelAlgebra,
-          updateSingleSpecs2Core,
-          updateSingleSpecs2Scalacheck
-        )
-      )
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "all wildcard",
-          Some("update all wildcard"),
-          artifactUpdatesOf(
-            updateSingleTypelevelAlgebra,
-            updateSingleSpecs2Core,
-            updateSingleSpecs2Scalacheck
-          )
-        )
-      )
-    )
-    assertEquals(notGrouped, List.empty)
-  }
-
-  test("GroupedUpdate.from: Group Update.Group for an ArtifactId filter without a group") {
-    val pullRequestArtifactSpecs2CoreWithoutGroup: PullRequestGroup = PullRequestGroup(
-      "specs2 core",
-      Some("update specs2 core"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter(None, "specs2-core".some).getOrElse(fail("Should not be called"))
-      )
-    )
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2CoreWithoutGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
-      )
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2 core",
-          Some("update specs2 core"),
-          artifactUpdatesOf(updateSingleSpecs2Core)
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
-  }
-
-  val pullRequestArtifactSpecs2CoreWithGroup: PullRequestGroup = PullRequestGroup(
-    "specs2 core",
-    Some("update specs2 core"),
-    NonEmptyList.one(
-      PullRequestUpdateFilter("org.specs2".some, "specs2-core".some).getOrElse(
-        fail("Should not be called")
-      )
-    )
-  )
-
-  test("GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a group") {
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2CoreWithGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
-      )
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2 core",
-          Some("update specs2 core"),
-          artifactUpdatesOf(updateSingleSpecs2Core)
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
-  }
-
-  test(
-    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with an invalid group"
-  ) {
-    val pullRequestArtifactSpecs2CoreWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "specs2 core",
-      Some("update specs2 core"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.invalid".some, "specs2-core".some).getOrElse(
-          fail("Should not be called")
-        )
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2CoreWithInvalidGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
-      )
-
     assertEquals(grouped, List.empty)
-    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core))
+    assertEquals(notGrouped, availableUpdateEdits)
   }
 
-  test(
-    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithoutGroup: PullRequestGroup = PullRequestGroup(
-      "specs2",
-      Some("update specs2"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter(None, "specs2-*".some).getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithoutGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2",
-          Some("update specs2"),
-          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
-  }
-
-  test(
-    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard and a group"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithGroup: PullRequestGroup = PullRequestGroup(
-      "specs2",
-      Some("update specs2"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.specs2".some, "specs2-*".some).getOrElse(
-          fail("Should not be called")
-        )
-      )
-    )
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
-      )
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "specs2",
-          Some("update specs2"),
-          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
-        )
-      )
-    )
-    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
-  }
-
-  test(
-    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with a wildcard an invalid group"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "specs2",
-      Some("update specs2"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter("org.invalid".some, "specs2-*".some).getOrElse(
-          fail("Should not be called")
-        )
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
-      )
-
-    assertEquals(grouped, List.empty)
-    assertEquals(
-      notGrouped,
-      List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
-    )
-  }
-
-  val majorUpdate: UpdatesForGivenEdit =
-    ("org.major".g % "major".a % "3.1.2" %> "4.0.0").single.stubEdit
-  val minorUpdate: UpdatesForGivenEdit =
-    ("org.minor".g % "minor".a % "3.1.2" %> "3.2.0").single.stubEdit
-  val patchUpdate: UpdatesForGivenEdit =
-    ("org.patch".g % "patch".a % "3.1.2" %> "3.1.3").single.stubEdit
-
-  test(
-    "GroupedUpdate.from: Group major updates"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "major",
-      Some("update major"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped("major", Some("update major"), artifactUpdatesOf(majorUpdate))
-      )
-    )
-
-    assertEquals(notGrouped, List(minorUpdate, patchUpdate))
-  }
-
-  test(
-    "GroupedUpdate.from: Group minor updates"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "minor",
-      Some("update minor"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped("minor", Some("update minor"), artifactUpdatesOf(minorUpdate))
-      )
-    )
-
-    assertEquals(notGrouped, List(majorUpdate, patchUpdate))
-  }
-
-  test(
-    "GroupedUpdate.from: Group patch updates"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "patch",
-      Some("update patch"),
-      NonEmptyList.one(
-        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
-      )
-    )
-
-    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
-  }
-
-  test(
-    "GroupedUpdate.from: Group minor & patch updates"
-  ) {
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "patch & minor",
-      Some("update patch & minor"),
-      NonEmptyList.of(
-        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
-          .getOrElse(fail("Should not be called")),
-        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "patch & minor",
-          Some("update patch & minor"),
-          artifactUpdatesOf(minorUpdate, patchUpdate)
-        )
-      )
-    )
-
-    assertEquals(notGrouped, List(majorUpdate))
-  }
-
-  test(
-    "GroupedUpdate.from: Group major & minor updates with version numbers containing a date and commit hash"
-  ) {
-    val majorUpdate: UpdatesForGivenEdit =
-      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
-
-    val minorUpdate: UpdatesForGivenEdit =
-      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
-
-    val patchUpdate: UpdatesForGivenEdit =
-      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220922-180024-dd318047").single.stubEdit
-
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "major & minor",
-      Some("update major & minor"),
-      NonEmptyList.of(
-        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
-          .getOrElse(fail("Should not be called")),
-        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped(
-          "major & minor",
-          Some("update major & minor"),
-          artifactUpdatesOf(majorUpdate, minorUpdate)
-        )
-      )
-    )
-
-    assertEquals(notGrouped, List(patchUpdate))
-  }
-
-  test(
-    "GroupedUpdate.from: Group patch updates with version numbers containing a date and commit hash"
-  ) {
-    val majorUpdate: UpdatesForGivenEdit =
-      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
-
-    val minorUpdate: UpdatesForGivenEdit =
-      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
-
-    val patchUpdate: UpdatesForGivenEdit =
-      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220920-180024-dd318047").single.stubEdit
-
-    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
-      "patch",
-      Some("update patch"),
-      NonEmptyList.of(
-        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
-          .getOrElse(fail("Should not be called"))
-      )
-    )
-
-    val (grouped, notGrouped) =
-      Update.groupByPullRequestGroup(
-        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
-        List(majorUpdate, minorUpdate, patchUpdate)
-      )
-
-    assertEquals(
-      grouped,
-      List(
-        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
-      )
-    )
-
-    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
-  }
+//  test(
+//    "GroupedUpdate.from: Do not group multiple Update.Single if the groupId does not match the filter"
+//  ) {
+//    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+//      "typelevel",
+//      Some("update typelevel"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestGroupTypeLevel),
+//        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+//      )
+//    assertEquals(grouped, List.empty)
+//    assertEquals(notGrouped, List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck))
+//  }
+//
+//  test("GroupedUpdate.from: Group a Update.Single for a single GroupId filter") {
+//    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+//      "typelevel",
+//      Some("update typelevel"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestGroupTypeLevel),
+//        List(updateSingleTypelevelAlgebra)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "typelevel",
+//          Some("update typelevel"),
+//          artifactUpdatesOf(updateSingleTypelevelAlgebra)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List.empty)
+//  }
+//
+//  test("GroupedUpdate.from: Group multiple Update.Single for a single GroupId filter") {
+//    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
+//      "specs2",
+//      Some("update specs2"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestGroupSpecs2),
+//        List(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2",
+//          Some("update specs2"),
+//          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List.empty)
+//  }
+//
+//  test("GroupedUpdate.from: Group multiple Updates for multiple GroupId filters") {
+//    val pullRequestGroupSpecs2: PullRequestGroup = PullRequestGroup(
+//      "specs2",
+//      Some("update specs2"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.specs2".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val pullRequestGroupTypeLevel: PullRequestGroup = PullRequestGroup(
+//      "typelevel",
+//      Some("update typelevel"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.typelevel".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val updates = List(
+//      updateSingleSpecs2Core,
+//      updateSingleSpecs2Scalacheck,
+//      updateSingleTypelevelAlgebra,
+//      updateSingleCirceCore
+//    )
+//    val pullRequestGroups = List(pullRequestGroupSpecs2, pullRequestGroupTypeLevel)
+//
+//    val (grouped, notGrouped) = Update.groupByPullRequestGroup(pullRequestGroups, updates)
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2",
+//          Some("update specs2"),
+//          artifactUpdatesOf(updateSingleSpecs2Core, updateSingleSpecs2Scalacheck)
+//        ),
+//        Update.Grouped(
+//          "typelevel",
+//          Some("update typelevel"),
+//          artifactUpdatesOf(updateSingleTypelevelAlgebra)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleCirceCore))
+//  }
+//
+//  val pullRequestGroupOrgWildcard: PullRequestGroup = PullRequestGroup(
+//    "org",
+//    Some("update org"),
+//    NonEmptyList.one(PullRequestUpdateFilter("org.*".some).getOrElse(fail("Should not be called")))
+//  )
+//
+//  test("GroupedUpdate.from: Group multiple Updates for a GroupId filter with a wildcard") {
+//    val updates = List(
+//      updateSingleSpecs2Core,
+//      updateSingleSpecs2Scalacheck,
+//      updateSingleTypelevelAlgebra,
+//      updateSingleCirceCore
+//    )
+//    val pullRequestGroups = List(pullRequestGroupOrgWildcard)
+//
+//    val (grouped, notGrouped) = Update.groupByPullRequestGroup(pullRequestGroups, updates)
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "org",
+//          Some("update org"),
+//          artifactUpdatesOf(
+//            updateSingleSpecs2Core,
+//            updateSingleSpecs2Scalacheck,
+//            updateSingleTypelevelAlgebra
+//          )
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleCirceCore))
+//  }
+//
+//  test("GroupedUpdate.from: Group everything when using * for OrganisationId") {
+//    val pullRequestGroupWildcardAll: PullRequestGroup = PullRequestGroup(
+//      "all wildcard",
+//      Some("update all wildcard"),
+//      NonEmptyList.one(PullRequestUpdateFilter("*".some).getOrElse(fail("Should not be called")))
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestGroupWildcardAll),
+//        List(
+//          updateSingleTypelevelAlgebra,
+//          updateSingleSpecs2Core,
+//          updateSingleSpecs2Scalacheck
+//        )
+//      )
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "all wildcard",
+//          Some("update all wildcard"),
+//          artifactUpdatesOf(
+//            updateSingleTypelevelAlgebra,
+//            updateSingleSpecs2Core,
+//            updateSingleSpecs2Scalacheck
+//          )
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List.empty)
+//  }
+//
+//  test("GroupedUpdate.from: Group Update.Group for an ArtifactId filter without a group") {
+//    val pullRequestArtifactSpecs2CoreWithoutGroup: PullRequestGroup = PullRequestGroup(
+//      "specs2 core",
+//      Some("update specs2 core"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter(None, "specs2-core".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2CoreWithoutGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+//      )
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2 core",
+//          Some("update specs2 core"),
+//          artifactUpdatesOf(updateSingleSpecs2Core)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
+//  }
+//
+//  val pullRequestArtifactSpecs2CoreWithGroup: PullRequestGroup = PullRequestGroup(
+//    "specs2 core",
+//    Some("update specs2 core"),
+//    NonEmptyList.one(
+//      PullRequestUpdateFilter("org.specs2".some, "specs2-core".some).getOrElse(
+//        fail("Should not be called")
+//      )
+//    )
+//  )
+//
+//  test("GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a group") {
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2CoreWithGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+//      )
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2 core",
+//          Some("update specs2 core"),
+//          artifactUpdatesOf(updateSingleSpecs2Core)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with an invalid group"
+//  ) {
+//    val pullRequestArtifactSpecs2CoreWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "specs2 core",
+//      Some("update specs2 core"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.invalid".some, "specs2-core".some).getOrElse(
+//          fail("Should not be called")
+//        )
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2CoreWithInvalidGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+//      )
+//
+//    assertEquals(grouped, List.empty)
+//    assertEquals(notGrouped, List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithoutGroup: PullRequestGroup = PullRequestGroup(
+//      "specs2",
+//      Some("update specs2"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter(None, "specs2-*".some).getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithoutGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2",
+//          Some("update specs2"),
+//          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group multiple Update.Single for an ArtifactId filter with a wildcard and a group"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithGroup: PullRequestGroup = PullRequestGroup(
+//      "specs2",
+//      Some("update specs2"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.specs2".some, "specs2-*".some).getOrElse(
+//          fail("Should not be called")
+//        )
+//      )
+//    )
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+//      )
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "specs2",
+//          Some("update specs2"),
+//          artifactUpdatesOf(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core)
+//        )
+//      )
+//    )
+//    assertEquals(notGrouped, List(updateSingleTypelevelAlgebra))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Not group multiple Update.Single for an ArtifactId filter with a wildcard an invalid group"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "specs2",
+//      Some("update specs2"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter("org.invalid".some, "specs2-*".some).getOrElse(
+//          fail("Should not be called")
+//        )
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+//      )
+//
+//    assertEquals(grouped, List.empty)
+//    assertEquals(
+//      notGrouped,
+//      List(updateSingleSpecs2Scalacheck, updateSingleSpecs2Core, updateSingleTypelevelAlgebra)
+//    )
+//  }
+//
+//  val majorUpdate: UpdatesForGivenEdit =
+//    ("org.major".g % "major".a % "3.1.2" %> "4.0.0").single.stubEdit
+//  val minorUpdate: UpdatesForGivenEdit =
+//    ("org.minor".g % "minor".a % "3.1.2" %> "3.2.0").single.stubEdit
+//  val patchUpdate: UpdatesForGivenEdit =
+//    ("org.patch".g % "patch".a % "3.1.2" %> "3.1.3").single.stubEdit
+//
+//  test(
+//    "GroupedUpdate.from: Group major updates"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "major",
+//      Some("update major"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped("major", Some("update major"), artifactUpdatesOf(majorUpdate))
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(minorUpdate, patchUpdate))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group minor updates"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "minor",
+//      Some("update minor"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped("minor", Some("update minor"), artifactUpdatesOf(minorUpdate))
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(majorUpdate, patchUpdate))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group patch updates"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "patch",
+//      Some("update patch"),
+//      NonEmptyList.one(
+//        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group minor & patch updates"
+//  ) {
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "patch & minor",
+//      Some("update patch & minor"),
+//      NonEmptyList.of(
+//        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+//          .getOrElse(fail("Should not be called")),
+//        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "patch & minor",
+//          Some("update patch & minor"),
+//          artifactUpdatesOf(minorUpdate, patchUpdate)
+//        )
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(majorUpdate))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group major & minor updates with version numbers containing a date and commit hash"
+//  ) {
+//    val majorUpdate: UpdatesForGivenEdit =
+//      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
+//
+//    val minorUpdate: UpdatesForGivenEdit =
+//      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
+//
+//    val patchUpdate: UpdatesForGivenEdit =
+//      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220922-180024-dd318047").single.stubEdit
+//
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "major & minor",
+//      Some("update major & minor"),
+//      NonEmptyList.of(
+//        PullRequestUpdateFilter(version = SemVer.Change.Major.some)
+//          .getOrElse(fail("Should not be called")),
+//        PullRequestUpdateFilter(version = SemVer.Change.Minor.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped(
+//          "major & minor",
+//          Some("update major & minor"),
+//          artifactUpdatesOf(majorUpdate, minorUpdate)
+//        )
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(patchUpdate))
+//  }
+//
+//  test(
+//    "GroupedUpdate.from: Group patch updates with version numbers containing a date and commit hash"
+//  ) {
+//    val majorUpdate: UpdatesForGivenEdit =
+//      ("org.major".g % "major".a % "1.0.0-20220920-180024-dd318047" %> "2.0.0-20220922-180024-dd318047").single.stubEdit
+//
+//    val minorUpdate: UpdatesForGivenEdit =
+//      ("org.minor".g % "minor".a % "1.0.0-20220920-180024-dd318047" %> "1.1.0-20220922-180024-dd318047").single.stubEdit
+//
+//    val patchUpdate: UpdatesForGivenEdit =
+//      ("org.patch".g % "patch".a % "1.0.0-20220920-180024-dd318047" %> "1.0.1-20220920-180024-dd318047").single.stubEdit
+//
+//    val pullRequestArtifactSpecs2WildcardWithInvalidGroup: PullRequestGroup = PullRequestGroup(
+//      "patch",
+//      Some("update patch"),
+//      NonEmptyList.of(
+//        PullRequestUpdateFilter(version = SemVer.Change.Patch.some)
+//          .getOrElse(fail("Should not be called"))
+//      )
+//    )
+//
+//    val (grouped, notGrouped) =
+//      Update.groupByPullRequestGroup(
+//        List(pullRequestArtifactSpecs2WildcardWithInvalidGroup),
+//        List(majorUpdate, minorUpdate, patchUpdate)
+//      )
+//
+//    assertEquals(
+//      grouped,
+//      List(
+//        Update.Grouped("patch", Some("update patch"), artifactUpdatesOf(patchUpdate))
+//      )
+//    )
+//
+//    assertEquals(notGrouped, List(majorUpdate, minorUpdate))
+//  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateCodecTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateCodecTest.scala
@@ -134,7 +134,7 @@ class UpdateCodecTest extends FunSuite {
       Update.Grouped(
         name = "all",
         title = Some("All"),
-        updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
+        updates = Nel.of(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
       )
     )
     assertEquals(obtained, expected)
@@ -144,7 +144,7 @@ class UpdateCodecTest extends FunSuite {
     val update = Update.Grouped(
       name = "all",
       title = Some("All"),
-      updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
+      updates = Nel.of(("org.specs2".g % "specs2-core".a % "3.9.4" % "test" %> "3.9.5").single)
     )
     val obtained = Decoder[Update].decodeJson(Encoder[Update].apply(update))
     assertEquals(obtained, Right(update))

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -19,13 +19,13 @@ class UpdateTest extends FunSuite {
   }
 
   test("groupByGroupId: 1 update") {
-    val updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single)
-    assertEquals(Update.groupByGroupId(updates), updates)
+    val updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single.stubEdit)
+    assertEquals(Update.groupByGroupId(updates), updates.flatMap(_.asUpdatesForArtifactId.toList))
   }
 
   test("groupByGroupId: 2 updates") {
-    val update0 = ("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single
-    val update1 = ("org.specs2".g % "specs2-scalacheck".a % "3.9.4" %> "3.9.5").single
+    val update0 = ("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single.stubEdit
+    val update1 = ("org.specs2".g % "specs2-scalacheck".a % "3.9.4" %> "3.9.5").single.stubEdit
     val expected = List(
       ("org.specs2".g % Nel.of("specs2-core".a, "specs2-scalacheck".a) % "3.9.4" %> "3.9.5").group
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -3,6 +3,7 @@ package org.scalasteward.core.data
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax
 import org.scalasteward.core.TestSyntax.*
+import org.scalasteward.core.edit.update.data.Substring.Replacement
 import org.scalasteward.core.util.Nel
 
 class UpdateTest extends FunSuite {
@@ -22,12 +23,21 @@ class UpdateTest extends FunSuite {
   test("performAllGrouping: 1 update") {
     val coreGroup = "com.fasterxml.jackson.core".g
     val datatypeGroup = "com.fasterxml.jackson.datatype".g
-    val update1 = (coreGroup % "jackson-core".a % "2.20.1" %> "2.20.2").single.stubEdit
-    val update2 = (coreGroup % "jackson-databind".a % "2.20.1" %> "2.20.2").single.stubEdit
-    val update3 = (datatypeGroup % "jackson-datatype-jdk8".a % "2.20.1" %> "2.20.2").single.stubEdit
-    val update4 = (datatypeGroup % "jackson-datatype-jsr310".a % "2.20.1" %> "2.20.2").single.stubEdit
+    val vUpdate = Version.Update("2.20.1".v, "2.20.2".v)
+    val singleEdit: Replacement = stubReplacement(positionIndex = 10, vUpdate)
+    val update1 = (coreGroup % "jackson-core".a % vUpdate).withEdit(singleEdit)
+    val update2 = (coreGroup % "jackson-databind".a % vUpdate).withEdit(singleEdit)
+    val update3 = (datatypeGroup % "jackson-datatype-jdk8".a % vUpdate).withEdit(singleEdit)
+    val update4 = (datatypeGroup % "jackson-datatype-jsr310".a % vUpdate).withEdit(singleEdit)
 
-    assertEquals(Update.performAllGrouping(List(update), List.empty), artifactUpdatesOf(update))
+    val boo = Map(
+
+    )
+
+    val updatesAndEdits = List(update1, update2, update3, update4)
+    val resultingUpdates = Update.performAllGrouping(updatesAndEdits, List.empty)
+    assertEquals(resultingUpdates.size, 1)
+    assertEquals(resultingUpdates.head.asSingleUpdates.size, 4)
   }
 
   test("groupByGroupId: 1 update") {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.data
 
 import munit.FunSuite
+import org.scalasteward.core.TestSyntax
 import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.util.Nel
 
@@ -16,6 +17,17 @@ class UpdateTest extends FunSuite {
     val update = ("com.softwaremill.sttp".g %
       Nel.of("circe".a, "core".a, "monix".a) % "1.3.2" %> "1.3.3").group
     assertEquals(update.mainArtifactId, "circe")
+  }
+
+  test("performAllGrouping: 1 update") {
+    val coreGroup = "com.fasterxml.jackson.core".g
+    val datatypeGroup = "com.fasterxml.jackson.datatype".g
+    val update1 = (coreGroup % "jackson-core".a % "2.20.1" %> "2.20.2").single.stubEdit
+    val update2 = (coreGroup % "jackson-databind".a % "2.20.1" %> "2.20.2").single.stubEdit
+    val update3 = (datatypeGroup % "jackson-datatype-jdk8".a % "2.20.1" %> "2.20.2").single.stubEdit
+    val update4 = (datatypeGroup % "jackson-datatype-jsr310".a % "2.20.1" %> "2.20.2").single.stubEdit
+
+    assertEquals(Update.performAllGrouping(List(update), List.empty), artifactUpdatesOf(update))
   }
 
   test("groupByGroupId: 1 update") {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -4,6 +4,7 @@ import munit.FunSuite
 import org.scalasteward.core.TestSyntax
 import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.edit.update.data.Substring.Replacement
+import org.scalasteward.core.nurture.InseparableUpdateSet
 import org.scalasteward.core.util.Nel
 
 class UpdateTest extends FunSuite {
@@ -25,24 +26,32 @@ class UpdateTest extends FunSuite {
     val datatypeGroup = "com.fasterxml.jackson.datatype".g
     val vUpdate = Version.Update("2.20.1".v, "2.20.2".v)
     val singleEdit: Replacement = stubReplacement(positionIndex = 10, vUpdate)
-    val update1 = (coreGroup % "jackson-core".a % vUpdate).withEdit(singleEdit)
-    val update2 = (coreGroup % "jackson-databind".a % vUpdate).withEdit(singleEdit)
-    val update3 = (datatypeGroup % "jackson-datatype-jdk8".a % vUpdate).withEdit(singleEdit)
-    val update4 = (datatypeGroup % "jackson-datatype-jsr310".a % vUpdate).withEdit(singleEdit)
+    val update1 = (coreGroup % "jackson-core".a % vUpdate).artifactForUpdate
+    val update2 = (coreGroup % "jackson-databind".a % vUpdate).artifactForUpdate
+    val update3 = (datatypeGroup % "jackson-datatype-jdk8".a % vUpdate).artifactForUpdate
+    val update4 = (datatypeGroup % "jackson-datatype-jsr310".a % vUpdate).artifactForUpdate
 
-    val boo = Map(
-
+    val updatesByEdit = Map(
+      Set(singleEdit) -> InseparableUpdateSet(
+        Nel.of(update1, update2, update3, update4),
+        "2.20.2".v
+      )
     )
 
-    val updatesAndEdits = List(update1, update2, update3, update4)
-    val resultingUpdates = Update.performAllGrouping(updatesAndEdits, List.empty)
+    val resultingUpdates = Update.performAllGrouping(updatesByEdit, List.empty)
     assertEquals(resultingUpdates.size, 1)
     assertEquals(resultingUpdates.head.asSingleUpdates.size, 4)
   }
 
   test("groupByGroupId: 1 update") {
-    val updates = List(("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single.stubEdit)
-    assertEquals(Update.groupByGroupId(updates), updates.flatMap(_.asUpdatesForArtifactId.toList))
+    val update = ("org.specs2".g % "specs2-core".a % "3.9.4" %> "3.9.5").single
+    val updatesByEdit = Map(
+      Set(stubReplacement(positionIndex = 10, update.versionUpdate)) -> InseparableUpdateSet(
+        Nel.one(update.artifactForUpdate),
+        update.nextVersion
+      )
+    )
+    assertEquals(Update.groupByGroupId(updatesByEdit), List(update))
   }
 
   test("groupByGroupId: 2 updates") {
@@ -51,7 +60,18 @@ class UpdateTest extends FunSuite {
     val expected = List(
       ("org.specs2".g % Nel.of("specs2-core".a, "specs2-scalacheck".a) % "3.9.4" %> "3.9.5").group
     )
-    assertEquals(Update.groupByGroupId(List(update0, update1)), expected)
+    val versionUpdate = Version.Update("3.9.4".v, "3.9.5".v)
+    val updatesByEdit = Map(
+      Set(stubReplacement(positionIndex = 10, versionUpdate)) -> InseparableUpdateSet(
+        Nel.one(update.artifactForUpdate),
+        versionUpdate.nextVersion
+      ),
+      Set(stubReplacement(positionIndex = 20, versionUpdate)) -> InseparableUpdateSet(
+        Nel.one(update.artifactForUpdate),
+        versionUpdate.nextVersion
+      )
+    )
+    assertEquals(Update.groupByGroupId(updatesByEdit), expected)
   }
 
   test("groupByArtifactIdName: 2 updates") {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/RewriteTest.scala
@@ -391,8 +391,10 @@ class RewriteTest extends FunSuite {
   test("artifact change: group update") {
     val update1 = ("io.chrisdavenport".g % "log4cats-core".a % "1.2.1" %> "1.3.0").single
       .migration(newerGroupId = Some("org.typelevel".g))
+      .stubEdit
     val update2 = ("io.chrisdavenport".g % "log4cats-slf4j".a % "1.2.1" %> "1.3.0").single
       .migration(newerGroupId = Some("org.typelevel".g))
+      .stubEdit
     val update = Update.groupByGroupId(List(update1, update2)).head
     val original = Map(
       "Dependencies.scala" -> """val log4catsVersion = "1.2.1" """,
@@ -986,7 +988,7 @@ class RewriteTest extends FunSuite {
   }
 
   private def runApplyUpdate(
-      update: Update.Single,
+      update: Update,
       files: Map[String, String],
       expected: Map[String, String]
   ): Unit = {

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeTypeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/ForgeTypeTest.scala
@@ -5,6 +5,7 @@ import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.{Repo, Update}
 import org.scalasteward.core.forge.ForgeType.{GitHub, GitLab}
 import org.scalasteward.core.git
+import org.scalasteward.core.util.Nel
 
 class ForgeTypeTest extends FunSuite {
   private val repo = Repo("foo", "bar")
@@ -27,7 +28,7 @@ class ForgeTypeTest extends FunSuite {
     val update = Update.Grouped(
       name = "my-group",
       title = None,
-      updates = List(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
+      updates = Nel.of(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
     )
 
     val updateBranch = git.branchFor(update, None)
@@ -44,7 +45,7 @@ class ForgeTypeTest extends FunSuite {
     val update = Update.Grouped(
       name = "my-group-${hash}",
       title = None,
-      updates = List(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
+      updates = Nel.of(("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single)
     )
 
     val updateBranch = git.branchFor(update, None)

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/data/NewPullRequestDataTest.scala
@@ -192,7 +192,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("bodyFor() grouped update") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
-    val update = Update.Grouped("my-group", Some("The PR title"), List(update1, update2))
+    val update = Update.Grouped("my-group", Some("The PR title"), Nel.of(update1, update2))
     val edits = List(
       UpdateEdit(
         update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
@@ -453,7 +453,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("bodyFor() grouped update when edits does not contain an update (scala-steward:off case)") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
-    val update = Update.Grouped("my-group", Some("The PR title"), List(update1, update2))
+    val update = Update.Grouped("my-group", Some("The PR title"), Nel.of(update1, update2))
     val edits = List(
       UpdateEdit(
         update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,
@@ -799,7 +799,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("label for grouped updates add labels for all update types & version changes") {
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = Update.Grouped("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, Nel.of(update1, update2))
 
     val labels = labelsFor(update, Nil, Nil)
 
@@ -825,7 +825,7 @@ class NewPullRequestDataTest extends FunSuite {
     val files = List("Readme.md", "travis.yml")
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = Update.Grouped("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, Nel.of(update1, update2))
 
     val note = oldVersionNote(files, update)
 
@@ -848,7 +848,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("adjustFutureUpdates for grouped updates shows settings for each update") {
     val update1 = ("a".g % "b".a % "1" -> "2").single
     val update2 = ("c".g % "d".a % "1.1.0" % "test" %> "1.2.0").single
-    val update = Update.Grouped("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, Nel.of(update1, update2))
 
     val note = adjustFutureUpdates(update)
 
@@ -989,7 +989,7 @@ class NewPullRequestDataTest extends FunSuite {
   test("from() should construct NewPullRequestData for grouped update") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
-    val update = Update.Grouped("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, Nel.of(update1, update2))
     val edits = List(
       UpdateEdit(
         update = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single,

--- a/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/CommitMsgTest.scala
@@ -3,13 +3,14 @@ package org.scalasteward.core.git
 import munit.FunSuite
 import org.scalasteward.core.TestSyntax.*
 import org.scalasteward.core.data.Update
+import org.scalasteward.core.util.Nel
 
 class CommitMsgTest extends FunSuite {
   test("Create title for Update.Grouped") {
     val update1 = ("ch.qos.logback".g % "logback-classic".a % "1.2.0" %> "1.2.3").single
     val update2 = ("com.example".g % "foo".a % "1.0.0" %> "2.0.0").single
 
-    val update = Update.Grouped("my-group", Some("The PR title"), List(update1, update2))
+    val update = Update.Grouped("my-group", Some("The PR title"), Nel.of(update1, update2))
     assertEquals(CommitMsg.replaceVariables("")(update, None).title, "The PR title")
   }
 
@@ -22,7 +23,7 @@ class CommitMsgTest extends FunSuite {
     val update = Update.Grouped(
       "my-group",
       Some("Title - ${artifactVersions}"),
-      List(update1, update2, update3, update4)
+      Nel.of(update1, update2, update3, update4)
     )
     assertEquals(
       CommitMsg.replaceVariables("")(update, None).title,
@@ -34,7 +35,7 @@ class CommitMsgTest extends FunSuite {
     "Do not create truncated title for Update.Grouped with ${artifactVersions} when 200 characters or less"
   ) {
     val singles = (0 to 23).map(i => ("com.example".g % s"foo-$i".a % "1.0.0" %> "2.0.0").single)
-    val update = Update.Grouped("my-group", Some("Title ---- ${artifactVersions}"), singles.toList)
+    val update = Update.Grouped("my-group", Some("Title ---- ${artifactVersions}"), Nel.fromListUnsafe(singles.toList))
     val title = CommitMsg.replaceVariables("")(update, None).title
     assertEquals(
       title,
@@ -47,7 +48,7 @@ class CommitMsgTest extends FunSuite {
     "Create truncated title for Update.Grouped with ${artifactVersions} when more than 200 characters"
   ) {
     val singles = (0 to 23).map(i => ("com.example".g % s"foo-$i".a % "1.0.0" %> "2.0.0").single)
-    val update = Update.Grouped("my-group", Some("Title ----- ${artifactVersions}"), singles.toList)
+    val update = Update.Grouped("my-group", Some("Title ----- ${artifactVersions}"), Nel.fromListUnsafe(singles.toList))
     assertEquals(
       CommitMsg.replaceVariables("")(update, None).title,
       "Title ----- foo-0 and 23 more to 2.0.0"

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -15,6 +15,7 @@ import org.scalasteward.core.mock.MockState.TraceEntry
 import org.scalasteward.core.mock.MockState.TraceEntry.Cmd
 import org.scalasteward.core.mock.{MockEff, MockEffOps, MockState}
 import org.scalasteward.core.repoconfig.{RetractedArtifact, UpdatePattern, VersionPattern}
+import org.scalasteward.core.util.Nel
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -32,7 +33,7 @@ class PullRequestRepositoryTest extends FunSuite {
   private val sha1 = Sha1.unsafeFrom("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8")
   private val number = PullRequestNumber(3291)
   private def groupedUpdate(updates: Update.ForArtifactId*) =
-    Update.Grouped("group", None, updates.toList)
+    Update.Grouped("group", None, Nel.fromListUnsafe(updates.toList))
   private def openPRFor(update: Update): PullRequestData[Id] =
     PullRequestData[Id](url, sha1, update, Open, number, Branch("update"))
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -371,7 +371,7 @@ class RepoConfigAlgTest extends FunSuite {
   test("configToIgnoreFurtherUpdates with grouped update") {
     val update1 = ("a".g % "b".a % "1" %> "2").single
     val update2 = ("c".g % "d".a % "1" %> "2").single
-    val update = Update.Grouped("my-group", None, List(update1, update2))
+    val update = Update.Grouped("my-group", None, Nel.of(update1, update2))
     val config = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())

--- a/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/loggerTest.scala
@@ -35,8 +35,8 @@ class loggerTest extends CatsEffectSuite {
     val c = ("a".g % "c".a % "1.0.0" %> "2.0.0").single
 
     val list = List(
-      Update.Grouped("all", None, List(a, b, c)),
-      Update.Grouped("some", None, List(a, b)),
+      Update.Grouped("all", None, Nel.of(a, b, c)),
+      Update.Grouped("some", None, Nel.of(a, b)),
       a,
       b,
       c


### PR DESCRIPTION
This fixes two issues:

* **Multiple PRs with the same diff**: Only one PR will raised, rather than several PRs with identical diffs like these ones:
  * https://github.com/guardian/play-json-extensions/pull/13 - Maven groupId: `com.fasterxml.jackson.core`
  * https://github.com/guardian/play-json-extensions/pull/14 - Maven groupId: `com.fasterxml.jackson.datatype`
* **Inaccurate PR descriptions**: PR descriptions are more accurate, in that they reflect _all_ artifacts that are getting updated, fixing https://github.com/scala-steward-org/scala-steward/issues/3780


See also:

* https://github.com/scala-steward-org/scala-steward/issues/25
* https://github.com/scala-steward-org/scala-steward/issues/3803
* https://github.com/scala-steward-org/scala-steward/pull/2019 - previous attempt at addressing this problem