### PR TITLE
Revert vulcan migrations

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1593,26 +1593,6 @@ changes = [
   {
     groupIdBefore = com.github.fd4s
     groupIdAfter = org.typelevel
-    artifactIdAfter = vulcan
-  },
-  {
-    groupIdBefore = com.github.fd4s
-    groupIdAfter = org.typelevel
-    artifactIdAfter = vulcan-enumeratum
-  },
-  {
-    groupIdBefore = com.github.fd4s
-    groupIdAfter = org.typelevel
-    artifactIdAfter = vulcan-generic
-  },
-  {
-    groupIdBefore = com.github.fd4s
-    groupIdAfter = org.typelevel
-    artifactIdAfter = vulcan-refined
-  },
-  {
-    groupIdBefore = com.github.fd4s
-    groupIdAfter = org.typelevel
     artifactIdAfter = fs2-kafka
   },
   {


### PR DESCRIPTION
Reverts some changes from https://github.com/scala-steward-org/scala-steward/pull/3860. I forgot that Vulcan is still published to the old group id, for now. Sorry and thanks!

https://github.com/typelevel/vulcan/blob/0e9b1d476cb00b33bfd036a1edc884df2c352a7c/build.sbt#L283-L285