### PR TITLE
Add migration: org.polyvariant smithy-trait-codegen-sbt → smithy-scala-tools-sbt

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1604,5 +1604,11 @@ changes = [
     groupIdBefore = com.github.fd4s
     groupIdAfter = org.typelevel
     artifactIdAfter = fs2-kafka-vulcan-testkit-munit
+  },
+  {
+    groupIdBefore = org.polyvariant
+    groupIdAfter = org.polyvariant
+    artifactIdBefore = smithy-trait-codegen-sbt
+    artifactIdAfter = smithy-scala-tools-sbt
   }
 ]


### PR DESCRIPTION
## Summary

Adds an artifact migration for `org.polyvariant`'s sbt plugin, which has been renamed:

- `smithy-trait-codegen-sbt` → `smithy-scala-tools-sbt`

## Context

The project [`polyvariant/smithy-trait-codegen-scala`](https://github.com/polyvariant/smithy-trait-codegen-scala) has been renamed to **`smithy-scala-tools`**. The new name better reflects its scope: build-time tooling for Smithy models (trait codegen + an IDL formatter), as opposed to [smithy4s](https://disneystreaming.github.io/smithy4s/) which targets runtime/service codegen.

GroupId stays `org.polyvariant` — only the artifact ID changes.

(A `smithy-scala-tools-core` artifact is also being introduced as part of the rename, but no `smithy-trait-codegen-core` was ever published — `core` is brand-new — so it doesn't need a migration entry.)

The new artifact `smithy-scala-tools-sbt` `0.3.0` is being published from [polyvariant/smithy-trait-codegen-scala#39](https://github.com/polyvariant/smithy-trait-codegen-scala/pull/39) (release: [v0.3.0](https://github.com/polyvariant/smithy-trait-codegen-scala/releases/tag/v0.3.0)). Maven Central propagation may still be in progress when this PR is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)