### PR TITLE
Add per-pattern overrides to cooldown config

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -114,8 +114,16 @@ updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 #
 # Scala Steward records the first time it sees any artefact version and calculates
 # the artefact version's age from that time.
+#
+# Optionally, the minimum age can be overridden for specific groupIds (or
+# groupId + artifactId). The first matching override wins; otherwise the
+# top-level `minimumAge` is used as the default.
 updates.cooldown = {
   minimumAge: "7 days"
+  overrides = [
+    { groupId = "org.typelevel", minimumAge = "3 days" },
+    { groupId = "org.acme", artifactId = "foo", minimumAge = "1 day" }
+  ]
 }
 
 # The dependencies which match the given pattern are retracted. Their existing pull-request will be closed.

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CooldownConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/CooldownConfig.scala
@@ -18,7 +18,8 @@ package org.scalasteward.core.repoconfig
 
 import cats.implicits.*
 import io.circe.generic.semiauto.deriveCodec
-import io.circe.{Codec, Decoder, Encoder}
+import io.circe.syntax.*
+import io.circe.{Codec, Decoder, Encoder, Json}
 import org.scalasteward.core.data.ArtifactUpdateCandidates
 import org.scalasteward.core.util.Timestamp
 import org.scalasteward.core.util.dateTime.parseFiniteDuration
@@ -26,19 +27,55 @@ import org.scalasteward.core.util.dateTime.parseFiniteDuration
 import scala.concurrent.duration.FiniteDuration
 
 final case class CooldownConfig(
-    minimumAge: FiniteDuration
+    minimumAge: FiniteDuration,
+    overrides: Option[List[CooldownConfig.Override]] = None
 ) {
+  def overridesOrDefault: List[CooldownConfig.Override] = overrides.getOrElse(Nil)
+
+  private def minimumAgeFor(updateCandidates: ArtifactUpdateCandidates): FiniteDuration =
+    overridesOrDefault
+      .find { o =>
+        UpdatePattern
+          .findMatch(List(o.pattern), updateCandidates, include = true)
+          .byArtifactId
+          .nonEmpty
+      }
+      .map(_.minimumAge)
+      .getOrElse(minimumAge)
+
   def filterForAge(
       updateCandidates: ArtifactUpdateCandidates,
       currentTime: Timestamp
-  ): Option[ArtifactUpdateCandidates] =
-    updateCandidates.filterVersionsWithFirstSeen(_.isOlderThan(minimumAge, currentTime))
+  ): Option[ArtifactUpdateCandidates] = {
+    val effectiveAge = minimumAgeFor(updateCandidates)
+    updateCandidates.filterVersionsWithFirstSeen(_.isOlderThan(effectiveAge, currentTime))
+  }
 }
 
 object CooldownConfig {
-  implicit val codec: Codec[CooldownConfig] = deriveCodec
   implicit val finiteDurationDecoder: Decoder[FiniteDuration] =
     Decoder[String].emap(s => parseFiniteDuration(s).leftMap(_.toString))
   implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
     Encoder[String].contramap(_.toString)
+
+  final case class Override(
+      pattern: UpdatePattern,
+      minimumAge: FiniteDuration
+  )
+
+  object Override {
+    implicit val codec: Codec[Override] = Codec.from(
+      Decoder.instance { c =>
+        for {
+          minimumAge <- c.get[FiniteDuration]("minimumAge")
+          pattern <- c.as[UpdatePattern]
+        } yield Override(pattern, minimumAge)
+      },
+      Encoder.instance { o =>
+        o.pattern.asJson.deepMerge(Json.obj("minimumAge" -> o.minimumAge.asJson))
+      }
+    )
+  }
+
+  implicit val codec: Codec[CooldownConfig] = deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -226,10 +226,22 @@ object UpdatesConfig {
   ): Option[List[String]] =
     combineOptions(x, y)(_.intersect(_))
 
+  // x = global, y = repo (see RepoConfigAlg: maybeGlobalRepoConfig |+| maybeRepoConfig).
+  // minimumAge: repo wins over global (preserves prior behavior).
+  // overrides: concatenated repo-first, deduped — repo entries take precedence by being checked first.
   private[repoconfig] def mergeCooldown(
       x: Option[CooldownConfig],
       y: Option[CooldownConfig]
-  ): Option[CooldownConfig] = (y ++ x).headOption // for now, simply let local override global
+  ): Option[CooldownConfig] = (x, y) match {
+    case (None, _)          => y
+    case (_, None)          => x
+    case (Some(g), Some(r)) =>
+      val mergedOverrides = combineOptions(r.overrides, g.overrides) { (rOv, gOv) =>
+        val rPatterns = rOv.map(_.pattern).toSet
+        rOv ::: gOv.filterNot(o => rPatterns.contains(o.pattern))
+      }
+      Some(CooldownConfig(minimumAge = r.minimumAge, overrides = mergedOverrides))
+  }
 
   intellijThisImportIsUsed(refinedDecoder: Decoder[NonNegInt])
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CooldownConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/CooldownConfigTest.scala
@@ -24,4 +24,120 @@ class CooldownConfigTest extends FunSuite {
       None
     )
   }
+
+  test("override applies for matching groupId, default for non-matching") {
+    val config = CooldownConfig(
+      minimumAge = 100.millis,
+      overrides = Some(
+        List(
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, None, None),
+            minimumAge = 1.millis
+          )
+        )
+      )
+    )
+
+    val matching =
+      ("org.typelevel".g % "example".a % "1.0.0" %> VersionWithFirstSeen(
+        "1.0.1".v,
+        Some(Timestamp(0))
+      )).single
+
+    val nonMatching =
+      ("org.other".g % "example".a % "1.0.0" %> VersionWithFirstSeen(
+        "1.0.1".v,
+        Some(Timestamp(0))
+      )).single
+
+    // matching: override age 1ms, version is 5ms old -> passes
+    assertEquals(config.filterForAge(matching, Timestamp(5)), Some(matching))
+    // non-matching: default age 100ms, version is 5ms old -> filtered out
+    assertEquals(config.filterForAge(nonMatching, Timestamp(5)), None)
+  }
+
+  test("first matching override wins") {
+    val config = CooldownConfig(
+      minimumAge = 100.millis,
+      overrides = Some(
+        List(
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, Some("example"), None),
+            minimumAge = 1.millis
+          ),
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, None, None),
+            minimumAge = 50.millis
+          )
+        )
+      )
+    )
+
+    val update =
+      ("org.typelevel".g % "example".a % "1.0.0" %> VersionWithFirstSeen(
+        "1.0.1".v,
+        Some(Timestamp(0))
+      )).single
+
+    // first override (1ms) wins, version is 5ms old -> passes
+    assertEquals(config.filterForAge(update, Timestamp(5)), Some(update))
+  }
+
+  test("merge: repo overrides come before global, dedup applied") {
+    val global = CooldownConfig(
+      minimumAge = 7.days.toMillis.millis,
+      overrides = Some(
+        List(
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, None, None),
+            minimumAge = 50.millis
+          ),
+          CooldownConfig.Override(
+            UpdatePattern("org.shared".g, None, None),
+            minimumAge = 60.millis
+          )
+        )
+      )
+    )
+    val repo = CooldownConfig(
+      minimumAge = 1.day.toMillis.millis,
+      overrides = Some(
+        List(
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, None, None),
+            minimumAge = 1.millis
+          )
+        )
+      )
+    )
+
+    val merged = UpdatesConfig.mergeCooldown(Some(global), Some(repo))
+
+    assertEquals(
+      merged.map(_.minimumAge),
+      Some(1.day.toMillis.millis) // repo wins
+    )
+    assertEquals(
+      merged.flatMap(_.overrides),
+      Some(
+        List(
+          CooldownConfig.Override(
+            UpdatePattern("org.typelevel".g, None, None),
+            1.millis
+          ),
+          CooldownConfig.Override(
+            UpdatePattern("org.shared".g, None, None),
+            60.millis
+          )
+        )
+      )
+    )
+  }
+
+  test("merge: only one side defined") {
+    val cfg = CooldownConfig(7.days.toMillis.millis)
+    assertEquals(UpdatesConfig.mergeCooldown(Some(cfg), None), Some(cfg))
+    assertEquals(UpdatesConfig.mergeCooldown(None, Some(cfg)), Some(cfg))
+    assertEquals(UpdatesConfig.mergeCooldown(None, None), None)
+  }
 }

--- a/modules/docs/mdoc/repo-specific-configuration.md
+++ b/modules/docs/mdoc/repo-specific-configuration.md
@@ -119,8 +119,16 @@ updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 #
 # Scala Steward records the first time it sees any artefact version and calculates
 # the artefact version's age from that time.
+#
+# Optionally, the minimum age can be overridden for specific groupIds (or
+# groupId + artifactId). The first matching override wins; otherwise the
+# top-level `minimumAge` is used as the default.
 updates.cooldown = {
   minimumAge: "7 days"
+  overrides = [
+    { groupId = "org.typelevel", minimumAge = "3 days" },
+    { groupId = "org.acme", artifactId = "foo", minimumAge = "1 day" }
+  ]
 }
 
 # The dependencies which match the given pattern are retracted. Their existing pull-request will be closed.


### PR DESCRIPTION
## Summary

Follows up on #3762 - a single global cooldown is a good start, but I think we may want to be more lenient on some repositories, especially in closed ecosystems.

Adds `updates.cooldown.overrides`, allowing per-`groupId` (or `groupId` + `artifactId`) `minimumAge` values that override the default. The first matching override wins; otherwise the top-level `minimumAge` is used.

```hocon
updates.cooldown = {
  minimumAge = "7 days"
  overrides = [
    { groupId = "org.typelevel", minimumAge = "3 days" },
    { groupId = "org.acme", artifactId = "foo", minimumAge = "1 day" }
  ]
}
```

(I actually didn't see before opening the PR that @rtyley ended up with the same design as what I imagined) :) 

Notes:
- Top-level `minimumAge` remains required as the default.
- Override patterns reuse `UpdatePattern` for consistency with `pin` / `allow` / `ignore`.
- When merging global + repo configs: top-level `minimumAge` keeps the prior repo-wins behavior; `overrides` lists are concatenated with repo entries first, deduplicated by pattern.

## Test plan

- [x] `CooldownConfigTest` covers override match, fallback, first-match-wins, merge ordering, dedup, and one-sided merges
- [x] Existing `FilterAlgTest` and `UpdatesConfigTest` still pass
- [x] Confirm mdoc-generated `docs/repo-specific-configuration.md` regenerates cleanly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)