### PR TITLE
Mention GitHub Dependabot now supports `sbt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Once that PR is merged, [**@scala-steward**][@scala-steward] will check periodic
 
 Many thanks to [VirtusLab][VirtusLab] for hosting and managing this public Scala Steward instance!
 
+## Alternatives to Scala Steward
+
+* GitHub: Since [May 2026](https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/),
+  Dependabot version updates now [support `sbt`](https://github.com/dependabot/dependabot-core/issues/352/).
+
 ## Show us the pull requests!
 
 If you are curious how [**@scala-steward**'s][@scala-steward] pull requests


### PR DESCRIPTION
Since May 2026 Dependabot version updates (not security updates?) now support `sbt`:

* https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/
* https://github.com/dependabot/dependabot-core/issues/352/

It's reasonable for us to let users know there is now an alternative to Scala Steward for _GitHub ∩ `sbt`_ users!

The existence of this alternative obviously raises questions about the future of Scala Steward - it'll be interesting to see how this pans out.

There's obviously some feature disparity - Dependbot probably leads in many areas, there are a few where Scala Steward is ahead - comparing Dependabot vs Scala Steward:

* GitHub-only vs [GitHub, GitLab, BitBucket, Azure, etc](https://github.com/scala-steward-org/scala-steward/blob/27b8f3d22b8594df90b04025ce0b5eedfd70f48b/modules/core/src/main/scala/org/scalasteward/core/forge/ForgeType.scala#L55-L60)
* `sbt`-only vs [`sbt`, `mill`, `scalacli`](https://github.com/scala-steward-org/scala-steward/tree/27b8f3d22b8594df90b04025ce0b5eedfd70f48b/modules/core/src/main/scala/org/scalasteward/core/buildtool)
* At launch, Dependabot cooldown support [seems](https://github.com/guardian/security-hq/pull/1373) to be broken
* [No post-update hooks](https://github.com/dependabot/dependabot-core/issues/352#issuecomment-4512334596), eg [reformatting code](https://github.com/scala-steward-org/scala-steward/blob/v0.38.0/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala#L175-L185) after updating [scalafmt](https://github.com/scalameta/scalafmt)

## Examples

Configuring this support in `.github/dependabot.yml`:

* https://github.com/guardian/security-hq/pull/1373
* https://github.com/guardian/security-hq/pull/1379

PRs produced by Dependabot:

* https://github.com/guardian/security-hq/pull/1376
* https://github.com/guardian/security-hq/pull/1378

## Dependabot implementation

The Dependabot implementation is open-source [under the MIT licence](https://github.com/dependabot/dependabot-core?tab=MIT-1-ov-file#readme):

* https://github.com/dependabot/dependabot-core/tree/main/sbt

Some interesting PRs in the Dependabot implementation:

* https://github.com/dependabot/dependabot-core/pull/14801
* https://github.com/dependabot/dependabot-core/pull/14874
* https://github.com/dependabot/dependabot-core/pull/14890
* https://github.com/dependabot/dependabot-core/pull/14918
* https://github.com/dependabot/dependabot-core/pull/15011