### PR TITLE
Add rule for weaver-test `0.13.0` upgrade.

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -277,6 +277,12 @@ migrations = [
     artifactIds: ["weaver-.*"],
     newVersion: "0.11.0",
     rewriteRules: ["github:typelevel/weaver-test/v0_11_0?sha=v0.11.0"]
+  },
+  {
+    groupId: "org.typelevel",
+    artifactIds: ["weaver-.*"],
+    newVersion: "0.13.0",
+    rewriteRules: ["github:typelevel/weaver-test/v0_13_0?sha=v0.13.0"]
   }
 
 ]


### PR DESCRIPTION
Weaver test `0.13.0` will be released shortly with [a `v0.13.0` scalafix rule](https://github.com/typelevel/weaver-test/blob/main/scalafix/rules/src/main/scala/fix/v0_13_0.scala).