### PR TITLE
Add --dry-run mode

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -4,7 +4,7 @@ All command line arguments for the `scala-steward` application.
 
 ```
 Usage:
-    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--signoff] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>]... [--refresh-backoff-period <duration>] [--exit-code-success-if-any-repo-succeeds]
+    scala-steward --workspace <file> --repos-file <uri> [--repos-file <uri>]... [--git-author-name <string>] --git-author-email <string> [--git-author-signing-key <string>] --git-ask-pass <file> [--sign-commits] [--signoff] [--forge-type <forge-type>] [--forge-api-host <uri>] --forge-login <string> [--do-not-fork] [--add-labels] [--ignore-opts-files] [--env-var <name=value>]... [--process-timeout <duration>] [--whitelist <string>]... [--read-only <string>]... [--enable-sandbox | --disable-sandbox] [--max-buffer-size <integer>] [--repo-config <uri>]... [--disable-default-repo-config] [--scalafix-migrations <uri>]... [--disable-default-scalafix-migrations] [--artifact-migrations <uri>]... [--disable-default-artifact-migrations] [--cache-ttl <duration>] [--bitbucket-use-default-reviewers] [--bitbucket-server-use-default-reviewers] [--gitlab-merge-when-pipeline-succeeds] [--gitlab-required-reviewers <integer>] [--gitlab-remove-source-branch] [--azure-repos-organization <string>] [--github-app-id <integer> --github-app-key-file <file>] [--url-checker-test-url <uri>]... [--default-maven-repo <string>]... [--refresh-backoff-period <duration>] [--exit-code-success-if-any-repo-succeeds] [--dry-run]
     scala-steward validate-repo-config
 
 
@@ -92,6 +92,8 @@ Options and flags:
         Period of time a failed build won't be triggered again; default: 0days
     --exit-code-success-if-any-repo-succeeds
         Whether the Scala Steward process should exit with success (exit code 0) if any repo succeeds; default: false
+    --dry-run
+        Whether to only do a dry run that does everything except pushing commits and opening, updating or closing pull requests; implies --do-not-fork; default: false
 
 Subcommands:
     validate-repo-config

--- a/docs/running.md
+++ b/docs/running.md
@@ -104,6 +104,21 @@ JAVA_OPTS="-Dhttp.proxyHost=webcache.example.com -Dhttp.proxyPort=8080 -Dhttps.p
 
 See Oracle proxies documentation for more info.
 
+### Dry run
+
+The `--dry-run` option runs the full pipeline&mdash;cloning repositories, applying
+updates, and computing diffs&mdash;but skips every write to the forge and to the
+local pull request cache. Concretely, with `--dry-run` Scala Steward will not:
+
+* push branches or delete remote branches,
+* create, update, or close pull requests,
+* comment on pull requests, or
+* create forks (`--dry-run` implies `--do-not-fork`).
+
+Actions that would have been taken are logged with a `[dry-run]` prefix. This is
+useful for verifying configuration or previewing what Scala Steward would do
+without making any changes.
+
 ### Running locally from sbt
 
 #### Sample run for GitLab

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -332,6 +332,13 @@ object Cli {
     if (ifAnyRepoSucceeds) SuccessIfAnyRepoSucceeds else SuccessOnlyIfAllReposSucceed
   }
 
+  private val dryRun: Opts[Boolean] =
+    flag(
+      "dry-run",
+      "Whether to only do a dry run that does everything except pushing commits and opening, " +
+        "updating or closing pull requests; implies --do-not-fork; default: false"
+    ).orFalse
+
   private val regular: Opts[Usage] = (
     workspace,
     reposFiles,
@@ -351,8 +358,36 @@ object Cli {
     urlCheckerTestUrls,
     defaultMavenRepos,
     refreshBackoffPeriod,
-    exitCodePolicy
-  ).mapN(Config.apply).map(Usage.Regular.apply)
+    exitCodePolicy,
+    dryRun
+  ).mapN { (workspace, reposFiles, gitCfg, forgeCfg, ignoreOptsFiles, processCfg, repoConfigCfg,
+        scalafixCfg, artifactCfg, cacheTtl, bitbucketCfg, bitbucketServerCfg, gitLabCfg,
+        azureReposCfg, gitHubApp, urlCheckerTestUrls, defaultMavenRepos, refreshBackoffPeriod,
+        exitCodePolicy, dryRun) =>
+    Config(
+      workspace,
+      reposFiles,
+      gitCfg,
+      // A dry run never pushes to a fork, so forking would only create an unused fork.
+      if (dryRun) forgeCfg.copy(doNotFork = true) else forgeCfg,
+      ignoreOptsFiles,
+      processCfg,
+      repoConfigCfg,
+      scalafixCfg,
+      artifactCfg,
+      cacheTtl,
+      bitbucketCfg,
+      bitbucketServerCfg,
+      gitLabCfg,
+      azureReposCfg,
+      gitHubApp,
+      urlCheckerTestUrls,
+      defaultMavenRepos,
+      refreshBackoffPeriod,
+      exitCodePolicy,
+      dryRun
+    )
+  }.map(Usage.Regular.apply)
 
   private val validateRepoConfig: Opts[Usage] =
     Opts

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -64,7 +64,8 @@ final case class Config(
     urlCheckerTestUrls: Nel[Uri],
     defaultResolvers: List[Resolver],
     refreshBackoffPeriod: FiniteDuration,
-    exitCodePolicy: ExitCodePolicy
+    exitCodePolicy: ExitCodePolicy,
+    dryRun: Boolean
 ) {
   def forgeSpecificCfg: ForgeSpecificCfg =
     forgeCfg.tpe match {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -37,7 +37,13 @@ import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.edit.hooks.HookExecutor
 import org.scalasteward.core.edit.scalafix.*
 import org.scalasteward.core.edit.update.ScannerAlg
-import org.scalasteward.core.forge.{ForgeApiAlg, ForgeAuthAlg, ForgeRepoAlg, ForgeSelection}
+import org.scalasteward.core.forge.{
+  DryRunForgeApiAlg,
+  ForgeApiAlg,
+  ForgeAuthAlg,
+  ForgeRepoAlg,
+  ForgeSelection
+}
 import org.scalasteward.core.git.{GenGitAlg, GitAlg}
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.{
@@ -46,7 +52,11 @@ import org.scalasteward.core.nurture.{
   PullRequestService,
   UpdateInfoUrlFinder
 }
-import org.scalasteward.core.persistence.{CachingKeyValueStore, JsonKeyValueStore}
+import org.scalasteward.core.persistence.{
+  CachingKeyValueStore,
+  DryRunKeyValueStore,
+  JsonKeyValueStore
+}
 import org.scalasteward.core.repocache.*
 import org.scalasteward.core.repoconfig.{RepoConfigAlg, RepoConfigLoader}
 import org.scalasteward.core.scalafmt.ScalafmtAlg
@@ -169,13 +179,18 @@ object Context {
       implicit val hookExecutor: HookExecutor[F] = new HookExecutor[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
         new RepoCacheRepository[F](repoCacheStore)
-      implicit val forgeApiAlg: ForgeApiAlg[F] = ForgeSelection
-        .forgeApiAlg[F](config.forgeCfg, config.forgeSpecificCfg, forgeAuthAlg.authenticateApi)
+      implicit val forgeApiAlg: ForgeApiAlg[F] = {
+        val baseForgeApiAlg = ForgeSelection
+          .forgeApiAlg[F](config.forgeCfg, config.forgeSpecificCfg, forgeAuthAlg.authenticateApi)
+        if (config.dryRun) new DryRunForgeApiAlg[F](baseForgeApiAlg) else baseForgeApiAlg
+      }
       implicit val forgeRepoAlg: ForgeRepoAlg[F] = new ForgeRepoAlg[F](config)
       implicit val forgeCfg: ForgeCfg = config.forgeCfg
       implicit val updateInfoUrlFinder: UpdateInfoUrlFinder[F] = new UpdateInfoUrlFinder[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
-        new PullRequestRepository[F](pullRequestsStore)
+        new PullRequestRepository[F](
+          if (config.dryRun) new DryRunKeyValueStore(pullRequestsStore) else pullRequestsStore
+        )
       implicit val pullRequestService: PullRequestService[F] =
         new PullRequestService[F](pullRequestRepository, forgeApiAlg)
       implicit val scalafixCli: ScalafixCli[F] = new ScalafixCli[F]
@@ -197,7 +212,7 @@ object Context {
       implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F](config)
       implicit val scannerAlg: ScannerAlg[F] = new ScannerAlg[F]
       implicit val editAlg: EditAlg[F] = new EditAlg[F]
-      implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F](config.forgeCfg)
+      implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F](config.forgeCfg, config.dryRun)
       implicit val pruningAlg: PruningAlg[F] = new PruningAlg[F]
       implicit val reposFilesLoader: ReposFilesLoader[F] = new ReposFilesLoader[F]
       implicit val stewardAlg: StewardAlg[F] = new StewardAlg[F](config)

--- a/modules/core/src/main/scala/org/scalasteward/core/forge/DryRunForgeApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/forge/DryRunForgeApiAlg.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.forge
+
+import cats.Monad
+import cats.syntax.all.*
+import org.http4s.Uri
+import org.scalasteward.core.data.Repo
+import org.scalasteward.core.forge.data.*
+import org.scalasteward.core.git.Branch
+import org.typelevel.log4cats.Logger
+
+/** A [[ForgeApiAlg]] decorator that turns all forge-mutating operations (creating forks, creating,
+  * updating, closing and commenting on pull requests) into no-ops that only log what would have
+  * happened. Read-only operations are delegated to `underlying`.
+  *
+  * This is used to implement the `--dry-run` mode.
+  */
+final class DryRunForgeApiAlg[F[_]](underlying: ForgeApiAlg[F])(implicit
+    logger: Logger[F],
+    F: Monad[F]
+) extends ForgeApiAlg[F] {
+  override def createFork(repo: Repo): F[RepoOut] =
+    logger.info(s"[dry-run] Would create a fork of ${repo.show}") >> underlying.getRepo(repo)
+
+  override def createPullRequest(repo: Repo, data: NewPullRequestData): F[PullRequestOut] =
+    logger
+      .info(s"[dry-run] Would create PR '${data.title}' in ${repo.show}")
+      .as(PullRequestOut(DryRunForgeApiAlg.url, PullRequestState.Open, DryRunForgeApiAlg.number, data.title))
+
+  override def getPullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    underlying.getPullRequest(repo, number)
+
+  override def updatePullRequest(
+      number: PullRequestNumber,
+      repo: Repo,
+      data: NewPullRequestData
+  ): F[Unit] =
+    logger.info(s"[dry-run] Would update PR #${number.value} in ${repo.show}")
+
+  override def closePullRequest(repo: Repo, number: PullRequestNumber): F[PullRequestOut] =
+    logger.info(s"[dry-run] Would close PR #${number.value} in ${repo.show}") >>
+      underlying.getPullRequest(repo, number)
+
+  override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
+    underlying.getBranch(repo, branch)
+
+  override def getRepo(repo: Repo): F[RepoOut] =
+    underlying.getRepo(repo)
+
+  override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
+    underlying.listPullRequests(repo, head, base)
+
+  override def commentPullRequest(
+      repo: Repo,
+      number: PullRequestNumber,
+      comment: String
+  ): F[Comment] =
+    logger.info(s"[dry-run] Would comment on PR #${number.value} in ${repo.show}").as(Comment(comment))
+}
+
+object DryRunForgeApiAlg {
+  private val number: PullRequestNumber = PullRequestNumber(0)
+  private val url: Uri = Uri.unsafeFromString("https://scala-steward.org/dry-run")
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -35,7 +35,7 @@ import org.scalasteward.core.util.{Nel, UrlChecker}
 import org.scalasteward.core.{git, util}
 import org.typelevel.log4cats.Logger
 
-final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
+final class NurtureAlg[F[_]](config: ForgeCfg, dryRun: Boolean)(implicit
     coursierAlg: CoursierAlg[F],
     editAlg: EditAlg[F],
     forgeApiAlg: ForgeApiAlg[F],
@@ -149,10 +149,13 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
   }
 
   private def deleteRemoteBranch(repo: Repo, branch: Branch): F[Unit] =
-    logger.attemptWarn.log_(s"Deleting remote branch ${branch.name} failed") {
-      val remoteBranch = branch.withPrefix("origin/")
-      gitAlg.branchExists(repo, remoteBranch).ifM(gitAlg.deleteRemoteBranch(repo, branch), F.unit)
-    }
+    if (dryRun)
+      logger.info(s"[dry-run] Would delete remote branch ${branch.name}")
+    else
+      logger.attemptWarn.log_(s"Deleting remote branch ${branch.name} failed") {
+        val remoteBranch = branch.withPrefix("origin/")
+        gitAlg.branchExists(repo, remoteBranch).ifM(gitAlg.deleteRemoteBranch(repo, branch), F.unit)
+      }
 
   private def applyNewUpdate(data: UpdateData): F[ProcessResult] =
     gitAlg.returnToCurrentBranch(data.repo) {
@@ -176,6 +179,8 @@ final class NurtureAlg[F[_]](config: ForgeCfg)(implicit
 
   private def pushCommits(data: UpdateData, commits: List[Commit]): F[ProcessResult] =
     if (commits.isEmpty) F.pure[ProcessResult](Ignored)
+    else if (dryRun)
+      logger.info(s"[dry-run] Would push ${commits.length} commit(s)").as(Updated)
     else
       for {
         _ <- logger.info(s"Push ${commits.length} commit(s)")

--- a/modules/core/src/main/scala/org/scalasteward/core/persistence/DryRunKeyValueStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/persistence/DryRunKeyValueStore.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.persistence
+
+import cats.Applicative
+
+/** A [[KeyValueStore]] decorator whose writes are no-ops, leaving the persisted state untouched.
+  * Reads are delegated to `underlying`.
+  *
+  * This is used in `--dry-run` mode to avoid recording fabricated pull requests, which would
+  * otherwise poison subsequent real runs (e.g. cooldown and obsolete-PR handling).
+  */
+final class DryRunKeyValueStore[F[_], K, V](underlying: KeyValueStore[F, K, V])(implicit
+    F: Applicative[F]
+) extends KeyValueStore[F, K, V] {
+  override def get(key: K): F[Option[V]] = underlying.get(key)
+
+  override def set(key: K, value: Option[V]): F[Unit] = F.unit
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -94,6 +94,24 @@ class CliTest extends FunSuite {
     assertEquals(obtained.forgeCfg.login, "e")
   }
 
+  test("parseArgs: dry-run defaults to false") {
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
+      minimumRequiredParams.flatten
+    ): @unchecked
+
+    assert(!obtained.dryRun)
+    assert(!obtained.forgeCfg.doNotFork)
+  }
+
+  test("parseArgs: dry-run implies do-not-fork") {
+    val Success(Usage.Regular(obtained)) = Cli.parseArgs(
+      (minimumRequiredParams :+ List("--dry-run")).flatten
+    ): @unchecked
+
+    assert(obtained.dryRun)
+    assert(obtained.forgeCfg.doNotFork)
+  }
+
   test("parseArgs: enable sandbox") {
     val Success(Usage.Regular(obtained)) = Cli.parseArgs(
       List(

--- a/modules/core/src/test/scala/org/scalasteward/core/forge/DryRunForgeApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/forge/DryRunForgeApiAlgTest.scala
@@ -1,0 +1,91 @@
+package org.scalasteward.core.forge
+
+import cats.effect.unsafe.implicits.global
+import munit.FunSuite
+import org.scalasteward.core.data.Repo
+import org.scalasteward.core.forge.data.{
+  Comment,
+  NewPullRequestData,
+  PullRequestNumber,
+  PullRequestState
+}
+import org.scalasteward.core.git.Branch
+import org.scalasteward.core.mock.MockForgeApiAlg.{MockForgeState, RepoState}
+import org.scalasteward.core.mock.MockState.TraceEntry.Log
+import org.scalasteward.core.mock.{MockEff, MockEffOps, MockForgeApiAlg, MockLogger, MockState}
+import org.typelevel.log4cats.Logger
+
+class DryRunForgeApiAlgTest extends FunSuite {
+  private implicit val logger: Logger[MockEff] = new MockLogger
+  private val underlying = MockForgeApiAlg.mockApiAlg
+  private val dryRun = new DryRunForgeApiAlg[MockEff](underlying)
+
+  private val repo = Repo("example-org", "example-repo")
+  private val stateWithRepo: MockState =
+    MockState.empty.copy(forgeState = MockForgeState(repos = Map(repo -> RepoState())))
+
+  private val prData = NewPullRequestData(
+    title = "Update foo to 1.2.3",
+    body = "body",
+    head = "update/foo-1.2.3",
+    base = Branch("main"),
+    labels = Nil,
+    assignees = Nil,
+    reviewers = Nil
+  )
+
+  test("createPullRequest does not open a PR, returns a placeholder, and logs") {
+    val (finalState, pr) =
+      dryRun.createPullRequest(repo, prData).runSA(stateWithRepo).unsafeRunSync()
+
+    assertEquals(pr.number, PullRequestNumber(0))
+    assertEquals(pr.state, PullRequestState.Open)
+    assertEquals(pr.title, prData.title)
+    // The forge state is untouched: no PR was created.
+    assertEquals(finalState.forgeState.repos(repo), RepoState())
+    assert(finalState.trace.exists {
+      case Log((_, msg)) => msg.contains("[dry-run]")
+      case _             => false
+    })
+  }
+
+  test("updatePullRequest does not modify the forge state") {
+    val finalState =
+      dryRun.updatePullRequest(PullRequestNumber(1), repo, prData).runS(stateWithRepo).unsafeRunSync()
+
+    assertEquals(finalState.forgeState.repos(repo), RepoState())
+  }
+
+  test("closePullRequest does not close the PR and reads it back") {
+    val (finalState, (open, closeResult)) = (for {
+      open <- underlying.createPullRequest(repo, prData)
+      closeResult <- dryRun.closePullRequest(repo, open.number)
+    } yield (open, closeResult)).runSA(stateWithRepo).unsafeRunSync()
+
+    // The read-back returns the still-open PR ...
+    assertEquals(closeResult.number, open.number)
+    assertEquals(closeResult.state, PullRequestState.Open)
+    // ... and it stays open in the forge state.
+    assertEquals(
+      finalState.forgeState.repos(repo).prs(open.number).current.state,
+      PullRequestState.Open
+    )
+  }
+
+  test("commentPullRequest does not post and echoes the comment") {
+    val (finalState, comment) =
+      dryRun.commentPullRequest(repo, PullRequestNumber(1), "hello").runSA(stateWithRepo).unsafeRunSync()
+
+    assertEquals(comment, Comment("hello"))
+    assertEquals(finalState.forgeState.repos(repo), RepoState())
+  }
+
+  test("getPullRequest delegates to the underlying forge") {
+    val (created, fetched) = (for {
+      created <- underlying.createPullRequest(repo, prData)
+      fetched <- dryRun.getPullRequest(repo, created.number)
+    } yield (created, fetched)).runA(stateWithRepo).unsafeRunSync()
+
+    assertEquals(fetched, created)
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockConfig.scala
@@ -8,7 +8,9 @@ import scala.io.Source
 
 object MockConfig {
   val mockRoot: File = File.temp / "scala-steward"
-  val reposFile: Uri = Uri.unsafeFromString((mockRoot / "repos.md").pathAsString)
+  // Build a proper file: URI (e.g. file:///C:/.../repos.md) so this works on Windows too,
+  // where a raw path like C:\...\repos.md is not a valid URI.
+  val reposFile: Uri = Uri.unsafeFromString((mockRoot / "repos.md").path.toUri.toString)
   mockRoot.delete(swallowIOExceptions = true) // Ensure folder is cleared of previous test files
 
   mockRoot.createDirectory()

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/DryRunKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/DryRunKeyValueStoreTest.scala
@@ -1,0 +1,47 @@
+package org.scalasteward.core.persistence
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import munit.FunSuite
+
+class DryRunKeyValueStoreTest extends FunSuite {
+  private def inMemory(
+      initial: Map[String, String]
+  ): IO[(Ref[IO, Map[String, String]], KeyValueStore[IO, String, String])] =
+    Ref[IO].of(initial).map { ref =>
+      val underlying = new KeyValueStore[IO, String, String] {
+        override def get(key: String): IO[Option[String]] = ref.get.map(_.get(key))
+        override def set(key: String, value: Option[String]): IO[Unit] =
+          ref.update(m => value.fold(m - key)(v => m.updated(key, v)))
+      }
+      (ref, underlying)
+    }
+
+  test("set is a no-op and leaves the underlying store untouched") {
+    val (a, b, raw) = (for {
+      refAndStore <- inMemory(Map("a" -> "1"))
+      (ref, underlying) = refAndStore
+      store = new DryRunKeyValueStore(underlying)
+      _ <- store.set("a", Some("2"))
+      _ <- store.set("b", Some("3"))
+      a <- store.get("a")
+      b <- store.get("b")
+      raw <- ref.get
+    } yield (a, b, raw)).unsafeRunSync()
+
+    assertEquals(a, Some("1")) // get delegates; original value unchanged by the suppressed set
+    assertEquals(b, None) // the suppressed set did not add the key
+    assertEquals(raw, Map("a" -> "1")) // underlying store never written
+  }
+
+  test("get delegates to the underlying store") {
+    val got = (for {
+      refAndStore <- inMemory(Map("k" -> "v"))
+      (_, underlying) = refAndStore
+      store = new DryRunKeyValueStore(underlying)
+      got <- store.get("k")
+    } yield got).unsafeRunSync()
+
+    assertEquals(got, Some("v"))
+  }
+}

--- a/modules/docs/mdoc/running.md
+++ b/modules/docs/mdoc/running.md
@@ -104,6 +104,21 @@ JAVA_OPTS="-Dhttp.proxyHost=webcache.example.com -Dhttp.proxyPort=8080 -Dhttps.p
 
 See Oracle proxies documentation for more info.
 
+### Dry run
+
+The `--dry-run` option runs the full pipeline&mdash;cloning repositories, applying
+updates, and computing diffs&mdash;but skips every write to the forge and to the
+local pull request cache. Concretely, with `--dry-run` Scala Steward will not:
+
+* push branches or delete remote branches,
+* create, update, or close pull requests,
+* comment on pull requests, or
+* create forks (`--dry-run` implies `--do-not-fork`).
+
+Actions that would have been taken are logged with a `[dry-run]` prefix. This is
+useful for verifying configuration or previewing what Scala Steward would do
+without making any changes.
+
 ### Running locally from sbt
 
 #### Sample run for GitLab


### PR DESCRIPTION
## What

Adds a `--dry-run` command-line flag that runs the full Scala Steward
pipeline — cloning repositories, applying updates, and computing diffs —
but skips every write to the forge and to the local pull request cache.

With `--dry-run`, Scala Steward will not:

- push branches or delete remote branches,
- create, update, or close pull requests,
- comment on pull requests, or
- create forks (`--dry-run` implies `--do-not-fork`).

Actions that would otherwise be taken are logged with a `[dry-run]`
prefix. This is useful for verifying configuration or previewing what
Scala Steward would do without making any changes.

## How

The write suppression is implemented with decorators wired in `Context`
when `--dry-run` is set, keeping the change isolated and cross-compiling
on Scala 2.13 and 3:

- `DryRunForgeApiAlg` decorates `ForgeApiAlg`, neutralizing
  `createPullRequest`, `updatePullRequest`, `closePullRequest`,
  `commentPullRequest` and `createFork` while delegating all reads.
- `DryRunKeyValueStore` decorates the pull-request `KeyValueStore` so the
  local PR cache is never written.
- `NurtureAlg` skips `gitAlg.push` and `gitAlg.deleteRemoteBranch` under
  dry-run, logging what it would have done.

Unit tests cover both decorators and the new CLI flag; docs (`help.md`
and the running guide) are updated.

## Note

This PR also includes a small unrelated fix to `MockConfig` (test-only):
the repos-file `Uri` is now built via `path.toUri` instead of directly
from a filesystem path, so the mock test config initializes on Windows,
where a raw path such as `C:\...\repos.md` is not a valid URI. It is a
separate commit and can be dropped if you'd prefer it in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
