### PR TITLE
Add artifact migration for datadog4s move to io.github.datadog4s

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -1676,4 +1676,34 @@ changes = [
     groupIdAfter = org.typelevel
     artifactIdAfter = doobie-refined
   }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s
+  }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s-api
+  }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s-common
+  }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s-http4s
+  }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s-jvm
+  }
+  {
+    groupIdBefore = com.avast.cloud
+    groupIdAfter = io.github.datadog4s
+    artifactIdAfter = datadog4s-statsd
+  }
 ]


### PR DESCRIPTION
## What

Adds artifact migrations (v2) for the `datadog4s` group id change from `com.avast.cloud` to `io.github.datadog4s`.

## Why

Starting November 2025, datadog4s moved to a new group id `io.github.datadog4s` to decouple from Avast Software and ensure continuity of the project. See the migration notice: https://datadog4s.github.io/datadog4s/migration-to-io.github.html

## Details

All artifacts published under the old `com.avast.cloud` group id are datadog4s modules. This PR maps each to the new group id:

- `datadog4s`
- `datadog4s-api`
- `datadog4s-common`
- `datadog4s-http4s`
- `datadog4s-jvm`
- `datadog4s-statsd`

(`datadog4s-playground` is not published for consumption, so it is excluded.)

Maven Central listings:
- Old group id: https://repo1.maven.org/maven2/com/avast/cloud/ · https://central.sonatype.com/namespace/com.avast.cloud
- New group id: https://repo1.maven.org/maven2/io/github/datadog4s/ · https://central.sonatype.com/namespace/io.github.datadog4s

## Notes

This migration only covers the group id in build files (dependency coordinates). The classes were also moved to the `io.github.datadog4s` namespace, which is a source-level import change not covered by artifact migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)