### PR TITLE
Drop building with Java 11, add Java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         scala: [2.13, 3]
-        java: [temurin@21, temurin@17, temurin@11]
+        java: [temurin@25, temurin@21, temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -40,6 +40,19 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@25)
+        id: setup-java-temurin-25
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@25' && steps.setup-java-temurin-25.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@21)
         id: setup-java-temurin-21
@@ -65,19 +78,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@21]
+        java: [temurin@25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -127,6 +127,19 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@25)
+        id: setup-java-temurin-25
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@25' && steps.setup-java-temurin-25.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@21)
         id: setup-java-temurin-21
@@ -152,19 +165,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Download target directories (2.13)

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,12 +21,12 @@ pull_request_rules:
   - or:
     - author=scala-steward
     - author=scala-steward-dev
+  - status-success=Test (ubuntu-22.04, 2.13, temurin@25)
   - status-success=Test (ubuntu-22.04, 2.13, temurin@21)
   - status-success=Test (ubuntu-22.04, 2.13, temurin@17)
-  - status-success=Test (ubuntu-22.04, 2.13, temurin@11)
+  - status-success=Test (ubuntu-22.04, 3, temurin@25)
   - status-success=Test (ubuntu-22.04, 3, temurin@21)
   - status-success=Test (ubuntu-22.04, 3, temurin@17)
-  - status-success=Test (ubuntu-22.04, 3, temurin@11)
   actions:
     merge:
       method: merge

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / githubWorkflowPublish := Seq(
     name = Some("Publish Docker image")
   )
 )
-ThisBuild / githubWorkflowJavaVersions := Seq("21", "17", "11").map(JavaSpec(Temurin, _))
+ThisBuild / githubWorkflowJavaVersions := Seq("25", "21", "17").map(JavaSpec(Temurin, _))
 ThisBuild / githubWorkflowBuild :=
   Seq(
     WorkflowStep.Use(
@@ -302,7 +302,9 @@ lazy val commonSettings = Def.settings(
 
 lazy val compileSettings = Def.settings(
   scalaVersion := Scala213,
-  scalacOptions ++= {
+  scalacOptions ++= Seq(
+    "-java-output-version:17"
+  ) ++ {
     scalaBinaryVersion.value match {
       case "2.13" =>
         Seq("-Xsource:3-cross")

--- a/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/client/ClientConfiguration.scala
@@ -44,18 +44,7 @@ object ClientConfiguration {
   private def defaultHttpClient[F[_]: Async](bmw: BuilderMiddleware): F[HttpClient] =
     Async[F].executor.flatMap { exec =>
       Async[F].delay {
-        val builder = HttpClient.newBuilder()
-
-        if (Runtime.version().feature() == 11) {
-          val params = javax.net.ssl.SSLContext.getDefault().getDefaultSSLParameters()
-          params.setProtocols(params.getProtocols().filter(_ != "TLSv1.3"))
-          builder.sslParameters(params)
-          ()
-        }
-
-        builder.executor(exec)
-
-        bmw(builder).build()
+        bmw(HttpClient.newBuilder().executor(exec)).build()
       }
     }
 


### PR DESCRIPTION
Fixes #3924.

Having updated `build.sbt`...

https://github.com/scala-steward-org/scala-steward/blob/72ff5eede0a3eb9de33635a3628ccfce523688a7/build.sbt#L45

...I ran [`sbt githubWorkflowGenerate`](https://github.com/sbt/sbt-github-actions#tasks) to programmatically update `.github/workflows/ci.yml` with the resulting changes.

## See also

* #2746 & #2779
* https://github.com/scala-steward-org/scala-steward/pull/3836
