### PR TITLE
Avoid false "Unable to bump version" when shared version val already bumped

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,3 +114,26 @@ folder is persisted between different runs.
 
 That's where Steward holds intermediate state about dependency versions and created PRs which ultimately
 helps it make decisions about which PRs to close and which ones to keep open.
+
+## Why does a PR for a shared version variable only list one dependency?
+
+When several dependencies share the same version `val` (for example in
+`project/Dependencies.scala`), updating that variable can bump every dependency
+that references it. Scala Steward's PR title and description currently describe
+the update using the artifact that triggered the rewrite, which may be only the
+first matching dependency.
+
+Dependencies that share the same Maven `groupId` and version range are already
+combined into a single `Update.ForGroupId` PR that lists every artifact in the
+group. The incomplete listing shows up mainly when the shared variable is used
+across different group IDs (for example `com.fasterxml.jackson.core` and
+`com.fasterxml.jackson.datatype`).
+
+Workarounds until broader grouping improvements land:
+
+* Configure [`pullRequests.grouping`](repo-specific-configuration.md#pullrequestsgrouping)
+  so related artifacts are raised together and listed in one PR description.
+* Prefer a single Maven group ID for libraries that always share a version, when
+  that matches how the artifacts are published.
+
+See also issue [#3780](https://github.com/scala-steward-org/scala-steward/issues/3780).

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -50,7 +50,13 @@ final class EditAlg[F[_]](implicit
       preCommit: F[Unit] = F.unit
   ): F[List[EditAttempt]] =
     findUpdateReplacements(data.repo, data.config, update).flatMap {
-      case Nil => logger.warn(s"Unable to bump version for update ${update.show}").as(Nil)
+      case Nil =>
+        isAlreadyApplied(data.repo, data.config, update).flatMap {
+          case true =>
+            logger.info(s"Version already bumped for update ${update.show}").as(Nil)
+          case false =>
+            logger.warn(s"Unable to bump version for update ${update.show}").as(Nil)
+        }
       case updateReplacements =>
         for {
           _ <- preCommit
@@ -76,6 +82,13 @@ final class EditAlg[F[_]](implicit
       versionPositions <- scannerAlg.findVersionPositions(repo, config, update.currentVersion)
       modulePositions <- scannerAlg.findModulePositions(repo, config, update.dependencies)
     } yield Selector.select(update, versionPositions, modulePositions)
+
+
+  private def isAlreadyApplied(repo: Repo, config: RepoConfig, update: Update.Single): F[Boolean] =
+    for {
+      nextVersionPositions <- scannerAlg.findVersionPositions(repo, config, update.nextVersion)
+      modulePositions <- scannerAlg.findModulePositions(repo, config, update.dependencies)
+    } yield Selector.isAlreadyApplied(update, nextVersionPositions, modulePositions)
 
   private def runScalafixMigrations(
       repo: Repo,

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/update/Selector.scala
@@ -21,7 +21,7 @@ import cats.syntax.all.*
 import java.util.regex.Pattern
 import org.scalasteward.core.buildtool.mill.MillAlg
 import org.scalasteward.core.buildtool.sbt.{buildPropertiesName, isSbtUpdate}
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{CrossDependency, Dependency, Update}
 import org.scalasteward.core.edit.update.data.*
 import org.scalasteward.core.edit.update.data.VersionPosition.*
 import org.scalasteward.core.scalafmt.{isScalafmtCoreUpdate, scalafmtConfName}
@@ -220,4 +220,39 @@ object Selector {
           }
       }
     }
+
+  /** Returns true if the target version of `update` is already present in the positions that
+    * [[select]] would edit for this update. This happens when several dependencies share a version
+    * variable: updating the first dependency rewrites the shared `val`, so later updates for the
+    * remaining dependencies find nothing left to change.
+    */
+  def isAlreadyApplied(
+      update: Update.Single,
+      nextVersionPositions: List[VersionPosition],
+      modulePositions: List[ModulePosition]
+  ): Boolean = {
+    val swapped = withSwappedVersions(update)
+    select(swapped, nextVersionPositions, modulePositions).nonEmpty
+  }
+
+  private def withSwappedVersions(update: Update.Single): Update.Single = {
+    val current = update.nextVersion
+    val next = update.currentVersion
+    update match {
+      case u: Update.ForArtifactId =>
+        val deps = u.crossDependency.dependencies.map(_.copy(version = current))
+        u.copy(
+          artifactForUpdate = u.artifactForUpdate.copy(crossDependency = CrossDependency(deps)),
+          nextVersion = next
+        )
+      case u: Update.ForGroupId =>
+        val artifacts = u.artifactsForUpdate.map { artifact =>
+          val deps = artifact.crossDependency.dependencies.map(_.copy(version = current))
+          artifact.copy(crossDependency = CrossDependency(deps))
+        }
+        u.copy(artifactsForUpdate = artifacts, nextVersion = next)
+    }
+  }
+
+
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -285,4 +285,54 @@ class EditAlgTest extends FunSuite {
 
     assertEquals(state, expected)
   }
+  // Related to https://github.com/scala-steward-org/scala-steward/issues/3780 and
+  // https://github.com/scala-steward-org/scala-steward/issues/2906: when several
+  // dependencies share a version val, the first update rewrites the val so later
+  // updates should not log a misleading "Unable to bump version" warning.
+  test("applyUpdate does not warn when version was already bumped via shared val") {
+    val repo = Repo("edit-alg", "test-already-bumped")
+    val data = RepoData(repo, dummyRepoCache, RepoConfig.empty)
+    val repoDir = workspaceAlg.repoDir(repo).unsafeRunSync()
+    val buildSbt = repoDir / "build.sbt"
+    // Different groupIds so these are not merged by Update.groupByGroupId (see #3780).
+    val updateLibrary1 = ("com.foo.core".g % "library-1".a % "1.2.3" %> "1.3.0").single
+    val updateLibrary2 = ("com.foo.extra".g % "library-2".a % "1.2.3" %> "1.3.0").single
+    val original =
+      """val FooLibraryVersion = "1.2.3"
+        |libraryDependencies ++= Seq(
+        |  "com.foo.core" %% "library-1" % FooLibraryVersion,
+        |  "com.foo.extra" %% "library-2" % FooLibraryVersion
+        |)
+        |""".stripMargin
+
+    val state = MockState.empty
+      .copy(execCommands = true)
+      .initGitRepo(repoDir, buildSbt -> original)
+      .flatMap { s =>
+        editAlg.applyUpdate(data, updateLibrary1).runS(s).flatMap { s1 =>
+          editAlg.applyUpdate(data, updateLibrary2).runS(s1)
+        }
+      }
+      .unsafeRunSync()
+
+    val warnLogs = state.trace.collect {
+      case Log((_, msg)) if msg.contains("Unable to bump version") => msg
+    }
+    val infoLogs = state.trace.collect {
+      case Log((_, msg)) if msg.contains("Version already bumped") => msg
+    }
+    assertEquals(warnLogs, Vector.empty)
+    assert(infoLogs.exists(_.contains("library-2")))
+    assertEquals(
+      state.files(buildSbt),
+      """val FooLibraryVersion = "1.3.0"
+        |libraryDependencies ++= Seq(
+        |  "com.foo.core" %% "library-1" % FooLibraryVersion,
+        |  "com.foo.extra" %% "library-2" % FooLibraryVersion
+        |)
+        |""".stripMargin
+    )
+  }
+
+
 }


### PR DESCRIPTION
Issue #3780 already has WIP PR #3852 covering the full grouping/description fix. This adjacent fix addresses related #2906 (misleading warning when multiple deps share a version variable) and documents the #3780 limitation in faq.md.

References #3780 and #2906.