### PR TITLE
Add missing artifact migrations for org.scalatestplus artifacts

### DIFF
--- a/modules/core/src/main/resources/artifact-migrations.v2.conf
+++ b/modules/core/src/main/resources/artifact-migrations.v2.conf
@@ -704,13 +704,158 @@ changes = [
   },
   {
     groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-3-2
+    artifactIdAfter = easymock-4-3
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-4-3
+    artifactIdAfter = easymock-5-0
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-5-0
+    artifactIdAfter = easymock-5-1
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-5-1
+    artifactIdAfter = easymock-5-2
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-5-2
+    artifactIdAfter = easymock-5-3
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = easymock-5-3
+    artifactIdAfter = easymock-5-6
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = jmock-2-8
+    artifactIdAfter = jmock-2-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = jmock-2-12
+    artifactIdAfter = jmock-2-13
+  },
+  {
+    groupIdAfter = org.scalatestplus
     artifactIdBefore = junit-4-12
     artifactIdAfter = junit-4-13
   },
   {
     groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-4-13
+    artifactIdAfter = junit-5-9
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-5-9
+    artifactIdAfter = junit-5-10
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-5-10
+    artifactIdAfter = junit-5-11
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-5-11
+    artifactIdAfter = junit-5-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-5-12
+    artifactIdAfter = junit-5-13
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = junit-5-13
+    artifactIdAfter = junit-5-14
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-1-10
+    artifactIdAfter = mockito-3-2
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-3-2
+    artifactIdAfter = mockito-3-3
+  },
+  {
+    groupIdAfter = org.scalatestplus
     artifactIdBefore = mockito-3-3
     artifactIdAfter = mockito-3-4
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-3-4
+    artifactIdAfter = mockito-3-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-3-12
+    artifactIdAfter = mockito-4-2
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-4-2
+    artifactIdAfter = mockito-4-5
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-4-5
+    artifactIdAfter = mockito-4-6
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-4-6
+    artifactIdAfter = mockito-4-11
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-4-11
+    artifactIdAfter = mockito-5-8
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-8
+    artifactIdAfter = mockito-5-10
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-10
+    artifactIdAfter = mockito-5-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-12
+    artifactIdAfter = mockito-5-14
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-14
+    artifactIdAfter = mockito-5-18
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-18
+    artifactIdAfter = mockito-5-19
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-19
+    artifactIdAfter = mockito-5-21
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = mockito-5-21
+    artifactIdAfter = mockito-5-23
   },
   {
     groupIdAfter = org.scalatestplus
@@ -724,13 +869,118 @@ changes = [
   },
   {
     groupIdAfter = org.scalatestplus
+    artifactIdBefore = scalacheck-1-16
+    artifactIdAfter = scalacheck-1-17
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = scalacheck-1-17
+    artifactIdAfter = scalacheck-1-18
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = scalacheck-1-18
+    artifactIdAfter = scalacheck-1-19
+  },
+  {
+    groupIdAfter = org.scalatestplus
     artifactIdBefore = testng-6-7
     artifactIdAfter = testng-7-5
   },
   {
     groupIdAfter = org.scalatestplus
+    artifactIdBefore = testng-7-5
+    artifactIdAfter = testng-7-6
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = testng-7-6
+    artifactIdAfter = testng-7-9
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = testng-7-9
+    artifactIdAfter = testng-7-10
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = testng-7-10
+    artifactIdAfter = testng-7-11
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = testng-7-11
+    artifactIdAfter = testng-7-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-2-45
+    artifactIdAfter = selenium-3-141
+  },
+  {
+    groupIdAfter = org.scalatestplus
     artifactIdBefore = selenium-3-141
     artifactIdAfter = selenium-4-1
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-1
+    artifactIdAfter = selenium-4-2
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-2
+    artifactIdAfter = selenium-4-4
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-4
+    artifactIdAfter = selenium-4-6
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-6
+    artifactIdAfter = selenium-4-7
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-7
+    artifactIdAfter = selenium-4-9
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-9
+    artifactIdAfter = selenium-4-12
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-12
+    artifactIdAfter = selenium-4-13
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-13
+    artifactIdAfter = selenium-4-16
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-16
+    artifactIdAfter = selenium-4-17
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-17
+    artifactIdAfter = selenium-4-21
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-21
+    artifactIdAfter = selenium-4-35
+  },
+  {
+    groupIdAfter = org.scalatestplus
+    artifactIdBefore = selenium-4-35
+    artifactIdAfter = selenium-4-41
   },
   {
     groupIdBefore = io.github.nafg


### PR DESCRIPTION
The `org.scalatestplus` wrappers encode the wrapped library's version in the artifact name (`mockito-5-12`, `scalacheck-1-18`, ...). Without an artifact migration, Scala Steward considers e.g. `mockito-5-12` up to date at 3.2.19.0 forever, so dependents never move to the newer wrappers. We hit this across our fleet: dozens of repos frozen on `mockito-5-12` / `scalacheck-1-18` despite Steward running on all of them.

The existing migrations stop at `scalacheck-1-15 → 1-16`, `mockito-3-3 → 3-4`, `junit-4-12 → 4-13`, `testng-6-7 → 7-5` and `selenium-3-141 → 4-1`. This PR adds the 50 missing links for all `org.scalatestplus` families — easymock, jmock, junit, mockito, scalacheck, selenium, testng — up to the latest artifacts published on Maven Central (`mockito-5-23`, `scalacheck-1-19`, `junit-5-14`, `testng-7-12`, `selenium-4-41`, `easymock-5-6`, `jmock-2-13`).

Each entry follows the file's existing convention: it points to the next artifact published on Maven Central, so chains converge one step per Steward run.

One entry worth calling out: `junit-4-13 → junit-5-9` crosses the JUnit 4 → Jupiter boundary. It follows the same precedent as the existing `testng-6-7 → testng-7-5` and `selenium-3-141 → selenium-4-1` major jumps, but happy to drop it if you consider it too aggressive.

`BuiltinConfigFilesTest` passes locally (3 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
