### PR TITLE
Block upgrades for Scala 3.10 and add directives-parser exclusion rule

### DIFF
--- a/modules/core/src/main/resources/default.scala-steward.conf
+++ b/modules/core/src/main/resources/default.scala-steward.conf
@@ -31,6 +31,21 @@ updates.ignore = [
   // Artifacts below are ignored because they are not yet announced.
 
   // Ignore the next Scala 3 Next version until it is announced.
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler",                      version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library",                       version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1",                  version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1_3",                version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala-library",                        version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "tasty-core",                           version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-sbt-bridge",                    version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-presentation-compiler",         version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-repl",                          version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-staging",                       version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-directives-parser",             version = { exact = "3.10.0" } },
+  { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.10.0" } },
+
+  // Ignore the next Scala 3.9 LTS version until it is announced.
   { groupId = "org.scala-lang", artifactId = "scala3-compiler",                      version = { exact = "3.9.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library",                       version = { exact = "3.9.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1",                  version = { exact = "3.9.0" } },
@@ -42,6 +57,7 @@ updates.ignore = [
   { groupId = "org.scala-lang", artifactId = "scala3-repl",                          version = { exact = "3.9.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-staging",                       version = { exact = "3.9.0" } },
   { groupId = "org.scala-lang", artifactId = "scala3-tasty-inspector",               version = { exact = "3.9.0" } },
+  { groupId = "org.scala-lang", artifactId = "scala3-directives-parser",             version = { exact = "3.9.0" } },
   { groupId = "org.scala-lang", artifactId = "scaladoc",                             version = { exact = "3.9.0" } },
 
   // Ignore the Scala 3.6.1 - abandoned hotfix to broken release 3.6.0


### PR DESCRIPTION
As we're starting the releases for 3.10.0-RC1 we setup the block rules. 
`scala3-directives-parser` is a new artifact introduced 3.9.0 