### PR TITLE
feat: update generated GitHub workflows instead of regenerating

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -32,6 +32,7 @@ import org.scalasteward.core.git.{gitBlameIgnoreRevsName, Commit, CommitMsg, Git
 import org.scalasteward.core.io.process.SlurpOptions
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.repocache.RepoCache
+import org.scalasteward.core.repoconfig.WorkflowTask
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtGroupId, ScalafmtAlg}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.logger.*
@@ -147,28 +148,30 @@ object HookExecutor {
   private val conditionalSbtGitHubWorkflowGenerateModules =
     (sbtGroupId, sbtArtifactId) :: (sbtScalafixGroupId, sbtScalafixArtifactId) :: scalaLangModules
 
-  private def sbtGithubWorkflowGenerateCommand(
+  private def sbtGithubWorkflowCommand(
       groupId: GroupId,
-      artifactId: ArtifactId
+      artifactId: ArtifactId,
+      workflowTask: WorkflowTask
   ): Nel[String] =
     if ((groupId, artifactId) == (GroupId("dev.zio"), ArtifactId("zio-sbt-ci")))
       Nel.of("sbt", "ciGenerateGithubWorkflow")
     else
-      Nel.of("sbt", "githubWorkflowUpdate")
+      Nel.of("sbt", workflowTask.taskName)
 
-  private def sbtGithubWorkflowGenerateHook(
+  private def sbtGithubWorkflowHook(
       groupId: GroupId,
       artifactId: ArtifactId,
+      workflowTask: WorkflowTask,
       enabledByCache: RepoCache => Boolean
   ): PostUpdateHook =
     PostUpdateHook(
       groupId = Some(groupId),
       artifactId = Some(artifactId),
-      command = sbtGithubWorkflowGenerateCommand(groupId, artifactId),
+      command = sbtGithubWorkflowCommand(groupId, artifactId, workflowTask),
       useSandbox = true,
       commitMessage = _ => CommitMsg("Update generated GitHub Actions workflow"),
       enabledByCache = enabledByCache,
-      enabledByConfig = _ => true,
+      enabledByConfig = _.sbtGithubActionsOrDefault.workflowTaskOrDefault == workflowTask,
       addToGitBlameIgnoreRevs = false
     )
 
@@ -204,11 +207,17 @@ object HookExecutor {
 
   private val postUpdateHooks: List[PostUpdateHook] =
     scalafmtHook ::
-      sbtGitHubWorkflowGenerateModules.map { case (gid, aid) =>
-        sbtGithubWorkflowGenerateHook(gid, aid, _ => true)
+      sbtGitHubWorkflowGenerateModules.flatMap { case (gid, aid) =>
+        Seq(
+          sbtGithubWorkflowHook(gid, aid, WorkflowTask.Generate, _ => true),
+          sbtGithubWorkflowHook(gid, aid, WorkflowTask.Update, _ => true)
+        )
       } ++
-      conditionalSbtGitHubWorkflowGenerateModules.map { case (gid, aid) =>
-        sbtGithubWorkflowGenerateHook(gid, aid, githubWorkflowGenerateExists)
+      conditionalSbtGitHubWorkflowGenerateModules.flatMap { case (gid, aid) =>
+        Seq(
+          sbtGithubWorkflowHook(gid, aid, WorkflowTask.Generate, githubWorkflowGenerateExists),
+          sbtGithubWorkflowHook(gid, aid, WorkflowTask.Update, githubWorkflowGenerateExists)
+        )
       } ++
       sbtTypelevelModules.map { case (gid, aid) => sbtTypelevelHook(gid, aid) }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/hooks/HookExecutor.scala
@@ -154,7 +154,7 @@ object HookExecutor {
     if ((groupId, artifactId) == (GroupId("dev.zio"), ArtifactId("zio-sbt-ci")))
       Nel.of("sbt", "ciGenerateGithubWorkflow")
     else
-      Nel.of("sbt", "githubWorkflowGenerate")
+      Nel.of("sbt", "githubWorkflowUpdate")
 
   private def sbtGithubWorkflowGenerateHook(
       groupId: GroupId,
@@ -166,7 +166,7 @@ object HookExecutor {
       artifactId = Some(artifactId),
       command = sbtGithubWorkflowGenerateCommand(groupId, artifactId),
       useSandbox = true,
-      commitMessage = _ => CommitMsg("Regenerate GitHub Actions workflow"),
+      commitMessage = _ => CommitMsg("Update generated GitHub Actions workflow"),
       enabledByCache = enabledByCache,
       enabledByConfig = _ => true,
       addToGitBlameIgnoreRevs = false

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,6 +31,7 @@ final case class RepoConfig(
     private val pullRequests: Option[PullRequestsConfig] = None,
     private val scalafmt: Option[ScalafmtConfig] = None,
     private val updates: Option[UpdatesConfig] = None,
+    private val sbtGithubActions: Option[SbtGithubActionsConfig] = None,
     private val postUpdateHooks: Option[List[PostUpdateHookConfig]] = None,
     private val updatePullRequests: Option[PullRequestUpdateStrategy] = None,
     private val buildRoots: Option[List[BuildRootConfig]] = None,
@@ -50,6 +51,9 @@ final case class RepoConfig(
 
   def updatesOrDefault: UpdatesConfig =
     updates.getOrElse(UpdatesConfig())
+
+  def sbtGithubActionsOrDefault: SbtGithubActionsConfig =
+    sbtGithubActions.getOrElse(SbtGithubActionsConfig())
 
   def buildRootsOrDefault(repo: Repo): List[BuildRoot] =
     buildRoots
@@ -101,6 +105,7 @@ object RepoConfig {
               pullRequests = x.pullRequests |+| y.pullRequests,
               scalafmt = x.scalafmt |+| y.scalafmt,
               updates = x.updates |+| y.updates,
+              sbtGithubActions = x.sbtGithubActions |+| y.sbtGithubActions,
               postUpdateHooks = x.postUpdateHooks |+| y.postUpdateHooks,
               updatePullRequests = x.updatePullRequests.orElse(y.updatePullRequests),
               buildRoots = x.buildRoots |+| y.buildRoots,

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/SbtGithubActionsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/SbtGithubActionsConfig.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.{Eq, Monoid}
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+
+final case class SbtGithubActionsConfig(
+    private val workflowTask: Option[WorkflowTask] = None
+) {
+  def workflowTaskOrDefault: WorkflowTask =
+    workflowTask.getOrElse(SbtGithubActionsConfig.defaultWorkflowTask)
+}
+
+object SbtGithubActionsConfig {
+  val defaultWorkflowTask: WorkflowTask = WorkflowTask.default
+
+  implicit val sbtGithubActionsConfigEq: Eq[SbtGithubActionsConfig] =
+    Eq.fromUniversalEquals
+
+  implicit val sbtGithubActionsCodec: Codec[SbtGithubActionsConfig] =
+    deriveCodec
+
+  implicit val scalafmtConfigMonoid: Monoid[SbtGithubActionsConfig] =
+    Monoid.instance(
+      SbtGithubActionsConfig(),
+      (x, y) => SbtGithubActionsConfig(workflowTask = x.workflowTask.orElse(y.workflowTask))
+    )
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/WorkflowTask.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/WorkflowTask.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2025 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.Eq
+import io.circe.{Decoder, Encoder}
+import org.apache.commons.lang3.StringUtils
+
+sealed trait WorkflowTask {
+  def name: String
+  def taskName: String = s"githubWorkflow${StringUtils.capitalize(name)}"
+}
+
+object WorkflowTask {
+  case object Generate extends WorkflowTask { val name = "generate" }
+  case object Update extends WorkflowTask { val name = "update" }
+
+  // To switch to Update once sbt-typelevel ships the task
+  // and pre-0.32.0 versions of sbt-github-actions age out
+  val default: WorkflowTask = Generate
+
+  def fromString(value: String): WorkflowTask =
+    value.trim.toLowerCase match {
+      case Generate.name => Generate
+      case Update.name   => Update
+      case _             => default
+    }
+
+  implicit val workflowTaskDecoder: Decoder[WorkflowTask] =
+    Decoder[String].map(fromString)
+
+  implicit val workflowTaskEncoder: Encoder[WorkflowTask] =
+    Encoder[String].contramap(_.name)
+
+  implicit val workflowTaskEq: Eq[WorkflowTask] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -128,10 +128,18 @@ object TestInstances {
       )
     )
 
+  implicit val workflowTaskArbitrary: Arbitrary[WorkflowTask] =
+    Arbitrary(Gen.oneOf(WorkflowTask.Generate, WorkflowTask.Update))
+
   implicit val scalafmtConfigArbitrary: Arbitrary[ScalafmtConfig] =
     Arbitrary(for {
       runAfterUpgrading <- Arbitrary.arbitrary[Option[Boolean]]
     } yield ScalafmtConfig(runAfterUpgrading))
+
+  implicit val sbtGithubActionsConfigArbitrary: Arbitrary[SbtGithubActionsConfig] =
+    Arbitrary(for {
+      workflowTask <- Arbitrary.arbitrary[Option[WorkflowTask]]
+    } yield SbtGithubActionsConfig(workflowTask))
 
   implicit val updatePatternArbitrary: Arbitrary[UpdatePattern] =
     Arbitrary(for {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -12,7 +12,13 @@ import org.scalasteward.core.io.{process, FileAlgTest}
 import org.scalasteward.core.mock.MockContext.context.{hookExecutor, workspaceAlg}
 import org.scalasteward.core.mock.MockState.TraceEntry.{Cmd, Log}
 import org.scalasteward.core.mock.{MockEffOps, MockState}
-import org.scalasteward.core.repoconfig.{PostUpdateHookConfig, RepoConfig, ScalafmtConfig}
+import org.scalasteward.core.repoconfig.{
+  PostUpdateHookConfig,
+  RepoConfig,
+  SbtGithubActionsConfig,
+  ScalafmtConfig,
+  WorkflowTask
+}
 import org.scalasteward.core.scalafmt.ScalafmtAlg.opts
 import org.scalasteward.core.scalafmt.{scalafmtArtifactId, scalafmtBinary, scalafmtGroupId}
 import org.scalasteward.core.util.Nel
@@ -102,6 +108,28 @@ class HookExecutorTest extends CatsEffectSuite {
   }
 
   test("sbt-github-actions") {
+    val update = ("com.codecommit".g % "sbt-github-actions".a % "0.9.4" %> "0.9.5").single
+    val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
+
+    val expected = MockState.empty.copy(
+      trace = Vector(
+        Log(
+          "Executing post-update hook for com.codecommit:sbt-github-actions with command 'sbt githubWorkflowGenerate'"
+        ),
+        Cmd.execSandboxed(repoDir, "sbt", "githubWorkflowGenerate"),
+        Cmd.gitStatus(repoDir)
+      )
+    )
+
+    state.map(assertEquals(_, expected))
+  }
+
+  test("sbt-github-actions update") {
+    val repoConfig =
+      RepoConfig.empty.copy(sbtGithubActions =
+        SbtGithubActionsConfig(workflowTask = Some(WorkflowTask.Update)).some
+      )
+    val data = RepoData(repo, dummyRepoCache, repoConfig)
     val update = ("com.codecommit".g % "sbt-github-actions".a % "0.9.4" %> "0.9.5").single
     val state = hookExecutor.execPostUpdateHooks(data, update).runS(MockState.empty)
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/hooks/HookExecutorTest.scala
@@ -108,9 +108,9 @@ class HookExecutorTest extends CatsEffectSuite {
     val expected = MockState.empty.copy(
       trace = Vector(
         Log(
-          "Executing post-update hook for com.codecommit:sbt-github-actions with command 'sbt githubWorkflowGenerate'"
+          "Executing post-update hook for com.codecommit:sbt-github-actions with command 'sbt githubWorkflowUpdate'"
         ),
-        Cmd.execSandboxed(repoDir, "sbt", "githubWorkflowGenerate"),
+        Cmd.execSandboxed(repoDir, "sbt", "githubWorkflowUpdate"),
         Cmd.gitStatus(repoDir)
       )
     )


### PR DESCRIPTION
This is useful for projects that want to refer to actions by hash instead of tag (and manage that through for example dependabot), but still want to use sbt-github-actions to manage the rest of the workflow.

This is a [new feature](https://github.com/sbt/sbt-github-actions/pull/230) in sbt-github-actions 0.32.0