### PR TITLE
Handle Scala 3.9.x as LTS

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/package.scala
@@ -48,7 +48,5 @@ package object data {
   val scalaLangModules: List[(GroupId, ArtifactId)] =
     scala2LangModules ++ scala3LangModules
 
-  val scalaNextMinVersion: Version = Version("3.4.0-NIGHTLY")
-
   val scala38: Version = Version("3.8.0-NIGHTLY")
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -77,14 +77,20 @@ object FilterAlg {
       .flatMap(scalaLTSFilter)
       .flatMap(globalFilter(_, repoConfig))
 
+  private def isScalaLtsVersion(version: Version): Boolean =
+    version.value.startsWith("3.3.") || version.value.startsWith("3.9.")
+
   def scalaLTSFilter(update: ArtifactUpdateCandidates): FilterResult =
     if (isScala3Lang(update)) {
-      if (update.artifactForUpdate.currentVersion >= scalaNextMinVersion) {
+      if (
+        update.artifactForUpdate.currentVersion.value.startsWith("3.") &&
+        !isScalaLtsVersion(update.artifactForUpdate.currentVersion)
+      ) {
         // already on Scala Next
         Right(update)
       } else {
-        // on Scala 3.3.x, just keep LTS versions
-        update.filterVersions(_ < scalaNextMinVersion).toRight(IgnoreScalaNext(update))
+        // on Scala LTS (3.3.x or 3.9.x), stay on LTS versions
+        update.filterVersions(isScalaLtsVersion).toRight(IgnoreScalaNext(update))
       }
     } else {
       Right(update)
@@ -96,8 +102,9 @@ object FilterAlg {
     } || isScalaLibraryFor3(update)
 
   private def isScalaLibraryFor3(update: ArtifactUpdateCandidates): Boolean =
-    (update.artifactForUpdate.groupId == scalaLangGroupId && update.artifactForUpdate.artifactId.name == scalaLibrary.name && update.newerVersions
-      .forall(_ > scala38))
+    (update.artifactForUpdate.groupId == scalaLangGroupId &&
+      update.artifactForUpdate.artifactId.name == scalaLibrary.name &&
+      update.newerVersions.forall(_ > scala38))
 
   private def globalFilter(
       update: ArtifactUpdateCandidates,

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -296,24 +296,28 @@ class FilterAlgTest extends FunSuite {
     assert(isDependencyConfigurationIgnored(dependency.copy(configurations = Some("scalafmt"))))
   }
 
-  test("scalaLTSFilter: LTS, no update") {
-    val update = ("org.scala-lang".g % "scala3-compiler".a % "3.3.2" %> Nel.of("3.4.0")).single
-    assertEquals(scalaLTSFilter(update), Left(IgnoreScalaNext(update)))
+  test("scalaLTSFilter: LTS->Next, no update") {
+    val update1 = ("org.scala-lang".g % "scala3-compiler".a % "3.3.2" %> Nel.of("3.4.0")).single
+    assertEquals(scalaLTSFilter(update1), Left(IgnoreScalaNext(update1)))
+
+    val update2 = ("org.scala-lang".g % "scala3-compiler".a % "3.9.2" %> Nel.of("3.10.0")).single
+    assertEquals(scalaLTSFilter(update2), Left(IgnoreScalaNext(update2)))
   }
 
-  test("scalaLTSFilter: LTS, filter versions") {
+  test("scalaLTSFilter: LTS->LTS, filter versions") {
     val update =
       ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.3.2" %> Nel.of(
         "3.3.3",
-        "3.4.0"
+        "3.4.0",
+        "3.9.0"
       )).single
     assertEquals(
       scalaLTSFilter(update),
-      Right(update.copy(newerVersionsWithFirstSeen = Nel.of("3.3.3".vfs)))
+      Right(update.copy(newerVersionsWithFirstSeen = Nel.of("3.3.3", "3.9.0").map(_.vfs)))
     )
   }
 
-  test("scalaLTSFilter: Next") {
+  test("scalaLTSFilter: Next->Next") {
     val update =
       ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.4.0" %> Nel.of(
         "3.4.1"
@@ -321,10 +325,19 @@ class FilterAlgTest extends FunSuite {
     assertEquals(scalaLTSFilter(update), Right(update))
   }
 
+  test("scalaLTSFilter: Next->LTS") {
+    val update =
+      ("org.scala-lang".g % ("scala3-compiler", "scala3-compiler_3").a % "3.8.4" %> Nel.of(
+        "3.9.0"
+      )).single
+    assertEquals(scalaLTSFilter(update), Right(update))
+  }
+
   test("scalaLTSFilter: Scala 3.8.x") {
     val update37_38 =
-      ("org.scala-lang".g % ("scala-library", "scala-library_3").a % "3.8.4" %> Nel.of(
-        "3.8.1"
+      ("org.scala-lang".g % ("scala-library", "scala-library_3").a % "3.7.4" %> Nel.of(
+        "3.8.1",
+        "3.9.0"
       )).single
     assertEquals(scalaLTSFilter(update37_38), Right(update37_38))
 
@@ -343,7 +356,7 @@ class FilterAlgTest extends FunSuite {
     assert(isScala3Lang(update33_24))
 
     val update37_38 =
-      ("org.scala-lang".g % ("scala-library", "scala-library_3").a % "3.8.4" %> Nel.of(
+      ("org.scala-lang".g % ("scala-library", "scala-library_3").a % "3.7.4" %> Nel.of(
         "3.8.1"
       )).single
     assert(isScala3Lang(update37_38))
@@ -365,6 +378,7 @@ class FilterAlgTest extends FunSuite {
       )).single
     assert(!isScala3Lang(updateScalaLibrary213))
   }
+
   test("exclude too-recent updates via config updates.cooldown") {
     val config = RepoConfig(updates =
       UpdatesConfig(cooldown =


### PR DESCRIPTION
The LTS versions are hard coded.
so we need to add 3.9 as the latest LTS version